### PR TITLE
[Docker] Update the tag of the built and published docker images

### DIFF
--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -31,7 +31,6 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=ref,event=tag,suffix=-rc
-            type=sha,suffix=-rc,format=short
             type=sha,format=short,suffix=-rc
             type=ref,event=branch,pattern=latest
 

--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -5,7 +5,7 @@ on:
     workflows: ["Path tests"]
     types:
       - completed
-    branches: 
+    branches:
       - main
 
 jobs:
@@ -31,8 +31,9 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=ref,event=tag,suffix=-rc
-            type=sha,suffix=-rc
-            type=sha,format=long,suffix=-rc
+            type=sha,suffix=-rc,format=short
+            type=sha,format=short,suffix=-rc
+            type=ref,event=branch,pattern=latest
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3


### PR DESCRIPTION
Two main changes:
- Always tag the latest image with `latest`
- Use a shortened version of the `sha`

Where images are stored: https://github.com/buildwithgrove/path/pkgs/container/path