### PR TITLE
fix: set lazy mode to true when setting shannon e2e test config

### DIFF
--- a/e2e/scripts/update_shannon_config_from_secrets.sh
+++ b/e2e/scripts/update_shannon_config_from_secrets.sh
@@ -18,9 +18,12 @@ update_shannon_config_from_env() {
         return 1
     fi
 
+    # Set the config values from the Github secrets environment variables.
+    # This also sets lazy_mode to minimize confusing log entries if an E2E test fails in the CI.
     yq -i '
 	.shannon_config.gateway_config.gateway_private_key_hex = env(SHANNON_GATEWAY_PRIVATE_KEY) |
-	.shannon_config.gateway_config.owned_apps_private_keys_hex = [env(SHANNON_OWNED_APPS_PRIVATE_KEYS)]
+	.shannon_config.gateway_config.owned_apps_private_keys_hex = [env(SHANNON_OWNED_APPS_PRIVATE_KEYS)] |
+    .shannon_config.full_node_config.lazy_mode = true
     ' $CONFIG_FILE
 }
 


### PR DESCRIPTION
This is to minimize the confusing log entries if an E2E test fails.

Discord conversation:
https://discord.com/channels/824324475256438814/1316586048670666802/1316744288910184560