### PR TITLE
Fix build workflow to trigger only for main branch

### DIFF
--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -5,7 +5,8 @@ on:
     workflows: ["Path tests"]
     types:
       - completed
-    branches: ["main"]
+    branches: 
+      - main
 
 jobs:
   build-and-push:

--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -5,6 +5,7 @@ on:
     workflows: ["Path tests"]
     types:
       - completed
+    branches: ["main"]
 
 jobs:
   build-and-push:

--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -5,6 +5,8 @@ on:
     workflows: ["Path tests"]
     types:
       - completed
+    branches: 
+      - main
 
 jobs:
   release-on-push:


### PR DESCRIPTION
# TL;DR

Fix for build workflow.

## Summary

This fix solves the issue with build workflow being triggered by pull requests. Instead, it changes the behavior to be triggered only by main branch.

## Related issues

#17 