### PR TITLE
Added status badge for ArgoCD path deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
 ![GitHub Issues or Pull Requests](https://img.shields.io/github/issues/buildwithgrove/path)
 ![GitHub Issues or Pull Requests](https://img.shields.io/github/issues-pr/buildwithgrove/path)
 ![GitHub Issues or Pull Requests](https://img.shields.io/github/issues-closed/buildwithgrove/path)
+![App Status](https://argocd.tooling.buildintheshade.com/api/badge?name=path&revision=true&showAppName=true)
 
 # Table of Contents <!-- omit in toc -->
 


### PR DESCRIPTION
# TL;DR

Adding deployment visibility in the Path repository for Path deployment

## Summary

- Added status badge for ArgoCD Path deployment status.

## TODO(@HebertCL)

- Fix config connector resources preventing Path deployment to function correctly.