### PR TITLE
[Docs] Adding diagrams to main page of path.grove.city

### DIFF
--- a/docusaurus/docs/README.md
+++ b/docusaurus/docs/README.md
@@ -30,3 +30,86 @@ to learn how PATH works, how to configure it and how to run it locally.
 
 Start by going through the [Envoy Walkthrough](./develop/envoy/walkthrough.md).
 to learn how our Envoy integration works, how to configure it and how to run it locally.
+
+## Is PATH for me?
+
+If you're a Web2 Gateway Provider, you have four modes of operation to choose from:
+
+1. **Step aside (N/A)**: Let clients use [Grove's Portal](https://portal.grove.city/) directly. For example, if you do not provide the services the client is looking for.
+
+2. **Hybrid (Frontline)**: Provide a front-end using your custom stack but leverage [Grove's Portal API](https://docs.grove.city/) behind the scenes. For example, if you want to provide a custom front-end but leverage Grove's infrastructure.
+
+3. **Full Stack (Direct):** Use `PATH` so you can provide the client with a custom experience but also settle traffic on `Pocket Network` yourself without relying on Grove's infrastructure.
+
+4. **Independent (N/A):** Use your own stack to settle traffic on your own infrastructure, independent of `Grove`, `PATH` or `Pocket Network`.
+
+Here's the information reorganized into a table and nodes section:
+
+```mermaid
+%%{init: {'flowchart': {'curve': 'basis', 'lineWidth': 2}, 'themeVariables': {'fontFamily': 'arial', 'nodeTextColor': '#000000', 'edgeTextColor': '#000000'}}}%%
+
+flowchart LR
+    Mobile((📱))
+
+    subgraph Routes
+        Grove1["To Pocket Network <br> Through Grove 🌿 <br> Using PATH"]
+        Grove2["To Pocket Network <br> Through Web2 Gateway <br> Via Grove 🌿"]
+        Grove3["To Pocket Network <br> Through Web2 Gateway <br> Using PATH"]
+        Gateway["To Web2 Gateway's Servers <br> Through Web2 Gateway <br> Using Gateway's Stack"]
+    end
+
+    subgraph PubSrv["Public Servers"]
+        Server1[(Public Server 1)]
+        Server2[(Public Server 2)]
+    end
+
+    subgraph PrivSrv["Private Servers"]
+        PServer1[(Private Server 1)]
+        PServer2[(Private Server 2)]
+    end
+
+    PubLabel["Pocket Network <br> - Shared <br> - Permissionless <br> - Incentivized <br> - Open Source Providers"]
+    PrivLabel["Web2 Gateway Servers <br> -Private <br> - Dedicated <br> - Solely owned"]
+
+    Mobile ---> | 1 | Grove1
+    Mobile ---> | 2 | Grove2
+    Mobile ---> | 3 | Grove3
+    Mobile ---> | 4 | Gateway
+
+    Grove1 --> Server1
+    Grove1 --> Server2
+
+    Grove2 -.-> Grove1
+
+    Grove3 ---> Server1
+    Grove3 ---> Server2
+
+    Gateway ---> PServer1
+    Gateway ---> PServer2
+
+
+    %% Label connections
+    PubSrv -.- PubLabel
+    PrivSrv -.- PrivLabel
+
+    %% Styling
+    classDef publicServers fill:#3D9970,stroke:#333,stroke-width:2px,color:#000000
+    classDef privateServers fill:#E67E22,stroke:#333,stroke-width:2px,color:#000000
+    classDef groveRoute fill:#E8F5E9,stroke:#333,stroke-width:2px,color:#000000
+    classDef web2Route fill:#FFEBEE,stroke:#333,stroke-width:2px,color:#000000
+    classDef labelStyle fill:none,stroke:none
+    class Server1,Server2 publicServers
+    class PServer1,PServer2 privateServers
+    class Grove1,Grove2 groveRoute
+    class Grove3,Gateway web2Route
+    class PubLabel,PrivLabel labelStyle
+```
+
+### Implementation Modes
+
+| Mode                   | Your Infrastructure | Your Gateway | Your Frontend | PATH | Grove | Pocket Network | Description                                                     |
+| ---------------------- | ------------------- | ------------ | ------------- | ---- | ----- | -------------- | --------------------------------------------------------------- |
+| 1. Step Aside (N/A)    | ❌                  | ❌           | ❌            | ❌   | ✅    | ✅             | Provider directs clients to Grove's Portal for direct access    |
+| 2. Hybrid (Frontline)  | ❌                  | ❌           | ✅            | ❌   | ✅    | ✅             | Provider uses custom frontend with Grove's Portal API backend   |
+| 3. Full Stack (Direct) | ✅                  | ✅           | ✅            | ✅   | ❌    | ✅             | Provider uses PATH to settle traffic directly on Pocket Network |
+| 4. Independent (N/A)   | ✅                  | ✅           | ✅            | ❌   | ❌    | ❌             | Provider uses entirely their own infrastructure and stack       |

--- a/docusaurus/docs/README.md
+++ b/docusaurus/docs/README.md
@@ -35,13 +35,13 @@ to learn how our Envoy integration works, how to configure it and how to run it 
 
 If you're a Web2 Gateway Provider, you have four modes of operation to choose from:
 
-1. **Step aside (N/A)**: Let clients use [Grove's Portal](https://portal.grove.city/) directly. For example, if you do not provide the services the client is looking for.
+1. **Dependent (Step Aside)**: Let clients use [Grove's Portal](https://portal.grove.city/) directly. For example, if you do not provide the services the customer is looking for.
 
-2. **Hybrid (Frontline)**: Provide a front-end using your custom stack but leverage [Grove's Portal API](https://docs.grove.city/) behind the scenes. For example, if you want to provide a custom front-end but leverage Grove's infrastructure.
+2. **Grove Hybrid (Frontend)**: Provide a custom front-end experience and build your own gateway infrastructure but leverage [Grove's Portal API](https://docs.grove.city/) behind the **scenes**. For example, if you want want to build your own business logic around quality-of-service, load balancing, authentication as well as building your own front-end.
 
-3. **Full Stack (Direct):** Use `PATH` so you can provide the client with a custom experience but also settle traffic on `Pocket Network` yourself without relying on Grove's infrastructure.
+3. **PATH Hybrid (Full Stack):** Use `PATH` so you can provide the client with a customized end-to-end experience but also settle traffic on `Pocket Network` yourself without relying on `Grove`'s infrastructure at all.
 
-4. **Independent (N/A):** Use your own stack to settle traffic on your own infrastructure, independent of `Grove`, `PATH` or `Pocket Network`.
+4. **Independent (On Your Own):** Use your own stack to settle traffic on your own infrastructure, independent of `Grove`, `PATH` or `Pocket Network`.
 
 Here's the information reorganized into a table and nodes section:
 
@@ -71,10 +71,10 @@ flowchart LR
     PubLabel["Pocket Network <br> - Shared <br> - Permissionless <br> - Incentivized <br> - Open Source Providers"]
     PrivLabel["Web2 Gateway Servers <br> -Private <br> - Dedicated <br> - Solely owned"]
 
-    Mobile ---> | 1 | Grove1
-    Mobile ---> | 2 | Grove2
-    Mobile ---> | 3 | Grove3
-    Mobile ---> | 4 | Gateway
+    Mobile ---> | 1\. Dependent | Grove1
+    Mobile ---> | 2\. Grove Hybrid| Grove2
+    Mobile ---> | 3\. PATH Hybrid | Grove3
+    Mobile ---> | 4\. Independent | Gateway
 
     Grove1 --> Server1
     Grove1 --> Server2
@@ -105,11 +105,13 @@ flowchart LR
     class PubLabel,PrivLabel labelStyle
 ```
 
-### Implementation Modes
+### Implementation Mode Comparison
 
-| Mode                   | Your Infrastructure | Your Gateway | Your Frontend | PATH | Grove | Pocket Network | Description                                                     |
-| ---------------------- | ------------------- | ------------ | ------------- | ---- | ----- | -------------- | --------------------------------------------------------------- |
-| 1. Step Aside (N/A)    | ❌                  | ❌           | ❌            | ❌   | ✅    | ✅             | Provider directs clients to Grove's Portal for direct access    |
-| 2. Hybrid (Frontline)  | ❌                  | ❌           | ✅            | ❌   | ✅    | ✅             | Provider uses custom frontend with Grove's Portal API backend   |
-| 3. Full Stack (Direct) | ✅                  | ✅           | ✅            | ✅   | ❌    | ✅             | Provider uses PATH to settle traffic directly on Pocket Network |
-| 4. Independent (N/A)   | ✅                  | ✅           | ✅            | ❌   | ❌    | ❌             | Provider uses entirely their own infrastructure and stack       |
+If you're a Web2 Gateway Provider, you can use this table to understand you preferable mode of operation:
+
+| Mode                         | Your Backend Infrastructure | Your Gateway Frontend | Your Gateway uses PATH | Customer uses Grove's Portal | Traffic Settled on Pocket Network | Description / Example                                                                                                         |
+| ---------------------------- | --------------------------- | --------------------- | ---------------------- | ---------------------------- | --------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| 1. Dependent (Step Aside)    | ❌                          | ❌                    | ❌                     | ✅                           | ✅                                | Customers go to Grove's Portal for direct access                                                                              |
+| 2. Grove Hybrid (Frontend)   | ❌                          | ✅                    | ❌                     | ❌                           | ✅                                | Customers go to your frontend but use Grove's Portal API backend behind the scenes                                            |
+| 3. PATH Hybrid (Full Stack)  | ❌                          | ✅                    | ✅                     | ❌                           | ✅                                | Customers go to your frontend but use PATH's features (e.g. Quality-of Service) and settle traffic on Pocket network directly |
+| 4. Independent (On Your Own) | ✅                          | ✅                    | ✅                     | ❌                           | ❌                                | Customers go to your frontend and dependent on your gateway and infrastructure across the whole stack                         |


### PR DESCRIPTION
> [!IMPORTANT]  
> Note to reviewer
> @Olshansk  is still iterating on the naming. Looking for feedback ons structure, naming and visuals for now. **This is an iteration, not the final product.**

## Summary

Adding the following section (per feedback from Alchemy) to make it a bit easier to start understanding who/why should use `PATH`.

<img width="926" alt="Screenshot 2025-01-28 at 12 01 09 AM" src="https://github.com/user-attachments/assets/c93562c6-cd47-46f2-ab45-c07c79c43eef" />


## Type of change

Select one or more from the following:

- [ ] New feature, functionality or library
- [ ] Bug fix
- [ ] Code health or cleanup
- [x] Documentation
- [ ] Other (specify)

## Sanity Checklist

- [ ] I have updated the GitHub Issue `assignees`, `reviewers`, `labels`, `project`, `iteration` and `milestone`
- [ ] For docs, I have run `make docusaurus_start`
- [ ] For code, I have run `make test_all`
- [ ] For configurations, I have update the documentation
- [ ] I added TODOs where applicable
