### PR TITLE
fix: update package name to use buildwithgrove

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM golang:1.22.3-alpine3.19 AS builder
 RUN apk add --no-cache git
 
-WORKDIR /go/src/github.com/pokt-foundation/portal-middleware
+WORKDIR /go/src/github.com/buildwithgrove/path
 COPY . .
 RUN apk add --no-cache make build-base
 RUN go build -o /go/bin/path ./cmd/main.go

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
 <h1>PATH<br/>Path API & Toolkit Harness.</h1>
-<img src=".github/grove_logo.png" alt="Grove logo" width="500"/>
+<img src="https://storage.googleapis.com/grove-brand-assets/Presskit/Logo%20Stacked-1.png" alt="Grove logo" width="500"/>
 
 </div>
 <br/>

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -8,13 +8,13 @@ import (
 	"github.com/pokt-network/poktroll/pkg/polylog"
 	"github.com/pokt-network/poktroll/pkg/polylog/polyzero"
 
-	"github.com/pokt-foundation/portal-middleware/config"
-	"github.com/pokt-foundation/portal-middleware/gateway"
-	"github.com/pokt-foundation/portal-middleware/relayer"
-	"github.com/pokt-foundation/portal-middleware/relayer/morse"
-	"github.com/pokt-foundation/portal-middleware/relayer/shannon"
-	"github.com/pokt-foundation/portal-middleware/request"
-	"github.com/pokt-foundation/portal-middleware/router"
+	"github.com/buildwithgrove/path/config"
+	"github.com/buildwithgrove/path/gateway"
+	"github.com/buildwithgrove/path/relayer"
+	"github.com/buildwithgrove/path/relayer/morse"
+	"github.com/buildwithgrove/path/relayer/shannon"
+	"github.com/buildwithgrove/path/request"
+	"github.com/buildwithgrove/path/router"
 )
 
 const configPath = ".config.yaml"

--- a/config/config.go
+++ b/config/config.go
@@ -8,11 +8,11 @@ import (
 
 	"gopkg.in/yaml.v3"
 
-	"github.com/pokt-foundation/portal-middleware/config/morse"
-	"github.com/pokt-foundation/portal-middleware/config/shannon"
-	"github.com/pokt-foundation/portal-middleware/config/utils"
-	"github.com/pokt-foundation/portal-middleware/relayer"
-	"github.com/pokt-foundation/portal-middleware/request"
+	"github.com/buildwithgrove/path/config/morse"
+	"github.com/buildwithgrove/path/config/shannon"
+	"github.com/buildwithgrove/path/config/utils"
+	"github.com/buildwithgrove/path/relayer"
+	"github.com/buildwithgrove/path/request"
 )
 
 /* ---------------------------------  Gateway Config Struct -------------------------------- */

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -6,12 +6,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/buildwithgrove/path/config/morse"
+	"github.com/buildwithgrove/path/config/shannon"
+	"github.com/buildwithgrove/path/relayer"
+	morseRelayer "github.com/buildwithgrove/path/relayer/morse"
+	shannonRelayer "github.com/buildwithgrove/path/relayer/shannon"
 	"github.com/pokt-foundation/pocket-go/provider"
-	"github.com/pokt-foundation/portal-middleware/config/morse"
-	"github.com/pokt-foundation/portal-middleware/config/shannon"
-	"github.com/pokt-foundation/portal-middleware/relayer"
-	morseRelayer "github.com/pokt-foundation/portal-middleware/relayer/morse"
-	shannonRelayer "github.com/pokt-foundation/portal-middleware/relayer/shannon"
 
 	"github.com/stretchr/testify/require"
 )

--- a/config/morse/gateway_config.go
+++ b/config/morse/gateway_config.go
@@ -8,10 +8,10 @@ import (
 
 	"gopkg.in/yaml.v3"
 
+	"github.com/buildwithgrove/path/config/utils"
+	"github.com/buildwithgrove/path/relayer"
+	morseRelayer "github.com/buildwithgrove/path/relayer/morse"
 	"github.com/pokt-foundation/pocket-go/provider"
-	"github.com/pokt-foundation/portal-middleware/config/utils"
-	"github.com/pokt-foundation/portal-middleware/relayer"
-	morseRelayer "github.com/pokt-foundation/portal-middleware/relayer/morse"
 )
 
 const (

--- a/config/morse/gateway_config_test.go
+++ b/config/morse/gateway_config_test.go
@@ -3,9 +3,9 @@ package morse
 import (
 	"testing"
 
+	"github.com/buildwithgrove/path/relayer"
+	morseRelayer "github.com/buildwithgrove/path/relayer/morse"
 	"github.com/pokt-foundation/pocket-go/provider"
-	"github.com/pokt-foundation/portal-middleware/relayer"
-	morseRelayer "github.com/pokt-foundation/portal-middleware/relayer/morse"
 	"github.com/stretchr/testify/require"
 )
 

--- a/config/morse/signed_aat.go
+++ b/config/morse/signed_aat.go
@@ -3,8 +3,8 @@ package morse
 import (
 	"fmt"
 
+	"github.com/buildwithgrove/path/config/utils"
 	sdk "github.com/pokt-foundation/pocket-go/provider"
-	"github.com/pokt-foundation/portal-middleware/config/utils"
 )
 
 // AATVersion is the current version of the Application Authentication Token (AAT).

--- a/config/shannon/gateway_config.go
+++ b/config/shannon/gateway_config.go
@@ -3,7 +3,7 @@ package shannon
 import (
 	"gopkg.in/yaml.v3"
 
-	shannonRelayer "github.com/pokt-foundation/portal-middleware/relayer/shannon"
+	shannonRelayer "github.com/buildwithgrove/path/relayer/shannon"
 )
 
 // Fields that are unmarshaled from the config YAML must be capitalized.

--- a/config/shannon/gateway_config_test.go
+++ b/config/shannon/gateway_config_test.go
@@ -3,7 +3,7 @@ package shannon
 import (
 	"testing"
 
-	shannonRelayer "github.com/pokt-foundation/portal-middleware/relayer/shannon"
+	shannonRelayer "github.com/buildwithgrove/path/relayer/shannon"
 
 	"github.com/stretchr/testify/require"
 )

--- a/config/user_data.go
+++ b/config/user_data.go
@@ -3,7 +3,7 @@ package config
 import (
 	"fmt"
 
-	"github.com/pokt-foundation/portal-middleware/config/utils"
+	"github.com/buildwithgrove/path/config/utils"
 	"gopkg.in/yaml.v3"
 )
 

--- a/e2e/shannon_relay_test.go
+++ b/e2e/shannon_relay_test.go
@@ -19,10 +19,10 @@ import (
 	"github.com/pokt-network/poktroll/pkg/polylog/polyzero"
 	"github.com/stretchr/testify/require"
 
-	"github.com/pokt-foundation/portal-middleware/config"
-	"github.com/pokt-foundation/portal-middleware/relayer"
-	"github.com/pokt-foundation/portal-middleware/relayer/shannon"
-	"github.com/pokt-foundation/portal-middleware/request"
+	"github.com/buildwithgrove/path/config"
+	"github.com/buildwithgrove/path/relayer"
+	"github.com/buildwithgrove/path/relayer/shannon"
+	"github.com/buildwithgrove/path/request"
 )
 
 const configPath = ".config.test.yaml"

--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -8,7 +8,7 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/pokt-foundation/portal-middleware/relayer"
+	"github.com/buildwithgrove/path/relayer"
 )
 
 // Gateway performs end-to-end handling of all service requests

--- a/gateway/qos.go
+++ b/gateway/qos.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/pokt-foundation/portal-middleware/relayer"
+	"github.com/buildwithgrove/path/relayer"
 )
 
 // TODO_IMPLEMENT: Add one QoS instance per service that is to be supported by the gateway, implementing the QoSService interface below.

--- a/gateway/request.go
+++ b/gateway/request.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/pokt-foundation/portal-middleware/relayer"
+	"github.com/buildwithgrove/path/relayer"
 )
 
 // HTTPRequestParser is used, in handling an HTTP service request, to extract

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/pokt-foundation/portal-middleware
+module github.com/buildwithgrove/path
 
 go 1.22.3
 

--- a/qos/evm/evm.go
+++ b/qos/evm/evm.go
@@ -10,8 +10,8 @@ import (
 
 	"github.com/pokt-network/poktroll/pkg/polylog"
 
-	"github.com/pokt-foundation/portal-middleware/gateway"
-	"github.com/pokt-foundation/portal-middleware/relayer"
+	"github.com/buildwithgrove/path/gateway"
+	"github.com/buildwithgrove/path/relayer"
 )
 
 const (

--- a/relayer/morse/app.go
+++ b/relayer/morse/app.go
@@ -3,7 +3,7 @@ package morse
 import (
 	"github.com/pokt-foundation/pocket-go/provider"
 
-	"github.com/pokt-foundation/portal-middleware/relayer"
+	"github.com/buildwithgrove/path/relayer"
 )
 
 // The relayer package's App interface is fulfilled by the app struct below.

--- a/relayer/morse/endpoint.go
+++ b/relayer/morse/endpoint.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/pokt-foundation/pocket-go/provider"
 
-	"github.com/pokt-foundation/portal-middleware/relayer"
+	"github.com/buildwithgrove/path/relayer"
 )
 
 // The relayer package's Endpoint interface is fulfilled by the endpoint struct below, which allows

--- a/relayer/morse/protocol.go
+++ b/relayer/morse/protocol.go
@@ -10,7 +10,7 @@ import (
 	sdkrelayer "github.com/pokt-foundation/pocket-go/relayer"
 	"github.com/pokt-network/poktroll/pkg/polylog"
 
-	"github.com/pokt-foundation/portal-middleware/relayer"
+	"github.com/buildwithgrove/path/relayer"
 )
 
 // relayer package's Protocol interface is fulfilled by the Protocol struct

--- a/relayer/relayer.go
+++ b/relayer/relayer.go
@@ -16,7 +16,7 @@ import (
 // It is defined in the `relayer` package and not the `service` package
 // because `service` is intended to handle off-chain details, while
 // `relayer` handles onchain details. See discussion here for more:
-// https://github.com/pokt-foundation/portal-middleware/pull/767#discussion_r1722001685
+// https://github.com/buildwithgrove/path/pull/767#discussion_r1722001685
 type ServiceID string
 
 // AppAddr is used as the unique identifier on an onchain application.

--- a/relayer/shannon/app.go
+++ b/relayer/shannon/app.go
@@ -1,7 +1,7 @@
 package shannon
 
 import (
-	"github.com/pokt-foundation/portal-middleware/relayer"
+	"github.com/buildwithgrove/path/relayer"
 )
 
 // relayer package's App interface is fulfilled by the app struct below.

--- a/relayer/shannon/endpoint.go
+++ b/relayer/shannon/endpoint.go
@@ -6,7 +6,7 @@ import (
 	sessiontypes "github.com/pokt-network/poktroll/x/session/types"
 	sdk "github.com/pokt-network/shannon-sdk"
 
-	"github.com/pokt-foundation/portal-middleware/relayer"
+	"github.com/buildwithgrove/path/relayer"
 )
 
 // By fulfilling the relayer package Endpoint interface, the endpoint struct below allows

--- a/relayer/shannon/fullnode.go
+++ b/relayer/shannon/fullnode.go
@@ -20,7 +20,7 @@ import (
 	sdk "github.com/pokt-network/shannon-sdk"
 	sdktypes "github.com/pokt-network/shannon-sdk/types"
 
-	"github.com/pokt-foundation/portal-middleware/relayer"
+	"github.com/buildwithgrove/path/relayer"
 )
 
 const (

--- a/relayer/shannon/protocol.go
+++ b/relayer/shannon/protocol.go
@@ -11,7 +11,7 @@ import (
 	servicetypes "github.com/pokt-network/poktroll/x/service/types"
 	sessiontypes "github.com/pokt-network/poktroll/x/session/types"
 
-	"github.com/pokt-foundation/portal-middleware/relayer"
+	"github.com/buildwithgrove/path/relayer"
 )
 
 // relayer package's Protocol interface is fulfilled by the Protocol struct

--- a/request/parser.go
+++ b/request/parser.go
@@ -8,8 +8,8 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/pokt-foundation/portal-middleware/gateway"
-	"github.com/pokt-foundation/portal-middleware/relayer"
+	"github.com/buildwithgrove/path/gateway"
+	"github.com/buildwithgrove/path/relayer"
 	"github.com/pokt-network/poktroll/pkg/polylog"
 )
 

--- a/request/qos_names.go
+++ b/request/qos_names.go
@@ -1,6 +1,6 @@
 package request
 
-import "github.com/pokt-foundation/portal-middleware/relayer"
+import "github.com/buildwithgrove/path/relayer"
 
 // SupportedServicesToQoSServiceName is a map of service IDs to the QoS Service that will be used
 // to perform request parsing, response building, and endpoint selection for the given service ID.

--- a/request/qos_provider.go
+++ b/request/qos_provider.go
@@ -5,9 +5,9 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/pokt-foundation/portal-middleware/gateway"
-	"github.com/pokt-foundation/portal-middleware/qos/evm"
-	"github.com/pokt-foundation/portal-middleware/relayer"
+	"github.com/buildwithgrove/path/gateway"
+	"github.com/buildwithgrove/path/qos/evm"
+	"github.com/buildwithgrove/path/relayer"
 	"github.com/pokt-network/poktroll/pkg/polylog"
 )
 

--- a/router/router.go
+++ b/router/router.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/pokt-network/poktroll/pkg/polylog"
 
-	"github.com/pokt-foundation/portal-middleware/config"
+	"github.com/buildwithgrove/path/config"
 )
 
 const (

--- a/router/router_test.go
+++ b/router/router_test.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/pokt-foundation/portal-middleware/config"
+	"github.com/buildwithgrove/path/config"
 	"github.com/pokt-network/poktroll/pkg/polylog/polyzero"
 
 	"github.com/stretchr/testify/mock"


### PR DESCRIPTION
Updates package name from `pokt-foundation/portal-middleware` to `buildwithgrove/path`.