### PR TITLE
[Workflows] Update GitHub actions from v3 to v4

### DIFF
--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -36,7 +36,7 @@ jobs:
             type=ref,event=branch,pattern=latest
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v4
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -15,7 +15,7 @@ jobs:
     if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     steps:
       - name: Checkout project
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
@@ -36,7 +36,7 @@ jobs:
             type=ref,event=branch,pattern=latest
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/upload-pages-artifact.yml
+++ b/.github/workflows/upload-pages-artifact.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
@@ -48,7 +48,7 @@ jobs:
       pages: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/upload-pages-artifact.yml
+++ b/.github/workflows/upload-pages-artifact.yml
@@ -68,15 +68,15 @@ jobs:
           yarn build
 
       - name: Setup Pages
-        uses: actions/configure-pages@v4
+        uses: actions/configure-pages@v5
         with:
           enablement: true
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v2
+        uses: actions/upload-pages-artifact@v3
         with:
           path: docusaurus/build
 
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary

Upgrade github ations from `v3` to `v4`.

## Issue

### Origin Document

https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/
<img width="1006" alt="Screenshot 2025-01-23 at 2 32 22 PM" src="https://github.com/user-attachments/assets/bcf75024-c2bb-4c2c-b38f-90d2d864af2a" />

### Example in action

<img width="1678" alt="Screenshot 2025-01-23 at 2 32 40 PM" src="https://github.com/user-attachments/assets/a0fddefd-71df-49f0-aa53-1ecb827e85af" />

https://github.com/buildwithgrove/path/actions/runs/12935368023/job/36078630477