### PR TITLE
[Config] Revamp Shannon config example

### DIFF
--- a/cmd/.config.shannon_example.yaml
+++ b/cmd/.config.shannon_example.yaml
@@ -2,11 +2,15 @@ shannon_config:
   full_node_config:
     rpc_url: https://example_full_node_rpc_url.your_domain # replace with your full node rpc url
     grpc_config:
-      host_port: example_fullnode_grpc.your_domain:443 # replace with your full node grpc host/port
-    gateway_address: "example_gateway_address_pokt1710ed9a8d0986d8" # replace with your gateway address
-    gateway_private_key: "example_gateway_private_key_52734539d033e35c6e6d1ce5ad96bcacb911" # replace with your gateway private key
-    delegated_app_addresses: # replace with delegated app addresses
-      - "example_delegated_app_address_pokt1a3b8ef9b"
+      host_port: example_fullnode_grpc.your_domain:443 # replace with your full node grpc host:port
+    lazy_mode: false # set to true to disable PATH caching mechanism
+  gateway_config:
+    gateway_mode: centralized # replace with your gateway mode centralized|delegated|trusted
+    gateway_address: example_gateway_address_pokt1710ed9a8d0986d8 # replace with your gateway address
+    gateway_private_key_hex: example_gateway_private_key_52734539d033e35c6e6d1ce5ad96bcacb911 # replace with your gateway private key
+    # Not applicable for delegated gateway mode
+    owned_apps_private_keys_hex: # replace with delegated app addresses
+      - example_owned_app_private_key_pokt1a3b8ef9b
 
 services:
   "F00C":

--- a/config/config.schema.yaml
+++ b/config/config.schema.yaml
@@ -128,8 +128,7 @@ properties:
         required:
           - gateway_mode
           - gateway_address
-          - gateway_hex_private_key
-          - owned_apps_hex_private_keys
+          - gateway_private_key_hex
         properties:
           gateway_mode:
             type: string
@@ -137,10 +136,10 @@ properties:
           gateway_address:
             type: string
             pattern: "^pokt1[0-9a-zA-Z]{38}$" # 43 total characters
-          gateway_hex_private_key:
+          gateway_private_key_hex:
             type: string
             pattern: "^[0-9a-fA-F]{64}$"
-          owned_apps_hex_private_keys:
+          owned_apps_private_keys_hex: # Not required in delegated gateway mode
             type: array
             items:
               type: string

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -135,7 +135,7 @@ func Test_LoadGatewayConfigFromYAML(t *testing.T) {
 			    grpc_url: "grpcs://grpc-url.io"
 			  gateway_config:
 			    gateway_address: "invalid_gateway_address"
-			    gateway_hex_private_key: "d5fcbfb894059a21e914a2d6bf1508319ce2b1b8878f15aa0c1cdf883feb018d"
+			    gateway_private_key_hex: "d5fcbfb894059a21e914a2d6bf1508319ce2b1b8878f15aa0c1cdf883feb018d"
 			    gateway_mode: "delegated"
 			`,
 			wantErr: true,

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -135,8 +135,8 @@ func Test_LoadGatewayConfigFromYAML(t *testing.T) {
 			    grpc_url: "grpcs://grpc-url.io"
 			  gateway_config:
 			    gateway_address: "invalid_gateway_address"
-                            gateway_hex_private_key: "d5fcbfb894059a21e914a2d6bf1508319ce2b1b8878f15aa0c1cdf883feb018d"
-                            gateway_mode: "delegated"
+			    gateway_hex_private_key: "d5fcbfb894059a21e914a2d6bf1508319ce2b1b8878f15aa0c1cdf883feb018d"
+			    gateway_mode: "delegated"
 			`,
 			wantErr: true,
 		},

--- a/config/testdata/shannon.example.yaml
+++ b/config/testdata/shannon.example.yaml
@@ -6,9 +6,9 @@ shannon_config:
       host_port: "grpc-url.io:443"
   gateway_config:
     gateway_address: "pokt1710ed9a8d0986d808e607c5815cc5a13f15dba"
-    gateway_hex_private_key: "d5fcbfb894059a21e914a2d6bf1508319ce2b1b8878f15aa0c1cdf883feb018d"
+    gateway_private_key_hex: "d5fcbfb894059a21e914a2d6bf1508319ce2b1b8878f15aa0c1cdf883feb018d"
     gateway_mode: "centralized"
-    owned_apps_hex_private_keys:
+    owned_apps_private_keys_hex:
       - "e5fcbfb894059a21e914a2d6bf1508319ce2b1b8878f15aa0c1cdf883feb018d"
       - "f5fcbfb894059a21e914a2d6bf1508319ce2b1b8878f15aa0c1cdf883feb018d"
 

--- a/e2e/scripts/update_shannon_config_from_secrets.sh
+++ b/e2e/scripts/update_shannon_config_from_secrets.sh
@@ -19,8 +19,8 @@ update_shannon_config_from_env() {
     fi
 
     yq -i '
-	.shannon_config.gateway_config.gateway_hex_private_key = env(SHANNON_GATEWAY_PRIVATE_KEY) |
-	.shannon_config.gateway_config.owned_apps_hex_private_keys= env(SHANNON_OWNED_APPS_PRIVATE_KEYS)
+	.shannon_config.gateway_config.gateway_private_key_hex = env(SHANNON_GATEWAY_PRIVATE_KEY) |
+	.shannon_config.gateway_config.owned_apps_private_keys_hex = env(SHANNON_OWNED_APPS_PRIVATE_KEYS)
     ' $CONFIG_FILE
 }
 

--- a/e2e/shannon.example.yaml
+++ b/e2e/shannon.example.yaml
@@ -12,10 +12,10 @@ shannon_config:
   gateway_config:
     gateway_mode: "centralized"
     # NOTE: gateway_hex_private_key must be replaced with the correct gateway private key secret
-    gateway_hex_private_key: cf09805c952fa999e9a63a9f434147b0a5abfd10f268879694c6b5a70e1ae177
+    gateway_private_key_hex: cf09805c952fa999e9a63a9f434147b0a5abfd10f268879694c6b5a70e1ae177
     # do not change gateway_address
     gateway_address: pokt1up7zlytnmvlsuxzpzvlrta95347w322adsxslw 
-    owned_apps_hex_private_keys:
+    owned_apps_private_keys_hex:
       # NOTE: the application private key must be replaced with the correct application private key secret
       - cf09805c952fa999e9a63a9f434147b0a5abfd10f268879694c6b5a70e1ae177
 services:

--- a/e2e/shannon.example.yaml
+++ b/e2e/shannon.example.yaml
@@ -11,7 +11,7 @@ shannon_config:
       host_port: testnet-validated-validator-grpc.poktroll.com:443
   gateway_config:
     gateway_mode: "centralized"
-    # NOTE: gateway_hex_private_key must be replaced with the correct gateway private key secret
+    # NOTE: gateway_private_key_hex must be replaced with the correct gateway private key secret
     gateway_private_key_hex: cf09805c952fa999e9a63a9f434147b0a5abfd10f268879694c6b5a70e1ae177
     # do not change gateway_address
     gateway_address: pokt1up7zlytnmvlsuxzpzvlrta95347w322adsxslw 

--- a/protocol/shannon/config.go
+++ b/protocol/shannon/config.go
@@ -44,8 +44,8 @@ type (
 	GatewayConfig struct {
 		GatewayMode             protocol.GatewayMode `yaml:"gateway_mode"`
 		GatewayAddress          string               `yaml:"gateway_address"`
-		GatewayPrivateKeyHex    string               `yaml:"gateway_hex_private_key"`
-		OwnedAppsPrivateKeysHex []string             `yaml:"owned_apps_hex_private_keys"`
+		GatewayPrivateKeyHex    string               `yaml:"gateway_private_key_hex"`
+		OwnedAppsPrivateKeysHex []string             `yaml:"owned_apps_private_keys_hex"`
 	}
 
 	// TODO_TECHDEBT(@adshmh): Move this and related helpers into a new `grpc` package.


### PR DESCRIPTION
* Update `Shannon` config example `cmd/.config.shannon_example.yaml` to comply with the new parser.
* Fix `Gateway` and `Application` config entry names `*_hex_private_key` -> `*_private_key_hex`
* Fix test config indentation.