### PR TITLE
[WIP] Trying to run test_request__relay_util_100_F00C_via_envoy

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -192,7 +192,7 @@ if MODE == "path_with_auth":
     k8s_resource(
         "ext-authz",
         labels=["envoy_auth"],
-        port_forwards=["10003:10003"],
+        port_forwards=["50051:50051"],
         resource_deps=["path-auth-data-server", "path-config-updater"],
         trigger_mode=TRIGGER_MODE_AUTO,
     )

--- a/config/config.schema.yaml
+++ b/config/config.schema.yaml
@@ -254,4 +254,4 @@ properties:
       port:
         description: "Port number for the auth server."
         type: integer
-        default: 10003
+        default: 50051

--- a/docusaurus/docs/develop/path/path_config.md
+++ b/docusaurus/docs/develop/path/path_config.md
@@ -319,7 +319,7 @@ Configures the External Authorization Server.
 | `grpc_host_port`                | string  | Yes      | -       | Host and port for the remote gRPC connection to the `Remote gRPC Server` (eg. PADS). Pattern requires a `host:port` format.                                      |
 | `grpc_use_insecure_credentials` | boolean | No       | false   | Set to true if the `Remote gRPC Server` does not use TLS                                                                                                         |
 | `endpoint_id_extractor_type`    | string  | No       | -       | Either `url_path` or `header`. Specifies how endpoint IDs are extracted. [See here for more details](../envoy/walkthrough.md#specifying-the-gateway-endpoint-id) |
-| `port`                          | integer | No       | 10003   | The local port for running the Auth Server                                                                                                                       |
+| `port`                          | integer | No       | 50051   | The local port for running the Auth Server                                                                                                                       |
 
 :::info
 

--- a/envoy/auth_server/config/config.go
+++ b/envoy/auth_server/config/config.go
@@ -14,7 +14,7 @@ import (
 
 const (
 	defaultEndpointIDExtractorType = auth.EndpointIDExtractorTypeURLPath
-	defaultPort                    = 10003
+	defaultPort                    = 50051
 )
 
 var grpcHostPortPattern = "^[^:]+:[0-9]+$"

--- a/envoy/auth_server/config/config_test.go
+++ b/envoy/auth_server/config/config_test.go
@@ -32,7 +32,7 @@ func Test_LoadAuthServerConfigFromYAML(t *testing.T) {
 auth_server_config:
   grpc_use_insecure_credentials: true
   endpoint_id_extractor_type: "url_path"
-  port: 10003
+  port: 50051
 `,
 			wantErr: true,
 		},
@@ -43,7 +43,7 @@ auth_server_config:
   grpc_host_port: "invalid_host_port"
   grpc_use_insecure_credentials: true
   endpoint_id_extractor_type: "url_path"
-  port: 10003
+  port: 50051
 `,
 			wantErr: true,
 		},

--- a/envoy/envoy.template.yaml
+++ b/envoy/envoy.template.yaml
@@ -53,7 +53,7 @@ static_resources:
                   address:
                     socket_address:
                       address: ext-authz
-                      port_value: 10003
+                      port_value: 50051
 
     # Cluster for the rate-limiting service.
     - name: ratelimit

--- a/local/kubernetes/envoy-ext-authz.yaml
+++ b/local/kubernetes/envoy-ext-authz.yaml
@@ -20,7 +20,7 @@ spec:
               mountPath: /app/config/.config.yaml
               subPath: .config.yaml
           ports:
-            - containerPort: 10003
+            - containerPort: 50051
       volumes:
         - name: path-config-local
           secret:
@@ -32,8 +32,8 @@ metadata:
   name: ext-authz
 spec:
   ports:
-    - port: 10003
-      targetPort: 10003
+    - port: 50051
+      targetPort: 50051
   selector:
     app: ext-authz
   type: ClusterIP

--- a/makefiles/test_requests.mk
+++ b/makefiles/test_requests.mk
@@ -173,5 +173,5 @@ test_request__relay_util_100_F00C_via_envoy: check_path_up_with_envoy check_rela
 		-H "target-service-id: F00C" \
 		-H "authorization: api_key_1" \
 		-d '{"jsonrpc":"2.0","method":"eth_blockNumber","id":1}' \
-		-x 1000 \
+		-x 100 \
 		-b


### PR DESCRIPTION
## Summary

Reproduction steps:

cp `[PATH] Morse Beta TestNet E2E Config (`./e2e/.morse.config.yam` into ./local/path/config/.config.yaml

```
make path_up
test_request__relay_util_100_F00C_via_envoy
```

Potential Issue:

![Screenshot 2025-03-06 at 10 27 15 AM](https://github.com/user-attachments/assets/366f4f0c-235c-4435-9346-506a71d9b34e)

Result:

![Screenshot 2025-03-06 at 10 30 51 AM](https://github.com/user-attachments/assets/13647e18-5c02-419f-a319-3975b9614047)


Changes:

- < Change 1 >
- < Change 2 >

## Issue

- Description: < Description >
- Issue: #{ISSUE_NUMBER}

## Type of change

Select one or more from the following:

- [ ] New feature, functionality or library
- [ ] Bug fix
- [ ] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## QoS Checklist

- [ ] 1. `make path_up` or `path_up_standalone`
- [ ] 2. Run one of the following:
  - For `path_up_standalone` with `anvil` on `Shannon`: `make test_request__relay_util_1000`
  - For `path_up` with `anvil` on `Shannon`: `make test_request__envoy_relay_util_100`
  - For `path_up` with `F00C` on `Morse`: `make test_request__relay_util_100_F00C_via_envoy`
- [ ] 3. Visit [PATH Relay Grafana Dashboard](http://localhost:3000/d/relays/path-service-requests) to view results

## Sanity Checklist

- [ ] I have updated the GitHub Issue `assignees`, `reviewers`, `labels`, `project`, `iteration` and `milestone`
- [ ] For docs, I have run `make docusaurus_start`
- [ ] For code, I have run `make test_all`
- [ ] For configurations, I have update the documentation
- [ ] I added TODOs where applicable
