### PR TITLE
[READY] Change trigger workflow from workflow_run to push

### DIFF
--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -1,10 +1,7 @@
 name: Tag and Release
 
 on:
-  workflow_run:
-    workflows: ["Path tests"]
-    types:
-      - completed
+  push:
     branches:
       - main
   workflow_dispatch: # Added to enable manual trigger via GitHub UI


### PR DESCRIPTION
# TL;DR

Change the worklow trigger from `workflow_run` which was pointing to the wrong branch to trigger to `push` which will trigger release creation when pushing to `main` branch.