### PR TITLE
[FIX][LOGGER] Fix Morse logger to use global logger instead of initializing its own

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -159,7 +159,7 @@ func getProtocol(logger polylog.Logger, config config.GatewayConfig) (gateway.Pr
 	}
 
 	if morseConfig := config.GetMorseConfig(); morseConfig != nil {
-		return getMorseProtocol(morseConfig, logger)
+		return getMorseProtocol(logger, morseConfig)
 	}
 
 	return nil, fmt.Errorf("no protocol config set")

--- a/cmd/morse.go
+++ b/cmd/morse.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"context"
 	"fmt"
 
 	"github.com/pokt-network/poktroll/pkg/polylog"
@@ -13,8 +12,8 @@ import (
 
 // getMorseProtocol returns an instance of the Morse protocol using the supplied Morse-specific configuration.
 func getMorseProtocol(
-	config *morseconfig.MorseGatewayConfig,
 	logger polylog.Logger,
+	config *morseconfig.MorseGatewayConfig,
 ) (gateway.Protocol, error) {
 	logger.Info().Msg("Starting PATH gateway with Morse protocol")
 
@@ -23,7 +22,7 @@ func getMorseProtocol(
 		return nil, fmt.Errorf("failed to create morse full node: %v", err)
 	}
 
-	protocol, err := morse.NewProtocol(context.Background(), fullNode, config)
+	protocol, err := morse.NewProtocol(logger, fullNode, config)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create morse protocol: %v", err)
 	}

--- a/protocol/morse/protocol.go
+++ b/protocol/morse/protocol.go
@@ -38,10 +38,9 @@ type FullNode interface {
 	SendRelay(context.Context, *sdkrelayer.Input) (*sdkrelayer.Output, error)
 }
 
-func NewProtocol(ctx context.Context, fullNode FullNode, offChainBackend OffChainBackend) (*Protocol, error) {
+func NewProtocol(logger polylog.Logger, fullNode FullNode, offChainBackend OffChainBackend) (*Protocol, error) {
 	protocol := &Protocol{
-		logger: polylog.Ctx(ctx),
-
+		logger:          logger,
 		fullNode:        fullNode,
 		offChainBackend: offChainBackend,
 	}


### PR DESCRIPTION
## Summary

Fix Morse logger to use global logger instead of initializing its own.

### Primary Changes:
- Updated the `getMorseProtocol` function to pass the `logger` as the primary argument, ensuring a global logger is used consistently across function calls.
- Modified the `NewProtocol` function to remove the initialization of its own logger, replacing it with the provided global `logger` as an argument.

### Secondary changes:
- Removed the unused `context` package import, cleaning up the import statements.
- Adjusted the parameter order in function signatures for consistency and clarity.

## Type of change

Select one or more from the following:

- [ ] New feature, functionality or library
- [x] Bug fix
- [x] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## Sanity Checklist

- [ ] I have updated the GitHub Issue 'assignees', 'reviewers', 'labels', 'project', 'iteration' and 'milestone'
- [ ] For docs, I have run 'make docusaurus_start'
- [ ] For code, I have run 'make test_all'
- [ ] For configurations, I have update the documentation
- [ ] I added TODOs where applicable
