### PR TITLE
[Test Fixes] Followup to #103 add Morse/Shannon/Service IDs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,24 +78,26 @@ test_auth_server: ## Run the auth server tests
 	(cd envoy/auth_server && go test ./... -count=1)
 
 .PHONY: test_e2e_shannon_relay_iterate
-test_e2e_shannon_relay_iterate: ## Instructions on how to iterate locally for an E2E shannon relay
+test_e2e_shannon_relay_iterate: ## Iterate on E2E shannon relay tests
 	@echo "go build -o bin/path ./cmd"
 	@echo "# Update ./bin/config/.config.yaml"
 	@echo "./bin/path"
 	@echo "curl http://anvil.localhost:3000/v1/abcd1234 -X POST -H \"Content-Type: application/json\" -d '{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"eth_blockNumber\"}'"
 
 .PHONY: test_e2e_shannon_relay
-test_e2e_shannon_relay: ## Run an E2E shannon relay test (iterate)
-	@echo "README: If you are iterating on E2E tests, stop this and run the following for instructions instead: 'make test_e2e_shannon_relay_iterate'."
+test_e2e_shannon_relay: shannon_e2e_config_warning ## Run an E2E Shannon relay test
+	@echo "###############################################################################################################################################################"
+	@echo "### README: If you are intending to iterate on E2E tests, stop this and run the following for instructions instead: 'make test_e2e_shannon_relay_iterate'. ###"
+	@echo "###############################################################################################################################################################"
 	go test -v ./e2e/... -tags=e2e -count=1 -run Test_ShannonRelay
 
 .PHONY: test_e2e_morse_relay
-test_e2e_morse_relay: ## Run an E2E Morse relay test
+test_e2e_morse_relay: morse_e2e_config_warning ## Run an E2E Morse relay test
 	go test -v ./e2e/... -tags=e2e -count=1 -run Test_MorseRelay
 
-################################
-### Copy Config Make Targets ###
-################################
+###################################
+### Shannon Config Make Targets ###
+###################################
 
 # TODO_MVP(@commoddity): Consolidate the copy_*_config targets into fewer targets once
 # the config files are consolidated as well.
@@ -115,6 +117,15 @@ copy_shannon_config: ## copies the example shannon configuration yaml file to .c
 		echo "##################################################################"; \
 		echo "### ./bin/config/.config.yaml already exists, not overwriting. ###"; \
 		echo "##################################################################"; \
+	fi
+
+.PHONY: shannon_e2e_config_warning
+shannon_e2e_config_warning: ## Prints a warning if the shannon E2E config is not populated
+	@if [ ! -f ./e2e/.shannon.config.yaml ]; then \
+		echo "#########################################################################"; \
+		echo "### Shannon E2E config not found, run: 'make copy_shannon_e2e_config' ###"; \
+		echo "#########################################################################"; \
+		exit; \
 	fi
 
 .PHONY: copy_shannon_e2e_config
@@ -148,6 +159,10 @@ config_shannon_localnet: ## Create a localnet config file to serve as a Shannon 
 		echo "#########################################################################"; \
 	fi
 
+###################################
+### Morse Config Make Targets ###
+###################################
+
 .PHONY: copy_morse_config
 copy_morse_config: ## copies the example morse configuration yaml file to .config.yaml file
 	@if [ ! -f ./bin/config/.config.yaml ]; then \
@@ -162,6 +177,15 @@ copy_morse_config: ## copies the example morse configuration yaml file to .confi
 		echo "##################################################################"; \
 		echo "### ./bin/config/.config.yaml already exists, not overwriting. ###"; \
 		echo "##################################################################"; \
+	fi
+
+.PHONY: morse_e2e_config_warning
+morse_e2e_config_warning: ## Prints a warning if the shannon E2E config is not populated
+	@if [ ! -f ./e2e/.morse.config.yaml ]; then \
+		echo "#####################################################################"; \
+		echo "### Morse E2E config not found, run: 'make copy_morse_e2e_config' ###"; \
+		echo "#####################################################################"; \
+		exit; \
 	fi
 
 .PHONY: copy_morse_e2e_config

--- a/Makefile
+++ b/Makefile
@@ -128,6 +128,7 @@ shannon_e2e_config_warning: ## Prints a warning if the shannon E2E config is not
 		exit; \
 	fi
 
+# If you are a Grove employee, search for this UUID in 1Password: 47k7kidj3y6nd3cghlakg76nlm
 .PHONY: copy_shannon_e2e_config
 copy_shannon_e2e_config: ## copies the example Shannon test configuration yaml file to .gitignored .shannon.config.yaml file
 	@if [ ! -f ./e2e/.shannon.config.yaml ]; then \
@@ -188,6 +189,7 @@ morse_e2e_config_warning: ## Prints a warning if the shannon E2E config is not p
 		exit; \
 	fi
 
+# If you are a Grove employee, search for this UUID in 1Password: un76qmz6xunx43icttjmagzlri
 .PHONY: copy_morse_e2e_config
 copy_morse_e2e_config: ## copies the example Morse test configuration yaml file to .gitignored ..morse.config.yaml file.
 	@if [ ! -f ./e2e/.morse.config.yaml ]; then \

--- a/cmd/qos.go
+++ b/cmd/qos.go
@@ -74,18 +74,6 @@ func getServiceQoSInstances(
 		case config.ServiceIDPOKT:
 			// TODO_TECHDEBT: add pokt qos service here
 
-		case config.ServiceIDE2E:
-			evmEndpointStore := &evm.EndpointStore{
-				Config: evm.EndpointStoreConfig{
-					// TODO_MVP(@adshmh): Read the chain ID from the configuration.
-					ChainID: "0x1",
-				},
-				Logger: logger,
-			}
-			if _, ok := gatewayServiceIDsIdx[serviceID]; ok {
-				gatewayQoSService[serviceID] = evm.NewServiceQoS(evmEndpointStore, logger)
-			}
-
 		default:
 			return nil, nil, fmt.Errorf("error building QoS instances: service ID %q not supported by PATH", serviceID)
 		}

--- a/config/service_alias.go
+++ b/config/service_alias.go
@@ -12,10 +12,9 @@ type ServiceQoSType string
 
 const (
 	// TODO_IMPROVE(@commoddity): consider using protocol scope for the service IDs.
-	ServiceIDEVM    ServiceQoSType = "evm"        // ServiceIDEVM represents the EVM service type, containing all EVM-based blockchains.
-	ServiceIDSolana ServiceQoSType = "solana"     // ServiceIDSolana represents the Solana blockchain service type.
-	ServiceIDPOKT   ServiceQoSType = "pokt"       // ServiceIDPOKT represents the POKT blockchain service type.
-	ServiceIDE2E    ServiceQoSType = "gatewaye2e" // ServiceIDE2E represents the service created for running PATH gateway's E2E tests.
+	ServiceIDEVM    ServiceQoSType = "evm"    // ServiceIDEVM represents the EVM service type, containing all EVM-based blockchains.
+	ServiceIDSolana ServiceQoSType = "solana" // ServiceIDSolana represents the Solana blockchain service type.
+	ServiceIDPOKT   ServiceQoSType = "pokt"   // ServiceIDPOKT represents the POKT blockchain service type.
 )
 
 // The ServiceQoSTypes map associates each supported service ID with a specific
@@ -56,9 +55,6 @@ var shannonQoSTypes = map[protocol.ServiceID]ServiceQoSType{
 var testQoSTypes = map[protocol.ServiceID]ServiceQoSType{
 	// Shannon Service IDs
 	"anvil": ServiceIDEVM, // ETH Local (development/testing)
-
-	// Gateway E2E service ID is used only for running PATH's Morse and Shannon E2E tests.
-	"gatewaye2e": ServiceIDE2E,
 }
 
 // TODO_TECHDEBT(@fredteumer): Revisit and consider removing these once #105 is complete.

--- a/config/service_alias.go
+++ b/config/service_alias.go
@@ -30,63 +30,82 @@ func init() {
 	for k, v := range legacyMorseQoSTypes {
 		ServiceQoSTypes[k] = v
 	}
+	for k, v := range testQoSTypes {
+		ServiceQoSTypes[k] = v
+	}
 }
 
+// Shannon service IDs.
+// As of 12/2024, these service IDs are on Beta TestNet and intended to be moved
+// over to MainNet once the network is ready.
 var shannonQoSTypes = map[protocol.ServiceID]ServiceQoSType{
-	// TODO_IMPROVE Add all non-EVM Morse Services and requisite initialization
-
-	// Shannon Service IDs
-	"anvil": ServiceIDEVM, // ETH Local (development/testing)
-
-	// TODO_IMPROVE(@commoddity): Use actual service IDs for Solana and POKT.
+	// Solana Service IDs
 	"solana": ServiceIDSolana,
 
+	// EVM Service IDs
+	"eth": ServiceIDEVM,
+
+	// POKT Service IDs
 	"pokt":  ServiceIDPOKT,
 	"morse": ServiceIDPOKT,
+}
+
+// Shannon test service IDs.
+// As of 12/2024, these service IDs are on Beta TestNet and primarily used
+// for E2E testing. They may or may not be moved over to MainNet once the network.
+var testQoSTypes = map[protocol.ServiceID]ServiceQoSType{
+	// Shannon Service IDs
+	"anvil": ServiceIDEVM, // ETH Local (development/testing)
 
 	// Gateway E2E service ID is used only for running PATH's Morse and Shannon E2E tests.
 	"gatewaye2e": ServiceIDE2E,
 }
 
-// All Morse EVM Services as of 12/17/2024 (#103)
 // TODO_TECHDEBT(@fredteumer): Revisit and consider removing these once #105 is complete.
+// Service IDs transferred from Morse to Shannon for backwards compatibility.
 var legacyMorseQoSTypes = map[protocol.ServiceID]ServiceQoSType{
-	"F001": ServiceIDEVM,    // Arbitrum One
-	"F002": ServiceIDEVM,    // Arbitrum Sepolia Testnet
-	"F003": ServiceIDEVM,    // Avalanche
-	"F004": ServiceIDEVM,    // Avalanche-DFK
-	"F005": ServiceIDEVM,    // Base
-	"F006": ServiceIDEVM,    // Base Sepolia Testnet
-	"F008": ServiceIDEVM,    // Blast
-	"F009": ServiceIDEVM,    // BNB Smart Chain
-	"F00A": ServiceIDEVM,    // Boba
-	"F00B": ServiceIDEVM,    // Celo
-	"F00C": ServiceIDEVM,    // Ethereum
-	"F00D": ServiceIDEVM,    // Ethereum Holesky Testnet
-	"F00E": ServiceIDEVM,    // Ethereum Sepolia Testnet
-	"F00F": ServiceIDEVM,    // Evmos
-	"F010": ServiceIDEVM,    // Fantom
-	"F011": ServiceIDEVM,    // Fraxtal
-	"F012": ServiceIDEVM,    // Fuse
-	"F013": ServiceIDEVM,    // Gnosis
-	"F014": ServiceIDEVM,    // Harmony-0
-	"F015": ServiceIDEVM,    // IoTeX
-	"F016": ServiceIDEVM,    // Kaia
-	"F017": ServiceIDEVM,    // Kava
-	"F018": ServiceIDEVM,    // Metis
-	"F019": ServiceIDEVM,    // Moonbeam
-	"F01A": ServiceIDEVM,    // Moonriver
-	"F01C": ServiceIDEVM,    // Oasys
-	"F01D": ServiceIDEVM,    // Optimism
-	"F01E": ServiceIDEVM,    // Optimism Sepolia Testnet
-	"F01F": ServiceIDEVM,    // opBNB
-	"F021": ServiceIDEVM,    // Polygon
-	"F022": ServiceIDEVM,    // Polygon Amoy Testnet
-	"F024": ServiceIDEVM,    // Scroll
+	// Deprecated Morse EVM chains
+	"0021": ServiceIDEVM, // ETH Mainnet
+
+	// All Morse EVM F-Chain Services as of 12/17/2024 (#103)
+	"F001": ServiceIDEVM, // Arbitrum One
+	"F002": ServiceIDEVM, // Arbitrum Sepolia Testnet
+	"F003": ServiceIDEVM, // Avalanche
+	"F004": ServiceIDEVM, // Avalanche-DFK
+	"F005": ServiceIDEVM, // Base
+	"F006": ServiceIDEVM, // Base Sepolia Testnet
+	"F008": ServiceIDEVM, // Blast
+	"F009": ServiceIDEVM, // BNB Smart Chain
+	"F00A": ServiceIDEVM, // Boba
+	"F00B": ServiceIDEVM, // Celo
+	"F00C": ServiceIDEVM, // Ethereum
+	"F00D": ServiceIDEVM, // Ethereum Holesky Testnet
+	"F00E": ServiceIDEVM, // Ethereum Sepolia Testnet
+	"F00F": ServiceIDEVM, // Evmos
+	"F010": ServiceIDEVM, // Fantom
+	"F011": ServiceIDEVM, // Fraxtal
+	"F012": ServiceIDEVM, // Fuse
+	"F013": ServiceIDEVM, // Gnosis
+	"F014": ServiceIDEVM, // Harmony-0
+	"F015": ServiceIDEVM, // IoTeX
+	"F016": ServiceIDEVM, // Kaia
+	"F017": ServiceIDEVM, // Kava
+	"F018": ServiceIDEVM, // Metis
+	"F019": ServiceIDEVM, // Moonbeam
+	"F01A": ServiceIDEVM, // Moonriver
+	"F01C": ServiceIDEVM, // Oasys
+	"F01D": ServiceIDEVM, // Optimism
+	"F01E": ServiceIDEVM, // Optimism Sepolia Testnet
+	"F01F": ServiceIDEVM, // opBNB
+	"F021": ServiceIDEVM, // Polygon
+	"F022": ServiceIDEVM, // Polygon Amoy Testnet
+	"F024": ServiceIDEVM, // Scroll
+	"F027": ServiceIDEVM, // Taiko
+	"F028": ServiceIDEVM, // Taiko Hekla Testnet
+	"F029": ServiceIDEVM, // Polygon zkEVM
+	"F02A": ServiceIDEVM, // zkLink
+	"F02B": ServiceIDEVM, // zkSync
+
+	// Solana F-Chain Service IDs as of 12/2024 (#103)
 	"F025": ServiceIDSolana, // Solana
-	"F027": ServiceIDEVM,    // Taiko
-	"F028": ServiceIDEVM,    // Taiko Hekla Testnet
-	"F029": ServiceIDEVM,    // Polygon zkEVM
-	"F02A": ServiceIDEVM,    // zkLink
-	"F02B": ServiceIDEVM,    // zkSync
 }

--- a/e2e/docker_test.go
+++ b/e2e/docker_test.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"syscall"
 	"testing"
+	"time"
 
 	"github.com/ory/dockertest/v3"
 	"github.com/ory/dockertest/v3/docker"
@@ -26,7 +27,11 @@ const (
 	configMountPoint     = ":/app/config/.config.yaml"
 	containerEnvImageTag = "IMAGE_TAG=test"
 	containerExtraHost   = "host.docker.internal:host-gateway" // allows the container to access the host machine's Docker daemon
-	timeoutSeconds       = 120
+	// containerExpirySeconds is the number of seconds after which the started PATH container should be removed by the dockertest library.
+	containerExpirySeconds = 240
+	// maxPathHealthCheckWaitTimeMillisec is the maximum amount of time a started PATH container has to report its status as healthy.
+	// Once this time expires, the associated E2E test is marked as failed and the PATH container is removed.
+	maxPathHealthCheckWaitTimeMillisec = 120000
 )
 
 var (
@@ -95,6 +100,7 @@ func setupPathDocker(t *testing.T, configFilePath string) (*dockertest.Pool, *do
 	if err != nil {
 		t.Fatalf("Could not construct pool: %s", err)
 	}
+	pool.MaxWait = time.Duration(maxPathHealthCheckWaitTimeMillisec) * time.Millisecond
 
 	// Build the image and log build output
 	buildOptions := docker.BuildImageOptions{
@@ -152,7 +158,7 @@ func setupPathDocker(t *testing.T, configFilePath string) (*dockertest.Pool, *do
 		}
 	}()
 
-	if err := resource.Expire(timeoutSeconds); err != nil {
+	if err := resource.Expire(containerExpirySeconds); err != nil {
 		t.Fatalf("[ERROR] Failed to set expiration on docker container: %v", err)
 	}
 

--- a/e2e/morse_relay_test.go
+++ b/e2e/morse_relay_test.go
@@ -34,14 +34,14 @@ func Test_MorseRelay(t *testing.T) {
 		{
 			name:         "should successfully relay eth_chainId for eth (F00C)",
 			reqMethod:    http.MethodPost,
-			serviceAlias: "eth",
+			serviceAlias: "F00C",
 			relayID:      "1201",
 			body:         `{"jsonrpc": "2.0", "id": "1201", "method": "eth_chainId"}`,
 		},
 		{
 			name:         "should successfully relay eth_blockNumber for eth (F00C)",
 			reqMethod:    http.MethodPost,
-			serviceAlias: "eth",
+			serviceAlias: "F00C",
 			relayID:      "1202",
 			body:         `{"jsonrpc": "2.0", "id": "1202", "method": "eth_blockNumber"}`,
 		},
@@ -59,7 +59,7 @@ func Test_MorseRelay(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			c := require.New(t)
 
-			// eg. fullURL = "http://test-service.localdev.me:55006/v1"
+			// eg. fullURL = "http://F00C.localdev.me:55006/v1/abcdef12"
 			fullURL := fmt.Sprintf("http://%s.%s:%s%s", test.serviceAlias, localdevMe, pathContainerPort, reqPath)
 
 			client := &http.Client{}


### PR DESCRIPTION
- Add back `0021` used in E2E tests
- Separate Morse, Shannon and test service IDs
- Logically group different service IDs w/in Morse