### PR TITLE
[PATCH] [READY] Fix `values.yaml` and small typo in makefile

### DIFF
--- a/local/kubernetes/path-values.yaml
+++ b/local/kubernetes/path-values.yaml
@@ -7,7 +7,7 @@ global:
 path:
   mountSecrets:
     - name: path-config-local
-      mountPath: /app/.config.yaml
+      mountPath: /app/config/.config.yaml
       subPath: .config.yaml
       items:
         - key: .config.yaml

--- a/makefiles/localnet.mk
+++ b/makefiles/localnet.mk
@@ -57,6 +57,6 @@ config_path_secrets: check_path_config
 dev_down:
 	@echo "Tearing down local environment..."
 	@tilt down
-	@kuebctl delete secret path-config-local
-	@kind delete cluster --name kind-path-localnet
+	@kubectl delete secret path-config-local
+	@kind delete cluster --name path-localnet
 	@kubectl config delete-context kind-path-localnet


### PR DESCRIPTION
# TL;DR

Fix typo in makefile and update mountSecrets block to the proper path, causing Path container to break both locally and in staging env.