### PR TITLE
[WIP][DO NOT MERGE] feat: cache endpoints in full node in centralized mode

### DIFF
--- a/cmd/shannon.go
+++ b/cmd/shannon.go
@@ -12,8 +12,6 @@ import (
 
 // getShannonFullNode builds and returns a FullNode implementation for Shannon protocol integration, using the supplied configuration.
 func getShannonFullNode(config *shannonconfig.ShannonGatewayConfig, logger polylog.Logger) (shannon.FullNode, error) {
-	var fullNode shannon.FullNode
-
 	// LazyFullNode skips all caching and queries the onchain data for serving each relay request.
 	// It is utilized in the CachingFullNode, so must be initialized in all cases.
 	lazyFullNode, err := shannon.NewLazyFullNode(config.FullNodeConfig, logger)
@@ -27,13 +25,12 @@ func getShannonFullNode(config *shannonconfig.ShannonGatewayConfig, logger polyl
 		if err != nil {
 			return nil, fmt.Errorf("failed to create Shannon caching full node: %v", err)
 		}
-		fullNode = cachingFullNode
-	} else {
-		// All other configurations use the lazy full node with no caching.
-		fullNode = lazyFullNode
+
+		return cachingFullNode, nil
 	}
 
-	return fullNode, nil
+	// All other configurations use the lazy full node with no caching.
+	return lazyFullNode, nil
 }
 
 // getShannonProtocol returns an instance of the Shannon protocol using the supplied Shannon-specific configuration.

--- a/cmd/shannon.go
+++ b/cmd/shannon.go
@@ -5,36 +5,42 @@ import (
 
 	shannonconfig "github.com/buildwithgrove/path/config/shannon"
 	"github.com/buildwithgrove/path/gateway"
+	"github.com/buildwithgrove/path/protocol"
 	"github.com/buildwithgrove/path/protocol/shannon"
 	"github.com/pokt-network/poktroll/pkg/polylog"
 )
 
 // getShannonFullNode builds and returns a FullNode implementation for Shannon protocol integration, using the supplied configuration.
-func getShannonFullNode(config shannon.FullNodeConfig, logger polylog.Logger) (shannon.FullNode, error) {
+func getShannonFullNode(config *shannonconfig.ShannonGatewayConfig, logger polylog.Logger) (shannon.FullNode, error) {
+	var fullNode shannon.FullNode
+
 	// LazyFullNode skips all caching and queries the onchain data for serving each relay request.
-	lazyFullNode, err := shannon.NewLazyFullNode(config, logger)
+	// It is utilized in the CachingFullNode, so must be initialized in all cases.
+	lazyFullNode, err := shannon.NewLazyFullNode(config.FullNodeConfig, logger)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create Shannon lazy full node: %v", err)
 	}
 
-	if config.LazyMode {
-		return lazyFullNode, nil
+	// Only use a CachingFullNode if the gateway mode is centralized and LazyMode is disabled.
+	if config.GatewayConfig.GatewayMode == protocol.GatewayModeCentralized && !config.FullNodeConfig.LazyMode {
+		cachingFullNode, err := shannon.NewCachingFullNode(lazyFullNode, logger)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create Shannon caching full node: %v", err)
+		}
+		fullNode = cachingFullNode
+	} else {
+		// All other configurations use the lazy full node with no caching.
+		fullNode = lazyFullNode
 	}
 
-	// Use a Caching FullNode implementation if LazyMode flag is not set.
-	cachingFullNode, err := shannon.NewCachingFullNode(lazyFullNode, logger)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create Shannon caching full node: %v", err)
-	}
-
-	return cachingFullNode, nil
+	return fullNode, nil
 }
 
 // getShannonProtocol returns an instance of the Shannon protocol using the supplied Shannon-specific configuration.
 func getShannonProtocol(config *shannonconfig.ShannonGatewayConfig, logger polylog.Logger) (gateway.Protocol, error) {
 	logger.Info().Msg("Starting PATH gateway with Shannon protocol")
 
-	fullNode, err := getShannonFullNode(config.FullNodeConfig, logger)
+	fullNode, err := getShannonFullNode(config, logger)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create a Shannon full node instance: %v", err)
 	}

--- a/protocol/shannon/fullnode_cache.go
+++ b/protocol/shannon/fullnode_cache.go
@@ -121,8 +121,8 @@ func (cfn *CachingFullNode) SetPermittedAppFilter(permittedAppFilter permittedAp
 }
 
 // GetServiceEndpoints returns (from the cache) the set of endpoints which delegate to the gateway, matching the supplied service ID.
-// It is required to fulfill the FullNode interface.
-func (cfn *CachingFullNode) GetServiceEndpoints(serviceID protocol.ServiceID, req *http.Request) (map[protocol.EndpointAddr]endpoint, error) {
+// As the caching full node is only used in Centralized gateway mode, the request is ignored.
+func (cfn *CachingFullNode) GetServiceEndpoints(serviceID protocol.ServiceID, _ *http.Request) (map[protocol.EndpointAddr]endpoint, error) {
 	cfn.endpointCacheMu.RLock()
 	defer cfn.endpointCacheMu.RUnlock()
 

--- a/protocol/shannon/fullnode_cache.go
+++ b/protocol/shannon/fullnode_cache.go
@@ -3,6 +3,7 @@ package shannon
 import (
 	"errors"
 	"fmt"
+	"net/http"
 	"sync"
 	"time"
 
@@ -17,6 +18,9 @@ import (
 
 // TODO_IMPROVE: make the refresh interval configurable.
 const cacheRefreshIntervalSeconds = 60
+
+// TODO_IMPROVE: make this configurable.
+const maxSessionFetchWorkers = 100
 
 // The Shannon Relayer's FullNode interface is implemented by the CachingFullNode struct below,
 // which provides the full node capabilities required by the Shannon relayer.
@@ -40,17 +44,36 @@ type CachingFullNode struct {
 	*LazyFullNode
 	Logger polylog.Logger
 
-	appCache   map[protocol.ServiceID][]apptypes.Application
-	appCacheMu sync.RWMutex
+	gatewayMode protocol.GatewayMode
+
+	appsCache   map[protocol.ServiceID][]apptypes.Application
+	appsCacheMu sync.RWMutex
+
+	endpointCache   map[protocol.ServiceID]map[protocol.EndpointAddr]endpoint
+	endpointCacheMu sync.RWMutex
 
 	// TODO_IMPROVE: Add a sessionCacheKey type with the necessary helpers to concat a key
 	// sessionCache caches sessions for use by the Relay function.
 	// map keys are of the format "serviceID-appID"
-	sessionCache   map[string]sessiontypes.Session
+	sessionCache   map[sessionCacheKey]sessiontypes.Session
 	sessionCacheMu sync.RWMutex
 
 	// once is used to ensure the cache update go routine of the `start` method is only run once.
 	once sync.Once
+}
+
+// sessionCacheKey returns a string to be used as the key for storing the session matching the supplied service ID and application address.
+// e.g. for service with ID `svc1` and app with address `appAddress1`, the key is `svc1-appAddress1`.
+type sessionCacheKey struct {
+	serviceID protocol.ServiceID
+	appAddr   string
+}
+
+func newSessionCacheKey(serviceID protocol.ServiceID, appAddr string) sessionCacheKey {
+	return sessionCacheKey{
+		serviceID: serviceID,
+		appAddr:   appAddr,
+	}
 }
 
 // start launches a goroutine, only once per instance of CachingFullNode in order to update the cached items at a fixed interval.
@@ -70,8 +93,11 @@ func (cfn *CachingFullNode) start() error {
 			for {
 				cfn.Logger.Info().Msg("Starting the cache update process.")
 
-				cfn.updateAppCache()
+				cfn.fetchApps()
 				cfn.updateSessionCache()
+				if cfn.gatewayMode == protocol.GatewayModeCentralized {
+					cfn.updateEndpointCache()
+				}
 
 				<-ticker.C
 			}
@@ -81,18 +107,54 @@ func (cfn *CachingFullNode) start() error {
 	return nil
 }
 
-// GetServiceApps returns (from the cache) the set of onchain applications which delegate to the gateway, matching the supplied service ID.
-// It is required to fulfill the FullNode interface.
-func (cfn *CachingFullNode) GetServiceApps(serviceID protocol.ServiceID) ([]apptypes.Application, error) {
-	cfn.appCacheMu.RLock()
-	defer cfn.appCacheMu.RUnlock()
+// SetPermittedAppFilter sets the permitted app filter for the protocol instance.
+func (cfn *CachingFullNode) SetPermittedAppFilter(permittedAppFilter permittedAppFilter, gatewayMode protocol.GatewayMode) {
+	cfn.gatewayMode = gatewayMode
+	cfn.LazyFullNode.SetPermittedAppFilter(permittedAppFilter, gatewayMode)
+}
 
-	apps, found := cfn.appCache[serviceID]
-	if !found {
-		return nil, fmt.Errorf("getServiceApps: no apps found for service %s", serviceID)
+// GetServiceEndpoints returns (from the cache) the set of endpoints which delegate to the gateway, matching the supplied service ID.
+// It is required to fulfill the FullNode interface.
+func (cfn *CachingFullNode) GetServiceEndpoints(serviceID protocol.ServiceID, req *http.Request) (map[protocol.EndpointAddr]endpoint, error) {
+	cfn.endpointCacheMu.RLock()
+	defer cfn.endpointCacheMu.RUnlock()
+
+	endpoints, err := cfn.getPermittedApps(serviceID, req)
+	if err != nil {
+		return nil, err
 	}
 
-	return apps, nil
+	return endpoints, nil
+}
+
+func (cfn *CachingFullNode) getPermittedApps(serviceID protocol.ServiceID, req *http.Request) (map[protocol.EndpointAddr]endpoint, error) {
+	endpoints := make(map[protocol.EndpointAddr]endpoint)
+
+	switch cfn.gatewayMode {
+	case protocol.GatewayModeCentralized:
+		cachedEndpoints, found := cfn.endpointCache[serviceID]
+		if !found {
+			return nil, fmt.Errorf("getServiceEndpoints: no endpoints found for service %s", serviceID)
+		}
+
+		endpoints = cachedEndpoints
+
+	case protocol.GatewayModeDelegated:
+		cfn.appsCacheMu.RLock()
+		apps := cfn.appsCache[serviceID]
+		cfn.appsCacheMu.RUnlock()
+
+		permittedApps := cfn.filterPermittedApps(apps, req)
+
+		filteredEndpoints, err := cfn.getAppsUniqueEndpoints(serviceID, permittedApps)
+		if err != nil {
+			return nil, fmt.Errorf("getServiceEndpoints: error getting the unique endpoints for service %s: %w", serviceID, err)
+		}
+
+		endpoints = filteredEndpoints
+	}
+
+	return endpoints, nil
 }
 
 // GetSession returns the cached session matching (serviceID, appAddr) combination.
@@ -101,7 +163,7 @@ func (cfn *CachingFullNode) GetSession(serviceID protocol.ServiceID, appAddr str
 	cfn.sessionCacheMu.RLock()
 	defer cfn.sessionCacheMu.RUnlock()
 
-	session, found := cfn.sessionCache[sessionCacheKey(serviceID, appAddr)]
+	session, found := cfn.sessionCache[newSessionCacheKey(serviceID, appAddr)]
 	if !found {
 		return session, fmt.Errorf("getSession: no cached sessions found for service %s, app %s", serviceID, appAddr)
 	}
@@ -119,25 +181,61 @@ func (cfn *CachingFullNode) ValidateRelayResponse(supplierAddr sdk.SupplierAddre
 // IsHealthy indicates the health status of the caching full node.
 // It is required to fulfill the health.Check interface.
 func (cfn *CachingFullNode) IsHealthy() bool {
-	cfn.appCacheMu.RLock()
-	defer cfn.appCacheMu.RUnlock()
+	cfn.endpointCacheMu.RLock()
+	defer cfn.endpointCacheMu.RUnlock()
 	cfn.sessionCacheMu.RLock()
 	defer cfn.sessionCacheMu.RUnlock()
 
-	return len(cfn.appCache) > 0 && len(cfn.sessionCache) > 0
+	return len(cfn.endpointCache) > 0 && len(cfn.sessionCache) > 0
 }
 
-func (cfn *CachingFullNode) updateAppCache() {
+/* ------------------------------- 1. Fetch and Cache Onchain Apps Data ------------------------------- */
+
+// fetchApps fetches the all apps for all services and filters them using the gateway mode's permittedAppFilter.
+func (cfn *CachingFullNode) fetchApps() {
 	appData, err := cfn.LazyFullNode.GetAllServicesApps()
 	if err != nil {
 		cfn.Logger.Warn().Err(err).Msg("updateAppCache: error getting the list of apps; skipping update.")
 		return
 	}
 
-	cfn.appCacheMu.Lock()
-	defer cfn.appCacheMu.Unlock()
-	cfn.appCache = appData
+	// In centralized mode, we know the delegated apps for the gateway operator,
+	// so we can filter out all apps that are not delegated to the gateway.
+	if cfn.gatewayMode == protocol.GatewayModeCentralized {
+		filteredAppsData := make(map[protocol.ServiceID][]apptypes.Application)
+
+		for serviceID, apps := range appData {
+			filteredAppsData[serviceID] = cfn.filterPermittedApps(apps, nil)
+		}
+
+		appData = filteredAppsData
+	}
+
+	cfn.appsCacheMu.Lock()
+	defer cfn.appsCacheMu.Unlock()
+	cfn.appsCache = appData
 }
+
+func (cfn *CachingFullNode) filterPermittedApps(apps []apptypes.Application, req *http.Request) []apptypes.Application {
+	var filteredApps []apptypes.Application
+
+	// The permittedAppFilter is used to filter only apps that are allowed by the gateway mode.
+	// - In Centralized mode, the permittedAppFilter is used to filter only apps that are owned by the gateway operator.
+	// -
+	for _, app := range apps {
+		if errSelectingApp := cfn.LazyFullNode.permittedAppFilter(&app, req); errSelectingApp != nil {
+			cfn.logger.Info().Err(errSelectingApp).Str("app_address", app.Address).
+				Msg("fetchApps: app filter rejected the app: skipping the app")
+			continue
+		}
+
+		filteredApps = append(filteredApps, app)
+	}
+
+	return filteredApps
+}
+
+/* ------------------------------- 2. Fetch and Cache Sessions ------------------------------- */
 
 func (cfn *CachingFullNode) updateSessionCache() {
 	sessions := cfn.fetchSessions()
@@ -151,39 +249,126 @@ func (cfn *CachingFullNode) updateSessionCache() {
 	cfn.sessionCache = sessions
 }
 
-func (cfn *CachingFullNode) fetchSessions() map[string]sessiontypes.Session {
-	logger := cfn.Logger.With("method", "fetchSessions")
+func (cfn *CachingFullNode) fetchSessions() map[sessionCacheKey]sessiontypes.Session {
+	cfn.appsCacheMu.RLock()
+	appsData := cfn.appsCache
+	cfn.appsCacheMu.RUnlock()
 
-	apps, err := cfn.LazyFullNode.GetAllServicesApps()
-	if err != nil {
-		logger.Warn().Err(err).Msg("fetchSession: error listing applications")
+	if len(appsData) == 0 {
+		return nil
 	}
 
-	sessions := make(map[string]sessiontypes.Session)
-	// TODO_TECHDEBT: use multiple go routines.
-	for serviceID, serviceApps := range apps {
-		for _, app := range serviceApps {
-			logger := logger.With(
-				"service", string(serviceID),
-				"address", app.Address,
-			)
+	sessions := make(map[sessionCacheKey]sessiontypes.Session)
+	var sessionsMu sync.Mutex // Mutex to protect the sessions map
 
-			session, err := cfn.LazyFullNode.GetSession(serviceID, string(app.Address))
-			if err != nil {
-				logger.Warn().Err(err).Msg("could not get a session")
-				continue
+	jobs := make(chan sessionCacheKey, len(appsData))
+
+	var wg sync.WaitGroup
+
+	// Start worker pool
+	for i := 0; i < maxSessionFetchWorkers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for job := range jobs {
+				logger := cfn.Logger.With(
+					"service", string(job.serviceID),
+					"address", job.appAddr,
+				)
+
+				session, err := cfn.LazyFullNode.GetSession(job.serviceID, job.appAddr)
+				if err != nil {
+					logger.Warn().Err(err).Msg("could not get a session")
+					continue
+				}
+
+				sessionsMu.Lock()
+				sessions[newSessionCacheKey(job.serviceID, job.appAddr)] = session
+				sessionsMu.Unlock()
+
+				logger.Info().Msg("fetchSessions: successfully fetched the session for service and app combination.")
 			}
+		}()
+	}
 
-			sessions[sessionCacheKey(serviceID, app.Address)] = session
-			logger.Info().Msg("successfully fetched the session for service and app combination.")
+	// Send jobs to the workers
+	for serviceID, serviceApps := range appsData {
+		for _, app := range serviceApps {
+			jobs <- sessionCacheKey{
+				serviceID: serviceID,
+				appAddr:   app.Address,
+			}
 		}
 	}
+	close(jobs)
+
+	wg.Wait()
 
 	return sessions
 }
 
-// sessionCacheKey returns a string to be used as the key for storing the session matching the supplied service ID and application address.
-// e.g. for service with ID `svc1` and app with address `appAddress1`, the key is `svc1-appAddress1`.
-func sessionCacheKey(serviceID protocol.ServiceID, appAddr string) string {
-	return fmt.Sprintf("%s-%s", string(serviceID), appAddr)
+/* ------------------------------- 3. Update Endpoint Cache ------------------------------- */
+
+// updateEndpointCache updates the endpoint cache by fetching the sessions for all apps and then
+// using the getAppsUniqueEndpoints method to get the unique endpoints for each service ID.
+func (cfn *CachingFullNode) updateEndpointCache() {
+	cfn.appsCacheMu.RLock()
+	appsData := cfn.appsCache
+	cfn.appsCacheMu.RUnlock()
+
+	if len(appsData) == 0 {
+		cfn.Logger.Warn().Msg("updateEndpointCache: received empty app list; skipping update.")
+		return
+	}
+
+	endpointData := make(map[protocol.ServiceID]map[protocol.EndpointAddr]endpoint)
+
+	for serviceID, apps := range appsData {
+		endpointsForService, err := cfn.getAppsUniqueEndpoints(serviceID, apps)
+		if err != nil {
+			continue
+		}
+
+		endpointData[serviceID] = endpointsForService
+	}
+
+	cfn.endpointCacheMu.Lock()
+	defer cfn.endpointCacheMu.Unlock()
+	cfn.endpointCache = endpointData
+}
+
+// TODO_FUTURE(@adshmh): Find a more optimized way of handling an overlap among endpoints
+// matching multiple sessions of apps delegating to the gateway.
+//
+// getAppsUniqueEndpoints returns a map of all endpoints which match the provided service ID and pass the supplied app filter.
+// If an endpoint matches a service ID through multiple apps/sessions, only a single entry
+// matching one of the apps/sessions is returned.
+func (cfn *CachingFullNode) getAppsUniqueEndpoints(serviceID protocol.ServiceID, apps []apptypes.Application) (map[protocol.EndpointAddr]endpoint, error) {
+	cfn.sessionCacheMu.RLock()
+	sessions := cfn.sessionCache
+	cfn.sessionCacheMu.RUnlock()
+
+	endpoints := make(map[protocol.EndpointAddr]endpoint)
+
+	for _, app := range apps {
+		session, found := sessions[newSessionCacheKey(serviceID, app.Address)]
+		if !found {
+			return nil, fmt.Errorf("getAppsUniqueEndpoints: could not get the session for service %s app %s", serviceID, app.Address)
+		}
+
+		appEndpoints, err := endpointsFromSession(session)
+		if err != nil {
+			return nil, fmt.Errorf("getAppsUniqueEndpoints: error getting all endpoints for app %s session %s: %w", app.Address, session.SessionId, err)
+		}
+
+		for endpointAddr, endpoint := range appEndpoints {
+			endpoints[endpointAddr] = endpoint
+		}
+	}
+
+	if len(endpoints) == 0 {
+		return nil, fmt.Errorf("getAppsUniqueEndpoints: no endpoints found for service %s", serviceID)
+	}
+
+	return endpoints, nil
 }

--- a/protocol/shannon/fullnode_lazy.go
+++ b/protocol/shannon/fullnode_lazy.go
@@ -82,8 +82,8 @@ type LazyFullNode struct {
 	logger polylog.Logger
 }
 
-// SetPermittedAppFilter sets the permitted app filter for the protocol instance.
-func (lfn *LazyFullNode) SetPermittedAppFilter(permittedAppFilter permittedAppFilter, _ protocol.GatewayMode) {
+// SetGatewayMode sets the permitted app filter for the protocol instance.
+func (lfn *LazyFullNode) SetGatewayMode(_ protocol.GatewayMode, permittedAppFilter permittedAppFilter) {
 	lfn.permittedAppFilter = permittedAppFilter
 }
 
@@ -111,6 +111,7 @@ func (lfn *LazyFullNode) GetServiceEndpoints(serviceID protocol.ServiceID, req *
 }
 
 func (lfn *LazyFullNode) GetAllServicesApps() (map[protocol.ServiceID][]apptypes.Application, error) {
+	// A nil request is passed to getAllApps to fetch all apps, which prevents them from being filtered by the permittedAppFilter.
 	allApps, err := lfn.getAllApps(context.TODO(), nil)
 	if err != nil {
 		return nil, err

--- a/protocol/shannon/fullnode_lazy.go
+++ b/protocol/shannon/fullnode_lazy.go
@@ -72,14 +72,15 @@ func NewLazyFullNode(config FullNodeConfig, logger polylog.Logger) (*LazyFullNod
 //   - This allows supporting short block times (e.g. LocalNet)
 //   - CachingFullNode struct can be used instead if caching is desired for performance reasons
 type LazyFullNode struct {
+	logger polylog.Logger
+
 	appClient     *sdk.ApplicationClient
 	sessionClient *sdk.SessionClient
 	blockClient   *sdk.BlockClient
 	accountClient *sdk.AccountClient
 
+	// permittedAppFilter is used to filter the apps that are permitted to send relays.
 	permittedAppFilter permittedAppFilter
-
-	logger polylog.Logger
 }
 
 // SetPermittedAppFilter sets the permitted app filter for the protocol instance.

--- a/protocol/shannon/gateway_mode.go
+++ b/protocol/shannon/gateway_mode.go
@@ -27,19 +27,17 @@ func (p *Protocol) SupportedGatewayModes() []protocol.GatewayMode {
 //
 // permittedAppFilter represents any function that can be used to filter an onchain app based on its attributes.
 // It is used by different gateway modes to select app(s) that are permitted for use by the gateway for sending relay requests.
-type permittedAppFilter func(*apptypes.Application) error
+type permittedAppFilter func(*apptypes.Application, *http.Request) error
 
 // getGatewayModePermittedAppFilter returns the app filter matching the supplied gateway mode.
 // As of now, the HTTP request that initiates a relay request can also be used to adjust the app filter, e.g. in the Delegated gateway mode.
-func (p *Protocol) getGatewayModePermittedAppFilter(
-	gatewayMode protocol.GatewayMode,
-	req *http.Request,
+func (p *Protocol) getGatewayModePermittedAppFilter(gatewayMode protocol.GatewayMode,
 ) (permittedAppFilter, error) {
 	switch gatewayMode {
 	case protocol.GatewayModeCentralized:
 		return getCentralizedGatewayModeAppFilter(p.gatewayAddr, p.ownedAppsAddr), nil
 	case protocol.GatewayModeDelegated:
-		return getDelegatedGatewayModeAppFilter(p.gatewayAddr, req), nil
+		return getDelegatedGatewayModeAppFilter(p.gatewayAddr), nil
 	// TODO_MVP(@adshmh): Uncomment the following code section once support for Permissionless Gateway mode is added to the shannon package.
 	//case protocol.GatewayModePermissionless:
 	//	return getPermissionlessGatewayModeAppFilter(p.ownedAppsAddr), nil

--- a/protocol/shannon/mode_centralized.go
+++ b/protocol/shannon/mode_centralized.go
@@ -44,11 +44,11 @@ func getCentralizedModeOwnedAppsAddr(ownedAppsPrivateKeysHex []string) ([]string
 func getCentralizedGatewayModeAppFilter(gatewayAddr string, ownedAppsAddr map[string]struct{}) permittedAppFilter {
 	return func(app *apptypes.Application, _ *http.Request) error {
 		if _, found := ownedAppsAddr[app.Address]; !found {
-			return fmt.Errorf("Centralized GatewayMode: app with address %s is not owned by the gateway", app.Address)
+			return fmt.Errorf("centralized GatewayMode: app with address %s is not owned by the gateway", app.Address)
 		}
 
 		if !gatewayHasDelegationForApp(gatewayAddr, app) {
-			return fmt.Errorf("Centralized GatewayMode: app with address %s does not delegate to gateway address: %s", app.Address, gatewayAddr)
+			return fmt.Errorf("centralized GatewayMode: app with address %s does not delegate to gateway address: %s", app.Address, gatewayAddr)
 		}
 
 		return nil

--- a/protocol/shannon/mode_centralized.go
+++ b/protocol/shannon/mode_centralized.go
@@ -2,6 +2,7 @@ package shannon
 
 import (
 	"fmt"
+	"net/http"
 
 	apptypes "github.com/pokt-network/poktroll/x/application/types"
 
@@ -41,7 +42,7 @@ func getCentralizedModeOwnedAppsAddr(ownedAppsPrivateKeysHex []string) ([]string
 
 // getCentralizedGatewayModeAppFilter returns a permittedAppsFilter for the Centralized gateway mode.
 func getCentralizedGatewayModeAppFilter(gatewayAddr string, ownedAppsAddr map[string]struct{}) permittedAppFilter {
-	return func(app *apptypes.Application) error {
+	return func(app *apptypes.Application, _ *http.Request) error {
 		if _, found := ownedAppsAddr[app.Address]; !found {
 			return fmt.Errorf("Centralized GatewayMode: app with address %s is not owned by the gateway", app.Address)
 		}

--- a/protocol/shannon/mode_delegated.go
+++ b/protocol/shannon/mode_delegated.go
@@ -19,13 +19,12 @@ const (
 	// TODO_DOCUMENT(@adshmh): Update the docs at https://path.grove.city/ to reflect this usage pattern.
 	// headerAppAddress is the key of the entry in HTTP headers that holds the target app's address in delegated mode.
 	// The target app will be used for sending the relay request.
-	// TODO_TECHDEBT(@commoddity): remove deprecated `x-` prefix from the header name.
-	headerAppAddr = "X-App-Address"
+	headerAppAddr = "app-address"
 )
 
 // getDelegatedGatewayModeAppFilter returns a permittedAppsFilter for the Delegated gateway mode.
-func getDelegatedGatewayModeAppFilter(gatewayAddr string, req *http.Request) permittedAppFilter {
-	return func(app *apptypes.Application) error {
+func getDelegatedGatewayModeAppFilter(gatewayAddr string) permittedAppFilter {
+	return func(app *apptypes.Application, req *http.Request) error {
 		selectedAppAddr, err := getAppAddrFromHTTPReq(req)
 		if err != nil {
 			return fmt.Errorf("Delegated GatewayMode: error getting the selected app from the HTTP request: %w", err)

--- a/protocol/shannon/mode_delegated.go
+++ b/protocol/shannon/mode_delegated.go
@@ -27,15 +27,15 @@ func getDelegatedGatewayModeAppFilter(gatewayAddr string) permittedAppFilter {
 	return func(app *apptypes.Application, req *http.Request) error {
 		selectedAppAddr, err := getAppAddrFromHTTPReq(req)
 		if err != nil {
-			return fmt.Errorf("Delegated GatewayMode: error getting the selected app from the HTTP request: %w", err)
+			return fmt.Errorf("delegated GatewayMode: error getting the selected app from the HTTP request: %w", err)
 		}
 
 		if app.Address != selectedAppAddr {
-			return fmt.Errorf("Delegated GatewayMode: app with address %s does not match the selected app address: %s", app.Address, selectedAppAddr)
+			return fmt.Errorf("delegated GatewayMode: app with address %s does not match the selected app address: %s", app.Address, selectedAppAddr)
 		}
 
 		if !gatewayHasDelegationForApp(gatewayAddr, app) {
-			return fmt.Errorf("Delegated GatewayMode: app with address %s does not delegate to gateway address: %s", app.Address, gatewayAddr)
+			return fmt.Errorf("delegated GatewayMode: app with address %s does not delegate to gateway address: %s", app.Address, gatewayAddr)
 		}
 
 		return nil
@@ -45,7 +45,7 @@ func getDelegatedGatewayModeAppFilter(gatewayAddr string) permittedAppFilter {
 // getAppAddrFromHTTPReq extracts the application address specified by the supplied HTTP request's headers.
 func getAppAddrFromHTTPReq(httpReq *http.Request) (string, error) {
 	if httpReq == nil || len(httpReq.Header) == 0 {
-		return "", fmt.Errorf("getAppAddrFromHTTPReq: no HTTP headers supplied.")
+		return "", fmt.Errorf("getAppAddrFromHTTPReq: no HTTP headers supplied")
 	}
 
 	selectedAppAddr := httpReq.Header.Get(headerAppAddr)

--- a/protocol/shannon/protocol.go
+++ b/protocol/shannon/protocol.go
@@ -40,8 +40,8 @@ type FullNode interface {
 	// GetAccountClient returns the account client from the fullnode, to be used in building relay request signers.
 	GetAccountClient() *sdk.AccountClient
 
-	// SetPermittedAppFilter sets the permitted app filter for the protocol instance.
-	SetPermittedAppFilter(permittedAppFilter permittedAppFilter, gatewayMode protocol.GatewayMode)
+	// SetGatewayMode sets the permitted app filter for the protocol instance.
+	SetGatewayMode(gatewayMode protocol.GatewayMode, permittedAppFilter permittedAppFilter)
 }
 
 // NewProtocol instantiates an instance of the Shannon protocol integration.
@@ -81,7 +81,7 @@ func NewProtocol(
 		return nil, fmt.Errorf("NewProtocol: error building the permitted apps filter for gateway mode %s: %w", protocol.gatewayMode, err)
 	}
 
-	fullNode.SetPermittedAppFilter(permittedAppFilter, protocol.gatewayMode)
+	fullNode.SetGatewayMode(protocol.gatewayMode, permittedAppFilter)
 
 	return protocol, nil
 }

--- a/protocol/shannon/protocol.go
+++ b/protocol/shannon/protocol.go
@@ -88,8 +88,9 @@ func NewProtocol(
 
 // Protocol provides the functionality needed by the gateway package for sending a relay to a specific endpoint.
 type Protocol struct {
-	FullNode
 	Logger polylog.Logger
+
+	FullNode
 
 	// gatewayMode is the gateway mode in which the current instance of the Shannon protocol integration operates.
 	// See protocol/shannon/gateway_mode.go for more details.

--- a/protocol/shannon/protocol.go
+++ b/protocol/shannon/protocol.go
@@ -40,8 +40,8 @@ type FullNode interface {
 	// GetAccountClient returns the account client from the fullnode, to be used in building relay request signers.
 	GetAccountClient() *sdk.AccountClient
 
-	// SetGatewayMode sets the permitted app filter for the protocol instance.
-	SetGatewayMode(gatewayMode protocol.GatewayMode, permittedAppFilter permittedAppFilter)
+	// SetPermittedAppFilter sets the permitted app filter for the protocol instance.
+	SetPermittedAppFilter(permittedAppFilter permittedAppFilter)
 }
 
 // NewProtocol instantiates an instance of the Shannon protocol integration.
@@ -81,7 +81,7 @@ func NewProtocol(
 		return nil, fmt.Errorf("NewProtocol: error building the permitted apps filter for gateway mode %s: %w", protocol.gatewayMode, err)
 	}
 
-	fullNode.SetGatewayMode(protocol.gatewayMode, permittedAppFilter)
+	fullNode.SetPermittedAppFilter(permittedAppFilter)
 
 	return protocol, nil
 }


### PR DESCRIPTION

## Summary

This is a Work in Progress PR to potentially reduce the issue of excessive processing happening pre-request.

It attempts to solve the issue by moving the derivation of which endpoints are present for the apps delegated to a gateway into the full node, which caches them as part of its data fetching iteration.

## Issue

Based on the conversation on Discord thread: 
https://discord.com/channels/824324475256438814/1316109400917934201/1329577115854569472

## Type of change

Select one or more from the following:

- [ ] New feature, functionality or library
- [ ] Bug fix
- [ ] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## Testing

<!-- READ & DELETE:
- Documentation changes: only keep this if you're making documentation changes
- Testing: Remove this if you didn't make code changes
  - See the quickstart guide for additional instructions: https://path.grove.city
-->

- [ ] **All Tests**: `make test_all`
- [ ] **Documentation**: `make docusaurus_start`; only needed if you make doc changes

## Sanity Checklist

- [ ] I have tested my changes using the available tooling
- [ ] I have commented my code
- [ ] I have performed a self-review of my own code; both comments & source code
- [ ] I create and reference any new tickets, if applicable
- [ ] I have left TODOs throughout the codebase, if applicable
