### PR TITLE
[QoS] Support array of objects as JSONRPC params

### DIFF
--- a/qos/evm/evm.go
+++ b/qos/evm/evm.go
@@ -53,6 +53,9 @@ func (qos *QoS) ParseHTTPRequest(_ context.Context, req *http.Request) (gateway.
 		), false
 	}
 
+	// TODO_TECHDEBT(@adshmh): support Batch JSONRPC requests, as per the JSONRPC spec:
+	// https://www.jsonrpc.org/specification#batch
+	//
 	// TODO_MVP(@adshmh): Add a JSON-RPC request validator to reject invalid/unsupported method calls early in request flow.
 	var jsonrpcReq jsonrpc.Request
 	if err := json.Unmarshal(body, &jsonrpcReq); err != nil {

--- a/qos/jsonrpc/params.go
+++ b/qos/jsonrpc/params.go
@@ -6,7 +6,7 @@ import (
 )
 
 // Params stores the data contained in the `params` field of a JSONRPC request.
-// As of PR #165, it supports:
+// As of PR #170, it supports:
 // - An array of objects
 // - An array of strings
 // See the below link on JSONRPC spec for more details:

--- a/qos/jsonrpc/params.go
+++ b/qos/jsonrpc/params.go
@@ -9,6 +9,7 @@ import (
 // As of PR #170, it supports:
 // - An array of objects
 // - An array of strings
+// - An array of primitive types
 // See the below link on JSONRPC spec for more details:
 // https://www.jsonrpc.org/specification#parameter_structures
 type Params struct {

--- a/qos/jsonrpc/params.go
+++ b/qos/jsonrpc/params.go
@@ -1,0 +1,41 @@
+package jsonrpc
+
+import (
+	"encoding/json"
+	"errors"
+)
+
+// Params stores the data contained in the `params` field of a JSONRPC request.
+// As of PR #165, it supports:
+// - An array of objects
+// - An array of strings
+// See the below link on JSONRPC spec for more details:
+// https://www.jsonrpc.org/specification#parameter_structures
+type Params struct {
+	// Params stores the raw JSON-RPC parameters without validation.
+	// The method-specific request handlers are responsible for validating the parameters based on the JSON-RPC method being called.
+	rawPayload []byte
+}
+
+func (p Params) MarshalJSON() ([]byte, error) {
+	return p.rawPayload, nil
+}
+
+func (p *Params) UnmarshalJSON(data []byte) error {
+	// Try first as a structure with array of interface{}
+	var genericValue []interface{}
+	if err := json.Unmarshal(data, &genericValue); err == nil {
+		p.rawPayload = data
+		return nil
+	}
+
+	// Try second as a structure with array of strings
+	var stringsValue []string
+	if err := json.Unmarshal(data, &stringsValue); err == nil {
+		p.rawPayload = data
+		return nil
+	}
+
+	// If both failed, return the error from the first attempt
+	return errors.New("failed to unmarshal as either []interface{} or []string")
+}

--- a/qos/jsonrpc/request.go
+++ b/qos/jsonrpc/request.go
@@ -23,5 +23,5 @@ type Request struct {
 	// For an example of a JSONRPC request where the params field
 	// is not a slice of strings, see the link below:
 	// https://ethereum.org/en/developers/docs/apis/json-rpc/#eth_signtransaction
-	Params []string `json:"params,omitempty"`
+	Params Params `json:"params,omitempty"`
 }

--- a/qos/jsonrpc/request.go
+++ b/qos/jsonrpc/request.go
@@ -16,12 +16,5 @@ type Request struct {
 	ID      ID      `json:"id,omitempty"`
 	JSONRPC Version `json:"jsonrpc"`
 	Method  Method  `json:"method"`
-	// TODO_MVP(@adshmh): support other forms of params field, based on the JSONRPC spec.
-	// See the link below for more details:
-	// https://www.jsonrpc.org/specification
-	//
-	// For an example of a JSONRPC request where the params field
-	// is not a slice of strings, see the link below:
-	// https://ethereum.org/en/developers/docs/apis/json-rpc/#eth_signtransaction
-	Params Params `json:"params,omitempty"`
+	Params  Params  `json:"params,omitempty"`
 }

--- a/qos/jsonrpc/request_test.go
+++ b/qos/jsonrpc/request_test.go
@@ -1,0 +1,36 @@
+package jsonrpc
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TODO_MVP(@adshmh): add a test case for batch JSONRPC requests
+func TestUnmarshalParams(t *testing.T) {
+	testCases := []struct {
+		name       string
+		rawPayload []byte
+	}{
+		{
+			name:       "params as array of single object",
+			rawPayload: []byte(`{"jsonrpc":"2.0","id":8522963871549545,"method":"eth_getLogs","params":[{"address":["0x1234","0xabcd","0xffff"],"fromBlock":"0x1234567","toBlock":"0xfffffff","topics":[]}]}`),
+		},
+		{
+			name:       "params as array of multiple objects",
+			rawPayload: []byte(`{"jsonrpc":"2.0","id":1949014,"method":"eth_call","params":[{"data":"0x12345678","from":"0x0000000000000000000000000000000000000000","to":"0x12345678abcdef12345678abcdef12345678abcd"},"latest"]}`),
+		},
+		{
+			name:       "params as mix of string and boolean",
+			rawPayload: []byte(`{"id":1,"jsonrpc":"2.0","method":"eth_getBlockByNumber","params":["latest",false]}`),
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			err := json.Unmarshal(testCase.rawPayload, &Request{})
+			require.NoError(t, err)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Support an array of objects as `params` field value in JSONRPC requests.

Changes:

- Add a new `Params` struct under `qos/jsonrpc` package
- Add unit tests to cover different formats of the `params` field in a JSONRPC request.
- Add a TODO for looking into batch JSONRPC requests.

## Issue

- Description: Request parsing fails for raw payloads representing JSONRPC requests with `params` field value as an array of objects.

## Type of change

Select one or more from the following:

- [x] New feature, functionality or library
- [ ] Bug fix
- [ ] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## QoS Checklist

- [ ] 1. `make path_up` or `path_up_standalone`
- [ ] 2. Run one of the following:
  - For `path_up_standalone` with `anvil` on `Shannon`: `make test_request__relay_util_1000`
  - For `path_up` with `anvil` on `Shannon`: `make test_request__envoy_relay_util_100`
  - For `path_up` with `F00C` on `Morse`: `make test_request__relay_util_100_F00C_via_envoy`
- [ ] 3. Visit [PATH Relay Grafana Dashboard](http://localhost:3000/d/relays/path-service-requests) to view results

## Sanity Checklist

- [x] I have updated the GitHub Issue `assignees`, `reviewers`, `labels`, `project`, `iteration` and `milestone`
- [ ] For docs, I have run `make docusaurus_start`
- [ ] For code, I have run `make test_all`
- [ ] For configurations, I have update the documentation
- [x] I added TODOs where applicable
