### PR TITLE
[Docs] Add config location for Morse E2E tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -198,7 +198,7 @@ copy_morse_e2e_config: ## copies the example Morse test configuration yaml file 
 		echo "### Created ./e2e/.morse.config.yaml                                                      ###"; \
 		echo "###                                                                                       ###"; \
 		echo "### If you are a Grove employee, use the instructions from the link below to get the      ###"; \
-		echo "### correct config file, and COPY IT OVER the ./e2e/.more.config.yaml file.               ###"; \
+		echo "### correct config file, and COPY IT OVER the ./e2e/.morse.config.yaml file.              ###"; \
 		echo "### https://path.grove.city/develop/path/introduction#running-the-e2e-tests-against-morse ###"; \
 		echo "###                                                                                       ###"; \
 		echo "### Otherwise, please update the the following in .morse.config.yaml:                     ###"; \

--- a/Makefile
+++ b/Makefile
@@ -194,11 +194,16 @@ morse_e2e_config_warning: ## Prints a warning if the shannon E2E config is not p
 copy_morse_e2e_config: ## copies the example Morse test configuration yaml file to .gitignored ..morse.config.yaml file.
 	@if [ ! -f ./e2e/.morse.config.yaml ]; then \
 		cp ./config/examples/config.morse_example.yaml ./e2e/.morse.config.yaml; \
-		echo "######################################################################"; \
-		echo "### Created ./e2e/.morse.config.yaml                               ###"; \
-		echo "### README: Please update the the following in .morse.config.yaml: ###"; \
-		echo "### 'url', 'relay_signing_key', & 'signed_aats'.                   ###"; \
-		echo "######################################################################"; \
+		echo "#############################################################################################"; \
+		echo "### Created ./e2e/.morse.config.yaml                                                      ###"; \
+		echo "###                                                                                       ###"; \
+		echo "### If you are a Grove employee, use the instructions from the link below to get the      ###"; \
+		echo "### correct config file, and COPY IT OVER the ./e2e/.more.config.yaml file.               ###"; \
+		echo "### https://path.grove.city/develop/path/introduction#running-the-e2e-tests-against-morse ###"; \
+		echo "###                                                                                       ###"; \
+		echo "### Otherwise, please update the the following in .morse.config.yaml:                     ###"; \
+		echo "### 'url', 'relay_signing_key', & 'signed_aats'.                                          ###"; \
+		echo "#############################################################################################"; \
 	else \
 		echo "#################################################################"; \
 		echo "### ./e2e/.morse.config.yaml already exists, not overwriting. ###"; \

--- a/docusaurus/docs/develop/path/introduction.md
+++ b/docusaurus/docs/develop/path/introduction.md
@@ -283,6 +283,10 @@ Then update the `morse_config.full_node_config` and `morse_config.signed_aats` v
 
 You can find the example Morse configuration file [here](https://github.com/buildwithgrove/path/tree/main/e2e/morse.example.yaml).
 
+   **NOTE: If you are a Grove employee, download [Grove's Morse configuration file for PATH E2E tests](https://start.1password.com/open/i?a=4PU7ZENUCRCRTNSQWQ7PWCV2RM&v=kudw25ob4zcynmzmv2gv4qpkuq&i=2qk5qlmrduh7irgjzih3hejfxu&h=buildwithgrove.1password.com) and COPY IT OVER the `e2e/.morse.config.yaml` file.**
+
+   **⚠️ IMPORTANT: The above configuration file is sensitive and the contents of this file must never be shared outside of your organization. ⚠️**
+
 #### Running the E2E tests
 
 To run the tests, use the following `make` targets:
@@ -290,9 +294,6 @@ To run the tests, use the following `make` targets:
 ```sh
 # Run E2E tests against Morse
 make test_e2e_morse_relay
-
-# Run all tests
-make test_all
 ```
 
 ## Running Localnet


### PR DESCRIPTION
## Summary

Add details on how to get the configuration file for Morse E2E tests.

## Issue

A valid config file is needed to run Morse E2E tests, with several fields' values not readily available due to being sensitive data items.

## Type of change

Select one or more from the following:

- [ ] New feature, functionality or library
- [ ] Bug fix
- [ ] Code health or cleanup
- [x] Documentation
- [ ] Other (specify)

## Testing

- [ ] **All Tests**: `make test_all`
- [x] **Documentation**: `make docusaurus_start`; only needed if you make doc changes

## Sanity Checklist

- [x] I have tested my changes using the available tooling
- [ ] I have commented my code
- [x] I have performed a self-review of my own code; both comments & source code
- [ ] I create and reference any new tickets, if applicable
- [ ] I have left TODOs throughout the codebase, if applicable
