### PR TITLE
feat(jsonrpc): Enhance request parameter validation and serialization

### DIFF
--- a/qos/jsonrpc/params.go
+++ b/qos/jsonrpc/params.go
@@ -42,6 +42,7 @@ func (p *Params) UnmarshalJSON(data []byte) error {
 	}
 
 	// Validate that params follows JSON-RPC 2.0 spec: must be array or object.
+	// json.Unmarshal into interface{} fails for primitive types as they are not valid top-level JSON structures.
 	// Examples:
 	//   Valid:   [1, "test"] or {"foo": "bar"}
 	//   Invalid: "test" or 42 or true

--- a/qos/jsonrpc/request.go
+++ b/qos/jsonrpc/request.go
@@ -1,5 +1,9 @@
 package jsonrpc
 
+import (
+	"encoding/json"
+)
+
 // Method is the method specified by a JSONRPC request.
 // See the following link for more details:
 // https://www.jsonrpc.org/specification
@@ -17,4 +21,33 @@ type Request struct {
 	JSONRPC Version `json:"jsonrpc"`
 	Method  Method  `json:"method"`
 	Params  Params  `json:"params,omitempty"`
+}
+
+// MarshalJSON customizes the JSON serialization of a Request.
+// It omits empty ID and Params fields from the output without requiring them to be stored as pointers.
+func (r Request) MarshalJSON() ([]byte, error) {
+	// Define a structure that makes ID and Params optional in the JSON output
+	type requestAlias struct {
+		JSONRPC Version `json:"jsonrpc"`
+		Method  Method  `json:"method"`
+		Params  *Params `json:"params,omitempty"` // Optional in JSON output
+		ID      *ID     `json:"id,omitempty"`     // Optional in JSON output
+	}
+
+	// Build the serializable version of the request
+	out := requestAlias{
+		JSONRPC: r.JSONRPC,
+		Method:  r.Method,
+	}
+
+	// Only include non-empty fields
+	if !r.ID.IsEmpty() {
+		out.ID = &r.ID
+	}
+	if !r.Params.IsEmpty() {
+		out.Params = &r.Params
+	}
+
+	// Marshal and return the serializable version of the request
+	return json.Marshal(out)
 }

--- a/qos/jsonrpc/request.go
+++ b/qos/jsonrpc/request.go
@@ -24,7 +24,7 @@ type Request struct {
 }
 
 // MarshalJSON customizes the JSON serialization of a Request.
-// It omits empty ID and Params fields from the output without requiring them to be stored as pointers.
+// It returns a serialized version of the receiver with empty fields (e.g. ID, Params, etc) omitted
 func (r Request) MarshalJSON() ([]byte, error) {
 	// Define a structure that makes ID and Params optional in the JSON output
 	type requestAlias struct {

--- a/qos/jsonrpc/request_test.go
+++ b/qos/jsonrpc/request_test.go
@@ -7,12 +7,80 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// Unit tests to verify the Request struct serialization maintains the JSONRPC 2.0 spec.
+func TestMarshalJSON(t *testing.T) {
+	testCases := []struct {
+		name       string
+		rawPayload string
+	}{
+		{
+			name:       "empty id and param fields are omitted from the serialized format",
+			rawPayload: `{"jsonrpc":"2.0","method":"eth_chainId"}`,
+		},
+		{
+			name: "param field as empty array is present in the serialized format",
+			// DEV_NOTE: the order of fields should be the same as that of the Request struct, to get the same string post deserialization and serialization.
+			rawPayload: `{"jsonrpc":"2.0","method":"eth_chainId","params":[],"id":1}`,
+		},
+		{
+			name: "empty id field is omitted but param field with single object as value is present in the serialized format",
+			// payload example from: https://polkadot.js.org/docs/substrate/rpc/#querystorageatkeys-vec-storagehash-at-hash-option-vec-storagedata
+			// DEV_NOTE: the order of fields should be the same as that of the Request struct, to get the same string post deserialization and serialization.
+			rawPayload: `{"jsonrpc":"2.0","method":"state_queryStorageAt","params":{"keys":["0x5f3e4907f716ac89b6347d15ececedca1c0000000000000000"],"at":"0x6857c3c171f65f77f52cd566c574c1f59b0a3738b8d487967e9c54789ee621dd"}}`,
+		},
+		{
+			name: "id and params fields are both present in the serialized format when specified",
+			// rawPayload is from: https://solana.com/docs/rpc/http/getblockcommitment
+			// DEV_NOTE: the order of fields should be the same as that of the Request struct, to get the same string post deserialization and serialization.
+			rawPayload: `{"jsonrpc":"2.0","method":"getBlockCommitment","params":[5],"id":1}`,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			var req Request
+			err := json.Unmarshal([]byte(testCase.rawPayload), &req)
+			require.NoError(t, err)
+
+			marshaledRequest, err := json.Marshal(req)
+			require.NoError(t, err)
+
+			require.Equal(t, testCase.rawPayload, string(marshaledRequest))
+		})
+	}
+}
+
 // TODO_MVP(@adshmh): add a test case for batch JSONRPC requests
 func TestUnmarshalParams(t *testing.T) {
 	testCases := []struct {
 		name       string
 		rawPayload []byte
+		expectErr  bool
 	}{
+		{
+			name:       "malformed params field fails to parse",
+			rawPayload: []byte(`{"jsonrpc":"2.0","id":1,"method":"test","params":"incomplete...}`),
+			expectErr:  true,
+		},
+		{
+			name:       "params field not speicifed",
+			rawPayload: []byte(`{"jsonrpc":"2.0","id":12345678,"method":"eth_chainId"}`),
+		},
+		{
+			name: "params field as a single object",
+			// payload example from: https://polkadot.js.org/docs/substrate/rpc/#querystorageatkeys-vec-storagehash-at-hash-option-vec-storagedata
+			rawPayload: []byte(`{"jsonrpc":"2.0","id":1,"method":"state_queryStorageAt","params":{"keys": ["0x5f3e4907f716ac89b6347d15ececedca1c0000000000000000"], "at": "0x6857c3c171f65f77f52cd566c574c1f59b0a3738b8d487967e9c54789ee621dd"}}`),
+		},
+		{
+			name: "params field as an array of a single value of a basic type",
+			// rawPayload is a copy-paste from: https://solana.com/docs/rpc/http/getblockcommitment
+			rawPayload: []byte(`{"jsonrpc":"2.0","id":1,"method":"getBlockCommitment","params":[5]}`),
+		},
+		{
+			name: "params field as an empty list",
+			// rawPayload is a copy-paste from: https://ethereum.org/en/developers/docs/apis/json-rpc/#net_version
+			rawPayload: []byte(`{"jsonrpc":"2.0","method":"net_version","params":[],"id":67}`),
+		},
 		{
 			name:       "params as array of single object",
 			rawPayload: []byte(`{"jsonrpc":"2.0","id":8522963871549545,"method":"eth_getLogs","params":[{"address":["0x1234","0xabcd","0xffff"],"fromBlock":"0x1234567","toBlock":"0xfffffff","topics":[]}]}`),
@@ -22,14 +90,20 @@ func TestUnmarshalParams(t *testing.T) {
 			rawPayload: []byte(`{"jsonrpc":"2.0","id":1949014,"method":"eth_call","params":[{"data":"0x12345678","from":"0x0000000000000000000000000000000000000000","to":"0x12345678abcdef12345678abcdef12345678abcd"},"latest"]}`),
 		},
 		{
-			name:       "params as mix of string and boolean",
-			rawPayload: []byte(`{"id":1,"jsonrpc":"2.0","method":"eth_getBlockByNumber","params":["latest",false]}`),
+			name: "params as mix of string and boolean",
+			// rawPayload is a copy-paste from: https://ethereum.org/en/developers/docs/apis/json-rpc/#eth_getblockbynumber
+			rawPayload: []byte(`{"jsonrpc":"2.0","method":"eth_getBlockByNumber","params":["0x1b4", true],"id":1}`),
 		},
 	}
 
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
 			err := json.Unmarshal(testCase.rawPayload, &Request{})
+			if testCase.expectErr {
+				require.NotNil(t, err)
+				return
+			}
+
 			require.NoError(t, err)
 		})
 	}

--- a/qos/jsonrpc/request_test.go
+++ b/qos/jsonrpc/request_test.go
@@ -94,6 +94,10 @@ func TestUnmarshalParams(t *testing.T) {
 			// rawPayload is a copy-paste from: https://ethereum.org/en/developers/docs/apis/json-rpc/#eth_getblockbynumber
 			rawPayload: []byte(`{"jsonrpc":"2.0","method":"eth_getBlockByNumber","params":["0x1b4", true],"id":1}`),
 		},
+		{
+			name:       "params as an empty object",
+			rawPayload: []byte(`{"jsonrpc":"2.0","method":"eth_chainId","id":1,"params":{}}`),
+		},
 	}
 
 	for _, testCase := range testCases {


### PR DESCRIPTION
## Summary

Improve JSON-RPC parameter validation and request serialization handling

### Primary Changes:
- Enhanced `Params` type validation to properly handle objects and arrays per JSON-RPC 2.0 spec
- Added custom `Request` marshaling to handle empty fields correctly 
- Added `IsEmpty()` method to control omission of optional fields in serialization

### Secondary changes:
- Added comprehensive test cases with examples from Ethereum, Polkadot and Solana docs
- Improved code documentation with detailed parameter type examples
- Updated error messages to be more descriptive## Issue

- Description: `params` field of the JSONRPC requests can be omitted in the request. 

## Type of change

Select one or more from the following:

- [x] New feature, functionality or library
- [ ] Bug fix
- [ ] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## QoS Checklist

- [ ] 1. `make path_up` or `path_up_standalone`
- [ ] 2. Run one of the following:
  - For `path_up_standalone` with `anvil` on `Shannon`: `make test_request__relay_util_1000`
  - For `path_up` with `anvil` on `Shannon`: `make test_request__envoy_relay_util_100`
  - For `path_up` with `F00C` on `Morse`: `make test_request__relay_util_100_F00C_via_envoy`
- [ ] 3. Visit [PATH Relay Grafana Dashboard](http://localhost:3000/d/relays/path-service-requests) to view results

## Sanity Checklist

- [x] I have updated the GitHub Issue `assignees`, `reviewers`, `labels`, `project`, `iteration` and `milestone`
- [ ] For docs, I have run `make docusaurus_start`
- [ ] For code, I have run `make test_all`
- [ ] For configurations, I have update the documentation
- [x] I added TODOs where applicable
