### PR TITLE
Fix: move COPY source to the bottom of the Dockerfile build instructions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,8 @@
 FROM golang:1.23-alpine3.19 AS builder
-RUN apk add --no-cache git
+RUN apk add --no-cache git make build-base
 
 WORKDIR /go/src/github.com/buildwithgrove/path
 COPY . .
-RUN apk add --no-cache make build-base
 RUN go build -o /go/bin/path ./cmd
 
 FROM alpine:3.19


### PR DESCRIPTION
## Summary

Optimize the E2E tests time by reducing the image build time through moving the COPY instruction to the bottom of the image building instructions.

## Issue

Reduce E2E tests runtime.

## Type of change

Select one or more from the following:

- [ ] New feature, functionality or library
- [ ] Bug fix
- [x] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## Testing

- [x] **All Tests**: `make test_all`

## Sanity Checklist

- [x] I have tested my changes using the available tooling
- [ ] I have commented my code
- [x] I have performed a self-review of my own code; both comments & source code
- [ ] I create and reference any new tickets, if applicable
- [ ] I have left TODOs throughout the codebase, if applicable
