### PR TITLE
Adding link to Discord to README.md and instructions for Technical Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,12 @@ Please visit [path.grove.city](https://path.grove.city) for documentation.
 
 The source code for the documentation is available in the `docs` directory.
 
+## Support
+
+For Bug Reports and Enhancement Requests, please open an [Issue](https://github.com/buildwithgrove/path/issues).
+
+For Technical Support please open a ticket in [Grove's Discord](https://discord.gg/build-with-grove).
+
 ---
 
 ## License

--- a/docusaurus/docs/operate/operate.md
+++ b/docusaurus/docs/operate/operate.md
@@ -8,3 +8,9 @@ title: Operator Introduction
 🚧 This documentation is still under construction 🚧
 
 :::
+
+## Operator Technical Support
+
+Should you require additional Technical Support please open a ticket in [Grove's Discord](https://discord.gg/build-with-grove).
+
+If you would like to submit a Bug Report or an Enhancement Request please create a [GitHub Issue](https://github.com/buildwithgrove/path/issues).

--- a/docusaurus/docusaurus.config.js
+++ b/docusaurus/docusaurus.config.js
@@ -118,7 +118,7 @@ const config = {
             items: [
               {
                 label: "Discord - Grove",
-                href: "https://discord.gg/uRnKAufk",
+                href: "https://discord.gg/build-with-grove",
               },
               {
                 label: "Twitter",


### PR DESCRIPTION
## Summary

This PR adds just a brief tidbit to the README.md file which instructs PATH users, when needing technical support to reach out via Discord. In addition, it adds instructions to open bug reports and/or enhancement requests to the GitHub Issues.

## Type of change

Select one or more from the following:

- [ ] New feature, functionality or library
- [ ] Bug fix
- [ ] Code health or cleanup
- [x] Documentation
- [ ] Other (specify)
