### PR TITLE
fix: resolves panic when endpoint called for an unassigned service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,7 @@ config.*.yaml
 .env
 .idea/
 .mise.local.toml
+
+# tmp directory
+tmp
+tmp/*

--- a/.gitignore
+++ b/.gitignore
@@ -18,10 +18,8 @@ bin
 go.work.sum
 
 # Config
-config.yaml
-config.*.yaml
 .config.yaml
-.config.test.yaml
+.config.*.yaml
 
 # Macos
 .DS_Store

--- a/config/config.go
+++ b/config/config.go
@@ -53,7 +53,9 @@ func LoadGatewayConfigFromYAML(path string) (GatewayConfig, error) {
 	}
 
 	// hydrate required fields and set defaults for optional fields
-	config.hydrateServiceAliases()
+	if err := config.hydrateServiceAliases(); err != nil {
+		return GatewayConfig{}, err
+	}
 	config.hydrateRouterConfig()
 
 	return config, config.validate()
@@ -102,15 +104,19 @@ func (c GatewayConfig) GetEnabledServiceConfigs() map[relayer.ServiceID]request.
 
 /* --------------------------------- Gateway Config Hydration Helpers -------------------------------- */
 
-func (c *GatewayConfig) hydrateServiceAliases() {
+func (c *GatewayConfig) hydrateServiceAliases() error {
 	if c.serviceAliases == nil {
 		c.serviceAliases = make(map[string]relayer.ServiceID)
 	}
 	for serviceID, service := range c.Services {
 		if service.Alias != "" {
+			if _, ok := c.serviceAliases[service.Alias]; ok {
+				return fmt.Errorf("duplicate service alias: %s", service.Alias)
+			}
 			c.serviceAliases[service.Alias] = serviceID
 		}
 	}
+	return nil
 }
 
 func (c *GatewayConfig) hydrateRouterConfig() {

--- a/config/config.schema.yaml
+++ b/config/config.schema.yaml
@@ -1,0 +1,148 @@
+type: object
+properties:
+  # NOTE: Exactly one of either "morse_config" or "shannon_config" must be present
+
+  # TODO_FUTURE: a single PATH deployment can support multiple protocols in theory, but
+  # this is not currently supported in order to simplify deployment. In the future, we
+  # may look into supporting multiple protocols within a single deployment.
+
+  # Morse Configuration (required for Morse gateways)
+  morse_config:
+    type: object
+    properties:
+      full_node_config:
+        type: object
+        properties:
+          url:
+            type: string
+            pattern: "^(http|https)://.*$"
+          relay_signing_key:
+            type: string
+            pattern: "^[0-9a-fA-F]{64}$"
+          http_config:
+            type: object
+            properties:
+              retries:
+                type: integer
+              timeout:
+                type: string
+              transport:
+                type: object
+                properties:
+                  max_conns_per_host:
+                    type: integer
+                  max_idle_conns_per_host:
+                    type: integer
+                  max_idle_conns:
+                    type: integer
+                  idle_conn_timeout:
+                    type: string
+                  dial_timeout:
+                    type: string
+                  keep_alive:
+                    type: string
+          request_config:
+            type: object
+            properties:
+              retries:
+                type: integer
+        required:
+          - url
+      signed_aats:
+        type: object
+        patternProperties:
+          "^[0-9a-fA-F]{40}$":
+            type: object
+            properties:
+              client_public_key:
+                type: string
+                pattern: "^[0-9a-fA-F]{64}$"
+              application_public_key:
+                type: string
+                pattern: "^[0-9a-fA-F]{64}$"
+              application_signature:
+                type: string
+                pattern: "^[0-9a-fA-F]{128}$"
+            required:
+              - client_public_key
+              - application_public_key
+              - application_signature
+
+  # Shannon Configuration (required for Shannon gateways)
+  shannon_config:
+    type: object
+    properties:
+      full_node_config:
+        type: object
+        properties:
+          rpc_url:
+            type: string
+            pattern: "^(http|https)://.*$"
+          grpc_config:
+            type: object
+            properties:
+              host_port:
+                type: string
+                pattern: "^[^:]+:[0-9]+$"
+              insecure:
+                type: boolean
+                default: false
+              base_delay:
+                type: string
+              max_delay:
+                type: string
+              min_connect_timeout:
+                type: string
+              keep_alive_time:
+                type: string
+              keep_alive_timeout:
+                type: string
+            required:
+              - host_port
+          gateway_address:
+            type: string
+            pattern: "^pokt1[0-9a-zA-Z]{43}$"
+          gateway_private_key:
+            type: string
+            pattern: "^[0-9a-fA-F]{64}$"
+          delegated_app_addresses:
+            type: array
+            items:
+              type: string
+              pattern: "^pokt1[0-9a-zA-Z]{43}$"
+        required:
+          - rpc_url
+          - grpc_config
+          - gateway_address
+          - gateway_private_key
+          - delegated_app_addresses
+
+  # Services Configuration (required)
+  services:
+    type: object
+    patternProperties:
+      "^[a-zA-Z0-9]+$":
+      type: object
+        properties:
+          alias:
+            type: string
+          request_timeout:
+            type: string
+
+  # Router Configuration (optional)
+  router_config:
+    type: object
+    properties:
+      port:
+        type: integer
+      max_request_body_size:
+        type: integer
+      read_timeout:
+        type: string
+      write_timeout:
+        type: string
+      idle_timeout:
+        type: string
+
+required:
+  - services

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -240,6 +240,17 @@ func Test_LoadGatewayConfigFromYAML(t *testing.T) {
 			yamlData: "invalid_yaml: [",
 			wantErr:  true,
 		},
+		{
+			name:     "should return error for duplicate service alias",
+			filePath: "duplicate_service_alias.yaml",
+			yamlData: `
+			morse_config:
+			  serviceAliases:
+			    eth-mainnet: "0021"
+			    eth-mainnet: "0022"
+			`,
+			wantErr: true,
+		},
 	}
 
 	for _, test := range tests {

--- a/request/errors.go
+++ b/request/errors.go
@@ -1,0 +1,29 @@
+package request
+
+import (
+	"fmt"
+	"net/http"
+)
+
+const (
+	// TODO_TECHDEBT: return the correct id field from the request
+	parserErrorTemplate = `{"jsonrpc":"2.0","id":"0","error":{"code":%d,"message":"%s"}}`
+)
+
+/* Parser Error Response */
+
+type ParserErrorResponse struct {
+	err string
+}
+
+func (r *ParserErrorResponse) GetPayload() []byte {
+	return []byte(fmt.Sprintf(parserErrorTemplate, http.StatusBadRequest, r.err))
+}
+
+func (r *ParserErrorResponse) GetHTTPStatusCode() int {
+	return http.StatusOK // JSON-RPC 2.0 spec requires a 200 status code even for errors.
+}
+
+func (r *ParserErrorResponse) GetHTTPHeaders() map[string]string {
+	return map[string]string{}
+}

--- a/request/errors.go
+++ b/request/errors.go
@@ -2,28 +2,25 @@ package request
 
 import (
 	"fmt"
-	"net/http"
 )
 
-const (
-	// TODO_TECHDEBT: return the correct id field from the request
-	parserErrorTemplate = `{"jsonrpc":"2.0","id":"0","error":{"code":%d,"message":"%s"}}`
-)
+const parserErrorTemplate = `{"code":%d,"message":"%s"}`
 
 /* Parser Error Response */
 
-type ParserErrorResponse struct {
-	err string
+type parserErrorResponse struct {
+	err  string
+	code int
 }
 
-func (r *ParserErrorResponse) GetPayload() []byte {
-	return []byte(fmt.Sprintf(parserErrorTemplate, http.StatusBadRequest, r.err))
+func (r *parserErrorResponse) GetPayload() []byte {
+	return []byte(fmt.Sprintf(parserErrorTemplate, r.code, r.err))
 }
 
-func (r *ParserErrorResponse) GetHTTPStatusCode() int {
-	return http.StatusOK // JSON-RPC 2.0 spec requires a 200 status code even for errors.
+func (r *parserErrorResponse) GetHTTPStatusCode() int {
+	return r.code
 }
 
-func (r *ParserErrorResponse) GetHTTPHeaders() map[string]string {
+func (r *parserErrorResponse) GetHTTPHeaders() map[string]string {
 	return map[string]string{}
 }

--- a/request/errors.go
+++ b/request/errors.go
@@ -1,10 +1,17 @@
 package request
 
 import (
+	"errors"
 	"fmt"
 )
 
 const parserErrorTemplate = `{"code":%d,"message":"%s"}`
+
+var (
+	errNoServiceIDProvided     = errors.New("no service ID provided")
+	errServiceIDNotEnabled     = errors.New("service ID not enabled")
+	errServiceNameNotSupported = errors.New("service name not supported")
+)
 
 /* Parser Error Response */
 

--- a/request/parser.go
+++ b/request/parser.go
@@ -1,11 +1,12 @@
-// The responsibility of the `request` package is to extract the service ID and find the target service's corresponding QoS instance.
-// See: https://github.com/buildwithgrove/path/blob/e0067eb0f9ab0956127c952980b09909a795b300/gateway/gateway.go#L52C2-L52C45
+// Request package is responsible for parsing and forwarding user requests.
+// It is not responsible for QoS, authorization, etc...
 //
-// Request package decides how the requested service is referenced by the user (currently: subdomain of the HTTP request).
-//
-// Processing should fail here only if:
+// For example, Processing should fail here only if:
 // A) No service is provided - Bad Request
 // B) The provided service is not found/configured for the gateway instance - Not Found
+//
+// The responsibility of the `request` package is to extract the service ID and find the target service's corresponding QoS instance.
+// See: https://github.com/buildwithgrove/path/blob/e0067eb0f9ab0956127c952980b09909a795b300/gateway/gateway.go#L52C2-L52C45
 package request
 
 import (

--- a/request/parser.go
+++ b/request/parser.go
@@ -14,13 +14,6 @@ import (
 	"github.com/buildwithgrove/path/relayer"
 )
 
-const (
-	// TODO_DISCUSS: should we create a common errors package for all errors?
-	// TODO_IMPROVE: define specific error codes for all errors
-	parserErrorCode     = -32000
-	parserErrorTemplate = `{"jsonrpc":"2.0","id":"0","error":{"code":%d,"message":"%s"}}`
-)
-
 type (
 	Parser struct {
 		Backend            Backend
@@ -68,6 +61,7 @@ func (p *Parser) GetQoSService(ctx context.Context, req *http.Request) (relayer.
 }
 
 func (p *Parser) GetHTTPErrorResponse(ctx context.Context, err error) gateway.HTTPResponse {
+	// TODO_TECHDEBT: return the correct id field from the request if the request is a valid JSON-RPC
 	return &ParserErrorResponse{err: err.Error()}
 }
 
@@ -89,22 +83,4 @@ func (p *Parser) getServiceID(host string) (relayer.ServiceID, error) {
 	}
 
 	return serviceID, nil
-}
-
-/* Parser Error Response */
-
-type ParserErrorResponse struct {
-	err string
-}
-
-func (r *ParserErrorResponse) GetPayload() []byte {
-	return []byte(fmt.Sprintf(parserErrorTemplate, parserErrorCode, r.err))
-}
-
-func (r *ParserErrorResponse) GetHTTPStatusCode() int {
-	return http.StatusBadRequest
-}
-
-func (r *ParserErrorResponse) GetHTTPHeaders() map[string]string {
-	return map[string]string{}
 }

--- a/request/parser.go
+++ b/request/parser.go
@@ -14,6 +14,13 @@ import (
 	"github.com/buildwithgrove/path/relayer"
 )
 
+const (
+	// TODO_DISCUSS: should wecreate a common errors package for all errors?
+	// TODO_IMPROVE: define specific error codes for all errors
+	parserErrorCode     = -32000
+	parserErrorTemplate = `{"jsonrpc":"2.0","id":"0","error":{"code":%d,"message":"%s"}}`
+)
+
 type (
 	Parser struct {
 		Backend            Backend
@@ -60,9 +67,26 @@ func (p *Parser) GetQoSService(ctx context.Context, req *http.Request) (relayer.
 	return serviceID, qosService, nil
 }
 
-// TODO_INCOMPLETE: implement this
 func (p *Parser) GetHTTPErrorResponse(ctx context.Context, err error) gateway.HTTPResponse {
-	return nil
+	return &ParserErrorResponse{err: err.Error()}
+}
+
+/* Parser Error Response */
+
+type ParserErrorResponse struct {
+	err string
+}
+
+func (r *ParserErrorResponse) GetPayload() []byte {
+	return []byte(fmt.Sprintf(parserErrorTemplate, parserErrorCode, r.err))
+}
+
+func (r *ParserErrorResponse) GetHTTPStatusCode() int {
+	return http.StatusBadRequest
+}
+
+func (r *ParserErrorResponse) GetHTTPHeaders() map[string]string {
+	return map[string]string{}
 }
 
 // getServiceID gets the service ID from the request host

--- a/request/parser.go
+++ b/request/parser.go
@@ -1,6 +1,3 @@
-// Package request provides a struct for setting and retrieving service
-// request details from the context during the relay request lifecycle.
-//
 // The responsibility of the `request` package is to extract the service ID and find the target service's corresponding QoS instance.
 // See: https://github.com/buildwithgrove/path/blob/e0067eb0f9ab0956127c952980b09909a795b300/gateway/gateway.go#L52C2-L52C45
 //

--- a/request/parser.go
+++ b/request/parser.go
@@ -15,7 +15,7 @@ import (
 )
 
 const (
-	// TODO_DISCUSS: should wecreate a common errors package for all errors?
+	// TODO_DISCUSS: should we create a common errors package for all errors?
 	// TODO_IMPROVE: define specific error codes for all errors
 	parserErrorCode     = -32000
 	parserErrorTemplate = `{"jsonrpc":"2.0","id":"0","error":{"code":%d,"message":"%s"}}`
@@ -71,24 +71,6 @@ func (p *Parser) GetHTTPErrorResponse(ctx context.Context, err error) gateway.HT
 	return &ParserErrorResponse{err: err.Error()}
 }
 
-/* Parser Error Response */
-
-type ParserErrorResponse struct {
-	err string
-}
-
-func (r *ParserErrorResponse) GetPayload() []byte {
-	return []byte(fmt.Sprintf(parserErrorTemplate, parserErrorCode, r.err))
-}
-
-func (r *ParserErrorResponse) GetHTTPStatusCode() int {
-	return http.StatusBadRequest
-}
-
-func (r *ParserErrorResponse) GetHTTPHeaders() map[string]string {
-	return map[string]string{}
-}
-
 // getServiceID gets the service ID from the request host
 // eg. host = "eth-mainnet.gateway.pokt.network" -> serviceID = "eth-mainnet"
 func (p *Parser) getServiceID(host string) (relayer.ServiceID, error) {
@@ -107,4 +89,22 @@ func (p *Parser) getServiceID(host string) (relayer.ServiceID, error) {
 	}
 
 	return serviceID, nil
+}
+
+/* Parser Error Response */
+
+type ParserErrorResponse struct {
+	err string
+}
+
+func (r *ParserErrorResponse) GetPayload() []byte {
+	return []byte(fmt.Sprintf(parserErrorTemplate, parserErrorCode, r.err))
+}
+
+func (r *ParserErrorResponse) GetHTTPStatusCode() int {
+	return http.StatusBadRequest
+}
+
+func (r *ParserErrorResponse) GetHTTPHeaders() map[string]string {
+	return map[string]string{}
 }

--- a/request/qos_provider.go
+++ b/request/qos_provider.go
@@ -1,7 +1,6 @@
 package request
 
 import (
-	"errors"
 	"fmt"
 	"time"
 
@@ -28,12 +27,6 @@ const (
 )
 
 /* --------------------------------- QoS Service Provider -------------------------------- */
-
-var (
-	errNoServiceIDProvided     = errors.New("no service ID provided")
-	errServiceIDNotEnabled     = errors.New("service ID not enabled")
-	errServiceNameNotSupported = errors.New("service name not supported")
-)
 
 type (
 	qosServiceProvider struct {

--- a/request/qos_provider.go
+++ b/request/qos_provider.go
@@ -30,8 +30,9 @@ const (
 /* --------------------------------- QoS Service Provider -------------------------------- */
 
 var (
-	ErrServiceIDNotEnabled     = errors.New("service ID %s not enabled")
-	ErrServiceNameNotSupported = errors.New("service name %s not supported")
+	errNoServiceIDProvided     = errors.New("no service ID provided")
+	errServiceIDNotEnabled     = errors.New("service ID not enabled")
+	errServiceNameNotSupported = errors.New("service name not supported")
 )
 
 type (
@@ -58,7 +59,7 @@ func newQoSServiceProvider(backend qosBackend, logger polylog.Logger) (*qosServi
 
 		serviceName, ok := supportedServicesToQoSServiceName[serviceID]
 		if !ok {
-			return nil, fmt.Errorf(ErrServiceIDNotEnabled.Error(), serviceID)
+			return nil, fmt.Errorf(errServiceIDNotEnabled.Error(), serviceID)
 		}
 
 		switch serviceName {
@@ -69,7 +70,7 @@ func newQoSServiceProvider(backend qosBackend, logger polylog.Logger) (*qosServi
 		case ServiceNamePOKT:
 			// TODO_TECHDEBT: add pokt qos service here
 		default:
-			return nil, fmt.Errorf(ErrServiceNameNotSupported.Error(), serviceName)
+			return nil, errServiceNameNotSupported
 		}
 	}
 
@@ -82,7 +83,7 @@ func newQoSServiceProvider(backend qosBackend, logger polylog.Logger) (*qosServi
 func (p *qosServiceProvider) GetQoSService(serviceID relayer.ServiceID) (gateway.QoSService, error) {
 	qosService, ok := p.qosServices[serviceID]
 	if !ok {
-		return nil, fmt.Errorf(ErrServiceIDNotEnabled.Error(), serviceID)
+		return nil, errServiceIDNotEnabled
 	}
 	return qosService, nil
 }


### PR DESCRIPTION
This PR fixes a bug where the `gateway` package would panic due to `parser.GetHTTPErrorResponse` returning a nil value when a service request is sent for a service not configured in the config YAML.