### PR TITLE
[docs] fix typo in PATH config

### DIFF
--- a/docusaurus/docs/develop/path/path_config.md
+++ b/docusaurus/docs/develop/path/path_config.md
@@ -105,7 +105,7 @@ morse_config:
       application_public_key: "<64-char-hex>" # Application public key
       application_signature: "<128-char-hex>" # Application signature
 
-# (Required) Morse Protocol Configuration
+# (Required) Shannon Protocol Configuration
 shannon_config:
   full_node_config:
     rpc_url: https://shannon-testnet-grove-rpc.beta.poktroll.com


### PR DESCRIPTION
## Summary

This PR aims to fix a small typo in the Path Config documentation.

## Issue

- Description: Fix typo in PATH config

## Type of change

Select one or more from the following:

- [ ] New feature, functionality or library
- [ ] Bug fix
- [ ] Code health or cleanup
- [x] Documentation
- [ ] Other (specify)

## Sanity Checklist

- [x] I have updated the GitHub Issue `assignees`, `reviewers`, `labels`, `project`, `iteration` and `milestone`
- [x] For docs, I have run `make docusaurus_start`
- [ ] For code, I have run `make test_all`
- [ ] For configurations, I have update the documentation
- [ ] I added TODOs where applicable
