### PR TITLE
[Morse Support] All Morse EVM IDs to `service_alias` map

### DIFF
--- a/config/service_alias.go
+++ b/config/service_alias.go
@@ -18,12 +18,39 @@ const (
 	ServiceIDE2E    ServiceQoSType = "gatewaye2e" // ServiceIDE2E represents the service created for running PATH gateway's E2E tests.
 )
 
-// The ServiceQoSTypes map associates each supported service ID with a specific implementation of the
-// gateway.QoSService interface.
-// THis is to handle requests for a given service ID.
-var ServiceQoSTypes = map[protocol.ServiceID]ServiceQoSType{
-	// All Morse EVM Services as of 12/17/2024 (#103)
-	// TODO_TECHDEBT(@fredteumer): Revisit and consider removing these once #105 is complete.
+// The ServiceQoSTypes map associates each supported service ID with a specific
+// implementation of the gateway.QoSService interface.
+// This is to handle requests for a given service ID.
+var ServiceQoSTypes = map[protocol.ServiceID]ServiceQoSType{}
+
+func init() {
+	for k, v := range shannonQoSTypes {
+		ServiceQoSTypes[k] = v
+	}
+	for k, v := range legacyMorseQoSTypes {
+		ServiceQoSTypes[k] = v
+	}
+}
+
+var shannonQoSTypes = map[protocol.ServiceID]ServiceQoSType{
+	// TODO_IMPROVE Add all non-EVM Morse Services and requisite initialization
+
+	// Shannon Service IDs
+	"anvil": ServiceIDEVM, // ETH Local (development/testing)
+
+	// TODO_IMPROVE(@commoddity): Use actual service IDs for Solana and POKT.
+	"solana": ServiceIDSolana,
+
+	"pokt":  ServiceIDPOKT,
+	"morse": ServiceIDPOKT,
+
+	// Gateway E2E service ID is used only for running PATH's Morse and Shannon E2E tests.
+	"gatewaye2e": ServiceIDE2E,
+}
+
+// All Morse EVM Services as of 12/17/2024 (#103)
+// TODO_TECHDEBT(@fredteumer): Revisit and consider removing these once #105 is complete.
+var legacyMorseQoSTypes = map[protocol.ServiceID]ServiceQoSType{
 	"F001": ServiceIDEVM, // Arbitrum One
 	"F002": ServiceIDEVM, // Arbitrum Sepolia Testnet
 	"F003": ServiceIDEVM, // Avalanche
@@ -61,18 +88,4 @@ var ServiceQoSTypes = map[protocol.ServiceID]ServiceQoSType{
 	"F029": ServiceIDEVM, // Polygon zkEVM
 	"F02A": ServiceIDEVM, // zkLink
 	"F02B": ServiceIDEVM, // zkSync
-
-	// TODO_IMPROVE Add all non-EVM Morse Services and requisite initialization
-
-	// Shannon Service IDs
-	"anvil": ServiceIDEVM, // ETH Local (development/testing)
-
-	// TODO_IMPROVE(@commoddity): Use actual service IDs for Solana and POKT.
-	"solana": ServiceIDSolana,
-
-	"pokt":  ServiceIDPOKT,
-	"morse": ServiceIDPOKT,
-
-	// Gateway E2E service ID is used only for running PATH's Morse and Shannon E2E tests.
-	"gatewaye2e": ServiceIDE2E,
 }

--- a/config/service_alias.go
+++ b/config/service_alias.go
@@ -22,7 +22,8 @@ const (
 // gateway.QoSService interface.
 // THis is to handle requests for a given service ID.
 var ServiceQoSTypes = map[protocol.ServiceID]ServiceQoSType{
-	// All Morse EVM Services as of 12/17/2024
+	// All Morse EVM Services as of 12/17/2024 (#103)
+	// TODO_TECHDEBT(@fredteumer): Revisit and consider removing these once #105 is complete.
 	"F001": ServiceIDEVM, // Arbitrum One
 	"F002": ServiceIDEVM, // Arbitrum Sepolia Testnet
 	"F003": ServiceIDEVM, // Avalanche
@@ -63,11 +64,8 @@ var ServiceQoSTypes = map[protocol.ServiceID]ServiceQoSType{
 
 	// TODO_IMPROVE Add all non-EVM Morse Services and requisite initialization
 
-	// Other Services (Shannon / Testing)
-	"0021":        ServiceIDEVM, // ETH Mainnet
-	"anvil":       ServiceIDEVM, // ETH Local (development/testing)
-	"eth":         ServiceIDEVM, // ETH general-purpose catch-all
-	"eth-mainnet": ServiceIDEVM, // ETH MainNet general-purpose catch-all
+	// Shannon Service IDs
+	"anvil": ServiceIDEVM, // ETH Local (development/testing)
 
 	// TODO_IMPROVE(@commoddity): Use actual service IDs for Solana and POKT.
 	"solana": ServiceIDSolana,

--- a/config/service_alias.go
+++ b/config/service_alias.go
@@ -23,47 +23,47 @@ const (
 // THis is to handle requests for a given service ID.
 var ServiceQoSTypes = map[protocol.ServiceID]ServiceQoSType{
 	// All Morse EVM Services as of 12/17/2024
-  "F001":        ServiceIDEVM, // Arbitrum One
-	"F002":				 ServiceIDEVM, // Arbitrum Sepolia Testnet
-	"F003":				 ServiceIDEVM, // Avalanche
-	"F004":				 ServiceIDEVM, // Avalanche-DFK
-	"F005":				 ServiceIDEVM, // Base
-	"F006":				 ServiceIDEVM, // Base Sepolia Testnet
-	"F008":				 ServiceIDEVM, // Blast
-	"F009":				 ServiceIDEVM, // BNB Smart Chain
-	"F00A":				 ServiceIDEVM, // Boba
-	"F00B":				 ServiceIDEVM, // Celo
-	"F00C":        ServiceIDEVM, // Ethereum
-	"F00D":        ServiceIDEVM, // Ethereum Holesky Testnet
-	"F00E":        ServiceIDEVM, // Ethereum Sepolia Testnet
-	"F00F":        ServiceIDEVM, // Evmos
-	"F010":        ServiceIDEVM, // Fantom
-	"F011":        ServiceIDEVM, // Fraxtal
-	"F012":        ServiceIDEVM, // Fuse
-	"F013":        ServiceIDEVM, // Gnosis 
-	"F014":        ServiceIDEVM, // Harmony-0
-	"F015":        ServiceIDEVM, // IoTeX
-	"F016":        ServiceIDEVM, // Kaia
-	"F017":        ServiceIDEVM, // Kava
-	"F018":        ServiceIDEVM, // Metis
-	"F019":        ServiceIDEVM, // Moonbeam
-	"F01A":        ServiceIDEVM, // Moonriver
-	"F01C":        ServiceIDEVM, // Oasys
-	"F01D":        ServiceIDEVM, // Optimism
-	"F01E":        ServiceIDEVM, // Optimism Sepolia Testnet
-	"F01F":        ServiceIDEVM, // opBNB
-	"F021":        ServiceIDEVM, // Polygon
-	"F022":        ServiceIDEVM, // Polygon Amoy Testnet
-	"F024":        ServiceIDEVM, // Scroll
-	"F027":        ServiceIDEVM, // Taiko
-	"F028":        ServiceIDEVM, // Taiko Hekla Testnet
-	"F029":        ServiceIDEVM, // Polygon zkEVM
-	"F02A":        ServiceIDEVM, // zkLink
-	"F02B":        ServiceIDEVM, // zkSync
+	"F001": ServiceIDEVM, // Arbitrum One
+	"F002": ServiceIDEVM, // Arbitrum Sepolia Testnet
+	"F003": ServiceIDEVM, // Avalanche
+	"F004": ServiceIDEVM, // Avalanche-DFK
+	"F005": ServiceIDEVM, // Base
+	"F006": ServiceIDEVM, // Base Sepolia Testnet
+	"F008": ServiceIDEVM, // Blast
+	"F009": ServiceIDEVM, // BNB Smart Chain
+	"F00A": ServiceIDEVM, // Boba
+	"F00B": ServiceIDEVM, // Celo
+	"F00C": ServiceIDEVM, // Ethereum
+	"F00D": ServiceIDEVM, // Ethereum Holesky Testnet
+	"F00E": ServiceIDEVM, // Ethereum Sepolia Testnet
+	"F00F": ServiceIDEVM, // Evmos
+	"F010": ServiceIDEVM, // Fantom
+	"F011": ServiceIDEVM, // Fraxtal
+	"F012": ServiceIDEVM, // Fuse
+	"F013": ServiceIDEVM, // Gnosis
+	"F014": ServiceIDEVM, // Harmony-0
+	"F015": ServiceIDEVM, // IoTeX
+	"F016": ServiceIDEVM, // Kaia
+	"F017": ServiceIDEVM, // Kava
+	"F018": ServiceIDEVM, // Metis
+	"F019": ServiceIDEVM, // Moonbeam
+	"F01A": ServiceIDEVM, // Moonriver
+	"F01C": ServiceIDEVM, // Oasys
+	"F01D": ServiceIDEVM, // Optimism
+	"F01E": ServiceIDEVM, // Optimism Sepolia Testnet
+	"F01F": ServiceIDEVM, // opBNB
+	"F021": ServiceIDEVM, // Polygon
+	"F022": ServiceIDEVM, // Polygon Amoy Testnet
+	"F024": ServiceIDEVM, // Scroll
+	"F027": ServiceIDEVM, // Taiko
+	"F028": ServiceIDEVM, // Taiko Hekla Testnet
+	"F029": ServiceIDEVM, // Polygon zkEVM
+	"F02A": ServiceIDEVM, // zkLink
+	"F02B": ServiceIDEVM, // zkSync
 
 	// TODO_IMPROVE Add all non-EVM Morse Services and requisite initialization
-	
-  // Other Services (Shannon / Testing)
+
+	// Other Services (Shannon / Testing)
 	"0021":        ServiceIDEVM, // ETH Mainnet
 	"anvil":       ServiceIDEVM, // ETH Local (development/testing)
 	"eth":         ServiceIDEVM, // ETH general-purpose catch-all

--- a/config/service_alias.go
+++ b/config/service_alias.go
@@ -22,9 +22,49 @@ const (
 // gateway.QoSService interface.
 // THis is to handle requests for a given service ID.
 var ServiceQoSTypes = map[protocol.ServiceID]ServiceQoSType{
-	// TODO_IMPROVE(@commoddity): Add all EVM service IDs here.
+	// All Morse EVM Services as of 12/17/2024
+  "F001":        ServiceIDEVM, // Arbitrum One
+	"F002":				 ServiceIDEVM, // Arbitrum Sepolia Testnet
+	"F003":				 ServiceIDEVM, // Avalanche
+	"F004":				 ServiceIDEVM, // Avalanche-DFK
+	"F005":				 ServiceIDEVM, // Base
+	"F006":				 ServiceIDEVM, // Base Sepolia Testnet
+	"F008":				 ServiceIDEVM, // Blast
+	"F009":				 ServiceIDEVM, // BNB Smart Chain
+	"F00A":				 ServiceIDEVM, // Boba
+	"F00B":				 ServiceIDEVM, // Celo
+	"F00C":        ServiceIDEVM, // Ethereum
+	"F00D":        ServiceIDEVM, // Ethereum Holesky Testnet
+	"F00E":        ServiceIDEVM, // Ethereum Sepolia Testnet
+	"F00F":        ServiceIDEVM, // Evmos
+	"F010":        ServiceIDEVM, // Fantom
+	"F011":        ServiceIDEVM, // Fraxtal
+	"F012":        ServiceIDEVM, // Fuse
+	"F013":        ServiceIDEVM, // Gnosis 
+	"F014":        ServiceIDEVM, // Harmony-0
+	"F015":        ServiceIDEVM, // IoTeX
+	"F016":        ServiceIDEVM, // Kaia
+	"F017":        ServiceIDEVM, // Kava
+	"F018":        ServiceIDEVM, // Metis
+	"F019":        ServiceIDEVM, // Moonbeam
+	"F01A":        ServiceIDEVM, // Moonriver
+	"F01C":        ServiceIDEVM, // Oasys
+	"F01D":        ServiceIDEVM, // Optimism
+	"F01E":        ServiceIDEVM, // Optimism Sepolia Testnet
+	"F01F":        ServiceIDEVM, // opBNB
+	"F021":        ServiceIDEVM, // Polygon
+	"F022":        ServiceIDEVM, // Polygon Amoy Testnet
+	"F024":        ServiceIDEVM, // Scroll
+	"F027":        ServiceIDEVM, // Taiko
+	"F028":        ServiceIDEVM, // Taiko Hekla Testnet
+	"F029":        ServiceIDEVM, // Polygon zkEVM
+	"F02A":        ServiceIDEVM, // zkLink
+	"F02B":        ServiceIDEVM, // zkSync
+
+	// TODO_IMPROVE Add all non-EVM Morse Services and requisite initialization
+	
+  // Other Services (Shannon / Testing)
 	"0021":        ServiceIDEVM, // ETH Mainnet
-	"F00C":        ServiceIDEVM, // ETH Mainnet (Full/Archival)
 	"anvil":       ServiceIDEVM, // ETH Local (development/testing)
 	"eth":         ServiceIDEVM, // ETH general-purpose catch-all
 	"eth-mainnet": ServiceIDEVM, // ETH MainNet general-purpose catch-all

--- a/config/service_alias.go
+++ b/config/service_alias.go
@@ -51,41 +51,42 @@ var shannonQoSTypes = map[protocol.ServiceID]ServiceQoSType{
 // All Morse EVM Services as of 12/17/2024 (#103)
 // TODO_TECHDEBT(@fredteumer): Revisit and consider removing these once #105 is complete.
 var legacyMorseQoSTypes = map[protocol.ServiceID]ServiceQoSType{
-	"F001": ServiceIDEVM, // Arbitrum One
-	"F002": ServiceIDEVM, // Arbitrum Sepolia Testnet
-	"F003": ServiceIDEVM, // Avalanche
-	"F004": ServiceIDEVM, // Avalanche-DFK
-	"F005": ServiceIDEVM, // Base
-	"F006": ServiceIDEVM, // Base Sepolia Testnet
-	"F008": ServiceIDEVM, // Blast
-	"F009": ServiceIDEVM, // BNB Smart Chain
-	"F00A": ServiceIDEVM, // Boba
-	"F00B": ServiceIDEVM, // Celo
-	"F00C": ServiceIDEVM, // Ethereum
-	"F00D": ServiceIDEVM, // Ethereum Holesky Testnet
-	"F00E": ServiceIDEVM, // Ethereum Sepolia Testnet
-	"F00F": ServiceIDEVM, // Evmos
-	"F010": ServiceIDEVM, // Fantom
-	"F011": ServiceIDEVM, // Fraxtal
-	"F012": ServiceIDEVM, // Fuse
-	"F013": ServiceIDEVM, // Gnosis
-	"F014": ServiceIDEVM, // Harmony-0
-	"F015": ServiceIDEVM, // IoTeX
-	"F016": ServiceIDEVM, // Kaia
-	"F017": ServiceIDEVM, // Kava
-	"F018": ServiceIDEVM, // Metis
-	"F019": ServiceIDEVM, // Moonbeam
-	"F01A": ServiceIDEVM, // Moonriver
-	"F01C": ServiceIDEVM, // Oasys
-	"F01D": ServiceIDEVM, // Optimism
-	"F01E": ServiceIDEVM, // Optimism Sepolia Testnet
-	"F01F": ServiceIDEVM, // opBNB
-	"F021": ServiceIDEVM, // Polygon
-	"F022": ServiceIDEVM, // Polygon Amoy Testnet
-	"F024": ServiceIDEVM, // Scroll
-	"F027": ServiceIDEVM, // Taiko
-	"F028": ServiceIDEVM, // Taiko Hekla Testnet
-	"F029": ServiceIDEVM, // Polygon zkEVM
-	"F02A": ServiceIDEVM, // zkLink
-	"F02B": ServiceIDEVM, // zkSync
+	"F001": ServiceIDEVM,    // Arbitrum One
+	"F002": ServiceIDEVM,    // Arbitrum Sepolia Testnet
+	"F003": ServiceIDEVM,    // Avalanche
+	"F004": ServiceIDEVM,    // Avalanche-DFK
+	"F005": ServiceIDEVM,    // Base
+	"F006": ServiceIDEVM,    // Base Sepolia Testnet
+	"F008": ServiceIDEVM,    // Blast
+	"F009": ServiceIDEVM,    // BNB Smart Chain
+	"F00A": ServiceIDEVM,    // Boba
+	"F00B": ServiceIDEVM,    // Celo
+	"F00C": ServiceIDEVM,    // Ethereum
+	"F00D": ServiceIDEVM,    // Ethereum Holesky Testnet
+	"F00E": ServiceIDEVM,    // Ethereum Sepolia Testnet
+	"F00F": ServiceIDEVM,    // Evmos
+	"F010": ServiceIDEVM,    // Fantom
+	"F011": ServiceIDEVM,    // Fraxtal
+	"F012": ServiceIDEVM,    // Fuse
+	"F013": ServiceIDEVM,    // Gnosis
+	"F014": ServiceIDEVM,    // Harmony-0
+	"F015": ServiceIDEVM,    // IoTeX
+	"F016": ServiceIDEVM,    // Kaia
+	"F017": ServiceIDEVM,    // Kava
+	"F018": ServiceIDEVM,    // Metis
+	"F019": ServiceIDEVM,    // Moonbeam
+	"F01A": ServiceIDEVM,    // Moonriver
+	"F01C": ServiceIDEVM,    // Oasys
+	"F01D": ServiceIDEVM,    // Optimism
+	"F01E": ServiceIDEVM,    // Optimism Sepolia Testnet
+	"F01F": ServiceIDEVM,    // opBNB
+	"F021": ServiceIDEVM,    // Polygon
+	"F022": ServiceIDEVM,    // Polygon Amoy Testnet
+	"F024": ServiceIDEVM,    // Scroll
+	"F025": ServiceIDSolana, // Solana
+	"F027": ServiceIDEVM,    // Taiko
+	"F028": ServiceIDEVM,    // Taiko Hekla Testnet
+	"F029": ServiceIDEVM,    // Polygon zkEVM
+	"F02A": ServiceIDEVM,    // zkLink
+	"F02B": ServiceIDEVM,    // zkSync
 }


### PR DESCRIPTION
adding all morse EVMs to `service_alias.go`. This will help enable users to launch on MORSE ASAP specifically with the F-chains cutover. 

This is a requirement on behalf of Chainstack (and any live Morse gateway) to cutover from Gateway Server -> Path in the immediate. This also aligns nicely from a timing standpoint given that the set of chains will be perfectly defined by the Foundation on 12/18 in accordance with this list of chains: https://docs.google.com/spreadsheets/d/1QWVGEuB2u5bkGfONoDNaltjny1jd9rJ_f7HZTjSGgQM/