### PR TITLE
[WIP][Review] Review of #152: `First implementation of relay metrics observability`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,15 @@ FROM golang:1.23-alpine3.19 AS builder
 RUN apk add --no-cache git make build-base
 
 WORKDIR /go/src/github.com/buildwithgrove/path
+
+# Copy only go.mod and go.sum first to cache dependency installation
+COPY go.mod go.sum ./
+RUN go mod download
+
+# Now copy the rest of the files
 COPY . .
+
+# Build the application
 RUN go build -o /go/bin/path ./cmd
 
 FROM alpine:3.19

--- a/Makefile
+++ b/Makefile
@@ -50,8 +50,7 @@ path_run: path_build check_path_config ## Run the path binary as a standalone bi
 
 .PHONY: path_up
 path_up: check_path_config dev_up config_path_secrets ## Brings up local Tilt development environment which includes PATH and all related dependencies (using kind cluster)
-	# Use the default MODE, i.e. path_with_auth
-	tilt up
+	tilt up # MODE=path_with_auth is the default
 
 .PHONY: path_up_standalone
 path_up_standalone: ## Brings up local Tilt development environment with PATH only

--- a/Tiltfile
+++ b/Tiltfile
@@ -74,11 +74,13 @@ docker_build_with_restart(
 )
 
 # Port 6060 is exposed to serve pprof data.
-# Use the `debug_goroutines` make target to view the pprof goroutine data: `make debug_goroutines`
+# Run the following commands to view the pprof data:
+#   $ make debug_goroutines
 path_port_forwards = ["6060:6060"]
 
-# Specify the dependencies if PATH is running with auth.
-# No ports, except 6060 for pprof, are exposed: all traffic must be routed through Envoy Proxy.
+# Specify dependencies if PATH is running with auth.
+# No ports (except 6060 for pprof), are exposed because all traffic MUST
+# be routed through Envoy Proxy.
 if MODE == "path_with_auth":
     path_resource_deps = [
         "ext-authz",
@@ -90,9 +92,9 @@ if MODE == "path_with_auth":
 
 # Specify the dependencies and port forwards if PATH is running WITHOUT auth.
 if MODE == "path_only":
-    # Run PATH without any dependencies and port 3069 exposed
+    # Run PATH without any dependencies
     path_resource_deps = []
-    # When running without auth port 3069 is exposed to serve relay requests.
+    # Expose port 3069 to serve relay requests (since envoy proxy is not used)
     path_port_forwards.append("3069:3069")
 
 # Run PATH with dependencies and port forwarding settings matching the MODE:

--- a/cmd/metrics.go
+++ b/cmd/metrics.go
@@ -8,16 +8,13 @@ import (
 	"github.com/buildwithgrove/path/metrics"
 )
 
+// TODO_TECHDEBT(@adshmh): Support configurable pprof server address/port.
 const (
-	// TODO_TECHDEBT(@adshmh): Support configurable pprof server address/port.
-	//
 	// pprofAddr is the address at which pprof server will be listening.
-	// This address is selected based on the following link's examples:
+	// NOTE: This address was selected based on the example here:
 	// https://pkg.go.dev/net/http/pprof
 	pprofAddr = ":6060"
 
-	// TODO_TECHDEBT(@adshmh): Support configurable metrics server address/port.
-	//
 	// prometheusMetricsServerAddr is the address at which the prometheus metrics server will be listening.
 	prometheusMetricsServerAddr = ":9090"
 )

--- a/docusaurus/docs/develop/path/cheat_sheet_morse.md
+++ b/docusaurus/docs/develop/path/cheat_sheet_morse.md
@@ -17,7 +17,6 @@ This guide covers setting up `PATH` with the **Morse** protocol. In MainNet as o
 - [3. Start PATH](#3-start-path)
 - [3.1 Start PATH](#31-start-path)
   - [3.1 Monitor PATH](#31-monitor-path)
-  - [3.2 View PATH go runtime debugging info](#32-view-path-go-runtime-debugging-info)
 - [4. Test Relays](#4-test-relays)
 - [Additional Notes](#additional-notes)
 
@@ -165,16 +164,6 @@ Wait for initialization logs:
 {"level":"info","message":"Starting the cache update process."}
 {"level":"info","package":"router","message":"PATH gateway running on port 3069"}
 ```
-
-### 3.2. View PATH go runtime debugging info
-
-Use the `debug_goroutines` make target to view go runtime's info on PATH:
-
-```bash
-make debug_goroutines
-```
-
-This opens the brower to port 8081 on localhost to show goruntime's debug info on PATH.
 
 ## 4. Test Relays
 

--- a/docusaurus/docs/develop/path/cheat_sheet_shannon.md
+++ b/docusaurus/docs/develop/path/cheat_sheet_shannon.md
@@ -18,7 +18,6 @@ This guide covers setting up `PATH` with the **Shannon** protocol. In Beta TestN
 - [3. Start PATH](#3-start-path)
 - [3.1 Start PATH](#31-start-path)
   - [3.1 Monitor PATH](#31-monitor-path)
-  - [3.2 View PATH go runtime debugging info](#32-view-path-go-runtime-debugging-info)
 - [4. Test Relays](#4-test-relays)
 
 ## 0. Prerequisites
@@ -221,16 +220,6 @@ Wait for initialization logs:
 {"level":"info","message":"Starting the cache update process."}
 {"level":"info","package":"router","message":"PATH gateway running on port 3069"}
 ```
-
-### 3.2. View PATH go runtime debugging info
-
-Use the `debug_goroutines` make target to view go runtime's info on PATH:
-
-```bash
-make debug_goroutines
-```
-
-This opens the brower to port 8081 on localhost to show goruntime's debug info on PATH.
 
 ## 4. Test Relays
 

--- a/docusaurus/docs/develop/path/env_setup.md
+++ b/docusaurus/docs/develop/path/env_setup.md
@@ -47,7 +47,7 @@ The following tools are required to start a local PATH instance:
 - [**kubectl**](https://kubernetes.io/docs/tasks/tools/#kubectl): CLI for interacting with Kubernetes
 - [**Helm**](https://helm.sh/docs/intro/install/): Package manager for Kubernetes
 - [**Tilt**](https://docs.tilt.dev/install.html): Local Kubernetes development environment
-- [**Graphviz**](https://graphviz.org) (Optional): Required for generating profiling & debugging performance
+- [**Graphviz**](https://graphviz.org) (Debug only): Required for generating profiling & debugging performance
 
 **Development Tools:**
 

--- a/docusaurus/docs/develop/path/env_setup.md
+++ b/docusaurus/docs/develop/path/env_setup.md
@@ -47,6 +47,7 @@ The following tools are required to start a local PATH instance:
 - [**kubectl**](https://kubernetes.io/docs/tasks/tools/#kubectl): CLI for interacting with Kubernetes
 - [**Helm**](https://helm.sh/docs/intro/install/): Package manager for Kubernetes
 - [**Tilt**](https://docs.tilt.dev/install.html): Local Kubernetes development environment
+- [**Graphviz**](https://graphviz.org) (Optional): Required for generating profiling & debugging performance
 
 **Development Tools:**
 

--- a/docusaurus/docs/develop/path/qos.md
+++ b/docusaurus/docs/develop/path/qos.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 6
+sidebar_position: 7
 title: Quality of Service
 description: High level overview of Quality of Service (QoS) in PATH
 ---

--- a/docusaurus/docs/develop/path/troubleshooting_faq.md
+++ b/docusaurus/docs/develop/path/troubleshooting_faq.md
@@ -1,0 +1,17 @@
+---
+sidebar_position: 8
+title: Troubleshooting & FAQ
+description: Tips & Tricks for Troubleshooting with FAQ
+---
+
+## Table of Contents <!-- omit in toc -->
+
+## How can I profile (`pprof`) PATH's runtime?
+
+Use the `debug_goroutines` make target to view go runtime's info on PATH like so:
+
+```bash
+make debug_goroutines
+```
+
+You can then view the Golang's runtime at [localhost:8081/ui](http://localhost:8081/ui).

--- a/docusaurus/docusaurus.config.js
+++ b/docusaurus/docusaurus.config.js
@@ -71,8 +71,8 @@ const config = {
     ({
       docs: {
         sidebar: {
-          hideable: false,
-          autoCollapseCategories: false,
+          hideable: true,
+          autoCollapseCategories: true,
         },
       },
       style: "dark",

--- a/docusaurus/src/css/custom.css
+++ b/docusaurus/src/css/custom.css
@@ -4,27 +4,229 @@
  * work well for content-centric websites.
  */
 
-/* You can override the default Infima variables here. */
 :root {
-  --ifm-color-primary: #2e8555;
-  --ifm-color-primary-dark: #29784c;
-  --ifm-color-primary-darker: #277148;
-  --ifm-color-primary-darkest: #205d3b;
-  --ifm-color-primary-light: #33925d;
-  --ifm-color-primary-lighter: #359962;
-  --ifm-color-primary-lightest: #3cad6e;
-  --ifm-code-font-size: 95%;
+  --ifm-color-primary: #1f2327;
+  --ifm-color-primary-dark: #1c2023;
+  --ifm-color-primary-darker: #191c1f;
+  --ifm-color-primary-darkest: #16191b;
+  /*--ifm-color-primary-light: #5e99e3;*/
+  /*--ifm-color-primary-lighter: #6aa1e5;*/
+  /*--ifm-color-primary-lightest: #90b8ec;*/
   --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.1);
+
+  /* Change collapse button color */
+  --docusaurus-collapse-button-bg: #f2f2f2 !important;
+  --docusaurus-collapse-button-bg-hover: #dadada !important;
+
+  /* Search style var */
+  --ifm-navbar-search-input-placeholder-color: var(--ifm-color-emphasis-800);
+
+  /* Hyperlinks hover */
+  --ifm-link-color: #389f58;
+
+  --ifm-menu-color-background-active: #e9ecef;
+  /* Pocket Custom */
+  --pokt-header-vertical-devider: #353a40;
+
+  /* Pocket Custom */
+  --pokt-nav-borders: #e3e8ed;
+  --pokt-nav-selected-border: #27292f;
+
+  /* Disable nav boxshadow in light mode */
+  --ifm-navbar-shadow: 0;
+
+  /* Disable nav nested items padding */
+  --ifm-menu-color: var(--ifm-color-primary);
+
+  --ifm-navbar-height: 81px;
+
+  /* Font Family */
+  --ifm-font-family-base: "Inter", system-ui, -apple-system, Segoe UI, Roboto,
+    Ubuntu, Cantarell, Noto Sans, sans-serif, BlinkMacSystemFont, "Segoe UI",
+    Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji",
+    "Segoe UI Symbol";
+
+  /* Search highlight color */
+  --search-local-highlight-color: var(--mantine-primary-color-filled);
 }
 
 /* For readability concerns, you should choose a lighter palette in dark mode. */
-[data-theme='dark'] {
-  --ifm-color-primary: #25c2a0;
-  --ifm-color-primary-dark: #21af90;
-  --ifm-color-primary-darker: #1fa588;
-  --ifm-color-primary-darkest: #1a8870;
-  --ifm-color-primary-light: #29d5b0;
-  --ifm-color-primary-lighter: #32d8b4;
-  --ifm-color-primary-lightest: #4fddbf;
+[data-theme="dark"] {
+  --ifm-color-primary: #e6edf3;
+  --ifm-color-primary-dark: #cfd5db;
+  --ifm-color-primary-darker: #b8bec2;
+  --ifm-color-primary-darkest: #a1a6aa;
+  /*--ifm-color-primary-light: #4ea7f2;*/
+  /*--ifm-color-primary-lighter: #5caef3;*/
+  /*--ifm-color-primary-lightest: #84c2f6;*/
   --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.3);
+  --ifm-navbar-background-color: #1a1b1e;
+  --ifm-menu-color-background-active: #27292f;
+
+  /* Change collapse button color */
+  --docusaurus-collapse-button-bg: #272729 !important;
+  --docusaurus-collapse-button-bg-hover: #232325 !important;
+
+  /* Search style var */
+  --ifm-navbar-search-input-icon: url('data:image/svg+xml;utf8,<svg fill="white" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" height="16px" width="16px"><path d="M6.02945,10.20327a4.17382,4.17382,0,1,1,4.17382-4.17382A4.15609,4.15609,0,0,1,6.02945,10.20327Zm9.69195,4.2199L10.8989,9.59979A5.88021,5.88021,0,0,0,12.058,6.02856,6.00467,6.00467,0,1,0,9.59979,10.8989l4.82338,4.82338a.89729.89729,0,0,0,1.29912,0,.89749.89749,0,0,0-.00087-1.29909Z" /></svg>');
+
+  /*!* Hyperlinks hover *!*/
+  /*--ifm-link-color: #379F58;*/
+
+  /* Pocket Custom */
+  --pokt-header-vertical-devider: #ced4da;
+
+  /* Pocket Custom */
+  --pokt-nav-borders: #343438;
+  --pokt-nav-selected-border: #ebeaef;
+}
+
+body {
+  background-color: var(--ifm-navbar-background-color) !important;
+}
+
+a.mantine-Button-root:hover {
+  color: var(--_button-color, var(--button-color, var(--mantine-color-white)));
+  text-decoration: none;
+}
+
+/* Header navbar styling and layout */
+.navbar {
+  border-bottom: 1px solid var(--mantine-color-default-border);
+  padding: 1rem;
+  height: auto;
+}
+.navbar__item {
+  position: relative;
+}
+.navbar__item:hover {
+  color: var(--mantine-primary-color-filled);
+}
+.navbar__item.navbar__link--active:before,
+.navbar__item .navbar__link.active:before {
+  content: "";
+  position: absolute;
+  width: 100%;
+  border-bottom: 2px solid var(--mantine-primary-color-filled);
+  left: 0;
+  bottom: -8px;
+}
+.navbar__items.navbar__items--right {
+  flex-direction: row-reverse;
+}
+
+/* Navbar right section search styling */
+.navbar__search {
+  border: 1px solid var(--mantine-color-default-border);
+  border-radius: 4px;
+  padding: 3px;
+  margin-right: 16px;
+}
+
+.navbar__search-input {
+  background-color: transparent;
+  outline-color: transparent;
+}
+
+.navbar__search-input:hover {
+  border-color: transparent;
+}
+
+.navbar__item.header-link-button {
+  border-radius: 100px;
+  color: var(--mantine-color-gray-0);
+}
+
+/* sidebar nav menu styling and spacing */
+.theme-doc-sidebar-item-category:not(:first-child) {
+  margin-top: 2rem;
+}
+
+nav.menu {
+  padding: 2rem 1rem;
+  overflow: hidden;
+}
+
+nav.menu:hover {
+  overflow-y: auto;
+}
+
+nav.menu .menu__list {
+  padding-left: 0;
+}
+
+nav.menu li > .menu__link {
+  font-size: 14px;
+}
+
+nav.menu li > .menu__link:not(.menu__link--active) {
+  font-weight: 400;
+}
+nav.menu li > .menu__link.menu__link--active {
+  font-weight: 600;
+}
+
+nav.menu li > .menu__list-item-collapsible {
+  font-size: 12px;
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+}
+nav.menu li > .menu__list-item-collapsible .menu__link {
+  color: var(--mantine-color-gray-filled);
+}
+
+/* blog sidebar */
+.blog-layout nav:not(.pagination-nav) {
+  border-right: 1px solid var(--mantine-color-default-border);
+  min-height: calc(100vh - var(--ifm-navbar-height));
+  margin: 0;
+  top: var(--ifm-navbar-height);
+  padding: 2rem 1rem;
+  overflow: hidden;
+}
+
+/* docs accordion */
+.docs-wrapper .mantine-Accordion-item {
+  border-left: calc(0.0625rem * var(--mantine-scale)) solid
+    var(--_item-border-color);
+  border-bottom: none;
+}
+
+/* TABLE */
+table {
+  display: table;
+  width: 100%;
+}
+
+table thead {
+  background-color: transparent;
+}
+
+table thead tr {
+  border: none;
+}
+
+table tr {
+  border-color: var(--mantine-color-default-border);
+}
+
+table thead tr th {
+  color: var(--mantine-color-text) !important;
+}
+
+table tr td,
+table tr th {
+  border: none;
+  border-color: var(--mantine-color-default-border);
+}
+
+table tr:nth-child(2n) {
+  background-color: transparent;
+}
+
+table tr:last-of-type td {
+  border-bottom: 1px solid;
+  /* border-bottom: calc(0.0625rem * var(--mantine-scale)) solid; */
+  border-color: var(--mantine-color-default-border);
 }

--- a/gateway/request_context.go
+++ b/gateway/request_context.go
@@ -82,7 +82,7 @@ func (rc *requestContext) InitFromHTTPRequest(httpReq *http.Request) error {
 
 // BuildQoSContextFromHTTP builds the QoS context instance using the supplied HTTP request's payload.
 func (rc *requestContext) BuildQoSContextFromHTTP(ctx context.Context, httpReq *http.Request) error {
-	// TODO_MVP(@adshmh): Add an HTTP request size metric/observation at the gateway/http level.
+	// TODO_MVP(@adshmh): Add an HTTP request size metric/observation at the gateway/http (L7) level.
 	// Required steps:
 	//  	1. Update QoSService interface to parse custom struct with []byte payload
 	//  	2. Read HTTP request body in `request` package and return struct for QoS Service

--- a/local/scripts/install_tools.sh
+++ b/local/scripts/install_tools.sh
@@ -13,13 +13,13 @@ command_exists() {
 # This function checks if Docker is installed. If not, it downloads and runs the official installation script.
 install_docker() {
     if command_exists docker; then
-        echo "$(date) - Docker already installed." >> install.log
+        echo "$(date) - Docker already installed." >>install.log
     else
-        echo "$(date) - Installing Docker..." >> install.log
+        echo "$(date) - Installing Docker..." >>install.log
         curl -fsSL https://get.docker.com -o get-docker.sh
         sh get-docker.sh
         rm -f get-docker.sh
-        echo "$(date) - Docker installation complete." >> install.log
+        echo "$(date) - Docker installation complete." >>install.log
     fi
 }
 
@@ -27,28 +27,28 @@ install_docker() {
 # This function checks if Kind is installed. If not, it downloads the binary and moves it to /usr/local/bin.
 install_kind() {
     if command_exists kind; then
-        echo "$(date) - Kind already installed." >> install.log
+        echo "$(date) - Kind already installed." >>install.log
     else
-        echo "$(date) - Installing Kind..." >> install.log
+        echo "$(date) - Installing Kind..." >>install.log
         KIND_VERSION=$(curl -s https://api.github.com/repos/kubernetes-sigs/kind/releases/latest | grep tag_name | cut -d '"' -f4)
         curl -Lo ./kind "https://kind.sigs.k8s.io/dl/${KIND_VERSION}/kind-linux-amd64"
         chmod +x kind
         mv kind /usr/local/bin/kind
-        echo "$(date) - Kind installation complete." >> install.log
+        echo "$(date) - Kind installation complete." >>install.log
     fi
 }
 
 # Function to install kubectl if not present
 install_kubectl() {
     if command_exists kubectl; then
-        echo "$(date) - kubectl already installed." >> install.log
+        echo "$(date) - kubectl already installed." >>install.log
     else
-        echo "$(date) - Installing kubectl..." >> install.log
+        echo "$(date) - Installing kubectl..." >>install.log
         KUBECTL_VERSION=$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)
         curl -LO "https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl"
         chmod +x kubectl
         mv kubectl /usr/local/bin/kubectl
-        echo "$(date) - kubectl installation complete." >> install.log
+        echo "$(date) - kubectl installation complete." >>install.log
     fi
 }
 
@@ -56,11 +56,11 @@ install_kubectl() {
 # This function checks if Helm is installed. If not, it uses the Helm install script to get the latest version.
 install_helm() {
     if command_exists helm; then
-        echo "$(date) - Helm already installed." >> install.log
+        echo "$(date) - Helm already installed." >>install.log
     else
-        echo "$(date) - Installing Helm..." >> install.log
+        echo "$(date) - Installing Helm..." >>install.log
         curl https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 | bash
-        echo "$(date) - Helm installation complete." >> install.log
+        echo "$(date) - Helm installation complete." >>install.log
     fi
 }
 
@@ -68,21 +68,33 @@ install_helm() {
 # This function checks if Tilt is installed. If not, it runs the Tilt install script.
 install_tilt() {
     if command_exists tilt; then
-        echo "$(date) - Tilt already installed." >> install.log
+        echo "$(date) - Tilt already installed." >>install.log
     else
-        echo "$(date) - Installing Tilt..." >> install.log
+        echo "$(date) - Installing Tilt..." >>install.log
         curl -fsSL https://raw.githubusercontent.com/tilt-dev/tilt/master/scripts/install.sh | bash
-        echo "$(date) - Tilt installation complete." >> install.log
+        echo "$(date) - Tilt installation complete." >>install.log
+    fi
+}
+
+# Function to install Graphviz if not present
+# This function checks if Graphviz is installed. If not, it installs it using the package manager.
+install_graphviz() {
+    if command_exists dot; then
+        echo "$(date) - Graphviz already installed." >>install.log
+    else
+        echo "$(date) - Visit this link to install Graphviz manually: https://graphviz.org"
+        echo "$(date) - This is optional and only needed for debugging purposes."
     fi
 }
 
 # Main execution starts here
-echo "$(date) - Starting installation script..." >> install.log
+echo "$(date) - Starting installation script..." >>install.log
 
 install_docker
 install_kind
 install_kubectl
 install_helm
 install_tilt
+install_graphviz
 
-echo "$(date) - Installation script completed." >> install.log
+echo "$(date) - Installation script completed." >>install.log

--- a/makefiles/configs.mk
+++ b/makefiles/configs.mk
@@ -7,9 +7,13 @@
 clear_all_local_configs: ## Clear all local configs
 	rm -f ./bin/config/.config.yaml
 	rm -f ./config/.config.yaml
+	rm -f ./local/path/config/.config.yaml
 	rm -f ./e2e/.shannon.config.yaml
 	rm -f ./e2e/.morse.config.yaml
-	rm -f ./local/path/config/.config.yaml
+	rm -f ./local/path/envoy/.envoy.yaml
+	rm -f ./local/path/envoy/.ratelimit.yaml
+	rm -f ./local/path/envoy/.allowed-services.lua
+	rm -f ./local/path/envoy/.gateway-endpoints.yaml
 	@echo "################################################################"
 	@echo "Cleared all local configs"
 	@echo "################################################################"

--- a/makefiles/configs.mk
+++ b/makefiles/configs.mk
@@ -2,6 +2,18 @@
 # Shared config helpers
 ################################################################
 
+
+.PHONY: clear_all_local_configs
+clear_all_local_configs: ## Clear all local configs
+	rm -f ./bin/config/.config.yaml
+	rm -f ./config/.config.yaml
+	rm -f ./e2e/.shannon.config.yaml
+	rm -f ./e2e/.morse.config.yaml
+	rm -f ./local/path/config/.config.yaml
+	@echo "################################################################"
+	@echo "Cleared all local configs"
+	@echo "################################################################"
+
 # Helper function to check if a config file exists
 define check_config_exists
 	@if [ ! -f $(1) ]; then \
@@ -26,15 +38,3 @@ define warn_file_exists
 		exit 1; \
 	fi
 endef
-
-
-.PHONY: clear_all_local_configs
-clear_all_local_configs: ## Clear all local configs
-	rm -f ./bin/config/.config.yaml
-	rm -f ./config/.config.yaml
-	rm -f ./e2e/.shannon.config.yaml
-	rm -f ./e2e/.morse.config.yaml
-	rm -f ./local/path/config/.config.yaml
-	@echo "################################################################"
-	@echo "Cleared all local configs"
-	@echo "################################################################"

--- a/makefiles/debug.mk
+++ b/makefiles/debug.mk
@@ -2,15 +2,22 @@
 ### Debug targets ###
 #####################
 
+.PHONY: check_graphviz
+# Internal helper: Check if graphviz is installed locally
+check_graphviz:
+	@if ! command -v graphviz >/dev/null 2>&1; then \
+		echo "Graphviz is not installed. Make sure you review README.md before continuing"; \
+		exit 1; \
+	fi;
+
 .PHONY: debug_goroutines
 # Deploys pprof (using graphviz) using docker at http://localhost:8081/ui/
 # Ref: https://www.graphviz.org/download
 #
 # TODO_TECHDEBT(@adshmh): Remove host networking mode flag (--network=host) and
-# use a standard method of accessing localhost:6060 within the container
-# to avoid the host from needing to download graphviz.
+# use a standard method of accessing localhost:6060 within the container.
+# This is needed to avoid the host from needing to download graphviz.
 debug_goroutines: check_docker
-
 	@docker run --rm \
 		--network=host \
 		golang:1.23.6-alpine3.20 \

--- a/makefiles/debug.mk
+++ b/makefiles/debug.mk
@@ -1,19 +1,16 @@
-######################
-### Debgug targets ###
-######################
+#####################
+### Debug targets ###
+#####################
 
-# TODO_TECHDEBT(@adshmh): Remove host networking mode flag i.e. --network=host, and use a standard method of accessing 
-# port 6060 on localhost from within the container.
-#
 .PHONY: debug_goroutines
-# Debugging helper: show goroutines pprof data on port 8081.
-# This adds graphviz to a golang docker container to remove the need for installing graphviz,
-# since graphviz does not have a general, distribution-independent, installation script:
-# https://www.graphviz.org/download
+# Deploys pprof (using graphviz) using docker at http://localhost:8081/ui/
+# Ref: https://www.graphviz.org/download
+#
+# TODO_TECHDEBT(@adshmh): Remove host networking mode flag (--network=host) and
+# use a standard method of accessing localhost:6060 within the container
+# to avoid the host from needing to download graphviz.
 debug_goroutines: check_docker
-	@echo "###########################################################################"
-	@echo "Starting a golang docker container with graphviz to display goruntime data."
-	@echo "###########################################################################"
+
 	@docker run --rm \
 		--network=host \
 		golang:1.23.6-alpine3.20 \

--- a/makefiles/test_requests.mk
+++ b/makefiles/test_requests.mk
@@ -85,7 +85,7 @@ test_request__evm_endpoint: debug_anvil_supplier_info_msg ## Test EVM endpoint r
 
 .PHONY: test_request__cometbft_endpoint
 test_request__cometbft_endpoint: ## Test CometBFT endpoint request against the PATH Gateway running on port 3069 without Envoy Proxy
-	curl 'http://localhost:3069/v1/status' \
+	curl 'http://localhost:3069/v1/health' \
 		-X GET \
 		-H 'Content-Type: application/json' \
 		-H 'target-service-id: cometbft'

--- a/metrics/gateway.go
+++ b/metrics/gateway.go
@@ -8,8 +8,10 @@ import (
 
 // See the metrics initialization below for details.
 const (
+	// The POSIX process that emits metrics
 	pathProcess = "path"
 
+	// The list of metrics being tracked for gateway-level observations
 	requestsTotal        = "requests_total"
 	responseSizeBytes    = "response_size_bytes"
 	relayDurationSeconds = "relay_duration_seconds"
@@ -23,7 +25,7 @@ func init() {
 
 var (
 	// relaysTotal is a counter tracking processed requests per PATH instance.
-	// It increments on each service request with labels:
+	// Increment on each service request with labels:
 	//   - service_id: Identifies the service
 	//   - request_type: "organic" or "synthetic"
 	//
@@ -53,6 +55,9 @@ var (
 			Help:      "Histogram of request processing time (duration) in seconds",
 			// Buckets are selected as: [0, 0.1), [0.1, 0.5), [0.5, 1), [1, 2), [2, 5), [5, 15)
 			// This is because the request processing time is expected to be normally distributed.
+			// This means we need a higher resolution (smaller buckets and more granularity) for the lower values,
+			// and less resolution (big buckets and low granularity) for the higher values because it'll have less
+			// data points.
 			Buckets: []float64{0.1, 0.5, 1, 2, 5, 15},
 		},
 		[]string{"service_id"},
@@ -64,22 +69,21 @@ var (
 	// Usage:
 	// 	- Performance tuning to understand skew of data distribution
 	//	- Visibility into small & large response size distribution
-	//
-	// TODO_TECHDEBT: Consider configuring bucket sizes externally for flexible adjustments
-	// in response to different data patterns or deployment scenarios.
 	relayResponseSizeBytes = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Subsystem: pathProcess,
 			Name:      responseSizeBytes,
 			Help:      "Histogram of response sizes in bytes for performance analysis.",
-			Buckets:   []float64{100, 500, 1000, 5000, 10000, 50000},
+			// TODO_IMPROVE: Consider configuring bucket sizes externally for flexible adjustments
+			// in response to different data patterns or deployment scenarios.
+			Buckets: []float64{100, 500, 1000, 5000, 10000, 50000},
 		},
 		[]string{"service_id"},
 	)
 
 	// TODO_MVP(@adshmh): Add a serviceRequestSize metric once the `request` package is refactored to
 	// fully encapsulate the task of dealing with the HTTP request, including:
-	//	!. Reading of all HTTP headers: target-service-id, etc.
+	//	1. Reading of all HTTP headers: target-service-id, etc.
 	//	2. Reading of the HTTP request's body
 	//	3. Building an HTTP observation using the extracted data.
 	// This will also involve a small refactor on protocol and qos packages to accept a custom struct
@@ -90,9 +94,9 @@ var (
 func publishGatewayMetrics(gatewayObservations *observation.GatewayObservations) {
 	serviceID := gatewayObservations.GetServiceId()
 
-	// Increment request counter with the following labels:
-	// 	- request_type
-	// 	- service_id
+	// Increment on each service request with labels:
+	//   - service_id: Identifies the service
+	//   - request_type: "organic" or "synthetic"
 	relaysTotal.With(
 		prometheus.Labels{
 			"service_id":   serviceID,

--- a/metrics/qos/evm.go
+++ b/metrics/qos/evm.go
@@ -9,8 +9,10 @@ import (
 )
 
 const (
+	// The linux process that emits metrics
 	pathProcess = "path"
 
+	// The list of metrics being tracked
 	evmRequestsTotalMetric = "evm_requests_total"
 )
 
@@ -19,8 +21,8 @@ func init() {
 }
 
 var (
-	// TODO_MVP(@adshmh): add a `validation` object field to indicate whether the user's request was valid,
-	// with two fields:
+	// TODO_MVP(@adshmh): add a `validation` object field to indicate whether
+	// the user's request was valid, with two fields:
 	//	1. Valid: whether the user's request was valid.
 	//	2. Reason: The reason the request is considered invalid, if applicable.
 	//

--- a/metrics/qos/evm.go
+++ b/metrics/qos/evm.go
@@ -9,10 +9,10 @@ import (
 )
 
 const (
-	// The linux process that emits metrics
+	// The POSIX process that emits metrics
 	pathProcess = "path"
 
-	// The list of metrics being tracked
+	// The list of metrics being tracked for EVM QoS
 	evmRequestsTotalMetric = "evm_requests_total"
 )
 
@@ -50,9 +50,9 @@ func PublishEVMMetrics(evmObservations *qos.EVMRequestObservations) {
 	// Increment request counters with all corresponding labels
 	evmRequestsTotal.With(
 		prometheus.Labels{
-			"success":        fmt.Sprintf("%t", getEVMRequestSuccess(evmObservations)),
 			"chain_id":       evmObservations.GetChainId(),
 			"request_method": evmObservations.GetJsonrpcRequest().GetMethod(),
+			"success":        fmt.Sprintf("%t", getEVMRequestSuccess(evmObservations)),
 		},
 	).Inc()
 }

--- a/proto/path/gateway.proto
+++ b/proto/path/gateway.proto
@@ -10,8 +10,8 @@ import "google/protobuf/timestamp.proto";
 
 // RequestType captures the origin of the request.
 // As of PR #72, it is one of:
-// 	1. Organic: a real user sent a service request to a PATH instance
-// 	2. Synthetic: internal infrastructure generated the service request for simulation and data purposes.
+//  1. Organic: a real user sent a service request to a PATH instance
+//  2. Synthetic: internal infrastructure generated the service request for simulation and data purposes.
 enum RequestType {
   REQUEST_TYPE_UNSPECIFIED = 0;
   REQUEST_TYPE_ORGANIC = 1;  // Service request sent by a user.
@@ -31,16 +31,16 @@ message GatewayObservations {
   // For example, wWhether the request was sent by a user or synthetically generated (e.g. by the endpoint hydrator).
   RequestType request_type = 2;
 
-	// service_id is the identifier specified via custom HTTP header.
-	// As of PR #72, this can only be specified through a custom header on the HTTP request, extracted in `request/parser.go`.	
-	string service_id = 3;
-	
-	// received_time is when the request was initially received
-	google.protobuf.Timestamp received_time = 4;
-	
-	// completed_time is when request processing finished and response was returned
-	google.protobuf.Timestamp completed_time = 5;
-	
-	// response_size is the size in bytes of the response payload
-	uint64 response_size = 6;
+  // service_id is the identifier specified via custom HTTP header.
+  // As of PR #72, this can only be specified through a custom header on the HTTP request, extracted in `request/parser.go`.
+  string service_id = 3;
+
+  // received_time is when the request was initially received
+  google.protobuf.Timestamp received_time = 4;
+
+  // completed_time is when request processing finished and response was returned
+  google.protobuf.Timestamp completed_time = 5;
+
+  // response_size is the size in bytes of the response payload
+  uint64 response_size = 6;
 }

--- a/proto/path/metadata/metadata.proto
+++ b/proto/path/metadata/metadata.proto
@@ -10,5 +10,3 @@ extend google.protobuf.FieldOptions {
   // Used for attaching a semantic meaning to a field.
   string semantic_meaning = 50001;
 }
-
-

--- a/proto/path/qos/evm.proto
+++ b/proto/path/qos/evm.proto
@@ -18,8 +18,8 @@ message EVMRequestObservations {
   // * Request is sent to additional endpoints for data collection
   repeated EVMEndpointObservation endpoint_observations = 2;
 
-	// chainID is the blockchain identifier for the evm QoS implementation.
-	// Expected as the `Result` field in eth_chainId responses.
+  // chainID is the blockchain identifier for the evm QoS implementation.
+  // Expected as the `Result` field in eth_chainId responses.
   string chain_id = 3;
 }
 

--- a/qos/evm/response_blocknumber.go
+++ b/qos/evm/response_blocknumber.go
@@ -28,7 +28,8 @@ func responseUnmarshallerBlockNumber(
 			logger: logger,
 
 			jsonRPCResponse: jsonrpcResp,
-			// A valid error JSONRPC response is considered a valid response.
+
+			// DEV_NOTE: A valid JSONRPC error response is considered a valid response.
 			valid: true,
 		}, nil
 	}
@@ -67,8 +68,9 @@ type responseToBlockNumber struct {
 
 	// result stores the result field of a response to a `eth_blockNumber` request.
 	result string
+
 	// valid is set to true if the endpoint response is deemed valid.
-	// As of PR #152, a respons is valid if either of the following holds:
+	// As of PR #152, a response is valid if either of the following holds:
 	//	- It is a valid JSONRPC error response
 	//	- It is a valid JSONRPC response with any string value in `result` field.
 	valid bool

--- a/qos/evm/response_chainid.go
+++ b/qos/evm/response_chainid.go
@@ -30,7 +30,7 @@ func responseUnmarshallerChainID(
 
 			jsonRPCResponse: jsonrpcResp,
 
-			// A valid error JSONRPC response is considered a valid response.
+			// DEV_NOTE: A valid JSONRPC error response is considered a valid response.
 			valid: true,
 		}, nil
 	}
@@ -53,8 +53,8 @@ func responseUnmarshallerChainID(
 		jsonRPCResponse: jsonrpcResp,
 		result:          result,
 
-		// if unmarhsaling succeeded, the response is considered valid.
-		valid: err == nil,
+		// if unmarshaling succeeded, the response is considered valid.
+		valid: (err == nil),
 	}, err
 }
 
@@ -70,7 +70,7 @@ type responseToChainID struct {
 	result string
 
 	// valid is set to true if the parsed response is deemed valid.
-	// As of PR #152, a respons is valid if either of the following holds:
+	// As of PR #152, a response is valid if either of the following holds:
 	//	- It is a valid JSONRPC error response
 	//	- It is a valid JSONRPC response with any string value in `result` field.
 	valid bool

--- a/qos/evm/response_generic.go
+++ b/qos/evm/response_generic.go
@@ -36,7 +36,8 @@ type responseGeneric struct {
 	jsonRPCResponse jsonrpc.Response
 
 	// valid is set to true if the parsed response is deemed valid.
-	// As of PR #152, a respons is deemed valid if it can be unmarshaled as a JSONRPC struct.
+	// As of PR #152, a response is deemed valid if it can be unmarshaled as a JSONRPC struct
+	// regardless of the contents of the response.
 	valid bool
 }
 


### PR DESCRIPTION
This PR contains manual changes made during the final review of #152 to expedite the E2E review process.

## Changes
- Update the main `Dockerfile` to avoid redownloading all dependencies every time
- Remove `pprof` from cheatsheets and move it to `FAQ` because devs just want to get through to the end
- Add `graphviz` to list of required dependencies
- Misc NITs & documentation improvements
- Minor improvements to docs UX

## Remaining open issues:

### 1. Unable to make a successful request with envoy

I have verified that when I check out `main`, the `make test_request__endpoint_url_path_mode__no_auth__service_id_header` works.

With these changes, I get `no healthy upstream` 100% of the time.


```
make test_request__endpoint_url_path_mode__no_auth__service_id_header
	#######################################################################################################################################
	INFO: If the request did not succeed, look into debugging the Anvil supplier by reviewing:
	  https://www.notion.so/buildwithgrove/PATH-Anvil-RelayMiner-Supplier-in-E2E-Test-infrastructure-17da36edfff680da98f2ff01705be00b?pvs=4
	########################################################################################################################################
	curl http://localhost:3070/v1/endpoint_3_no_auth \
			-X POST \
			-H "target-service-id: anvil" \
			-d '{"jsonrpc": "2.0", "id": 1, "method": "eth_blockNumber" }'
	no healthy upstream
```

### 2. Documentation

We need base level to show where the metrics live.

A link + screenshot in the FAQ or a new metrics page is a fine start. It's easier to add afterwards.

### 3. Local reproducibility

What did you use for "load testing" this? Was it Pacal's relay util or something else?

## Issue

- Issue: #89
