### PR TITLE
Remove ArgoCD broken status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@
 ![GitHub Issues or Pull Requests](https://img.shields.io/github/issues/buildwithgrove/path)
 ![GitHub Issues or Pull Requests](https://img.shields.io/github/issues-pr/buildwithgrove/path)
 ![GitHub Issues or Pull Requests](https://img.shields.io/github/issues-closed/buildwithgrove/path)
-![App Status](https://argocd.tooling.buildintheshade.com/api/badge?name=path-gateway&revision=true&showAppName=true)
 
 ## Overview
 


### PR DESCRIPTION
## Summary

Remove ArgoCD status badge from README

Changes:

- `README.md`

## Issue

N/A

## Type of change

Select one or more from the following:

- [ ] New feature, functionality or library
- [X] Bug fix
- [ ] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## QoS Checklist

- [ ] 1. `make path_up` or `path_up_standalone`
- [ ] 2. Run one of the following:
  - For `path_up_standalone` with `anvil` on `Shannon`: `make test_request__relay_util_1000`
  - For `path_up` with `anvil` on `Shannon`: `make test_request__envoy_relay_util_100`
  - For `path_up` with `F00C` on `Morse`: `make test_request__relay_util_100_F00C_via_envoy`
- [ ] 3. Visit [PATH Relay Grafana Dashboard](http://localhost:3000/d/relays/path-service-requests) to view results

## Sanity Checklist

- [ ] I have updated the GitHub Issue `assignees`, `reviewers`, `labels`, `project`, `iteration` and `milestone`
- [ ] For docs, I have run `make docusaurus_start`
- [ ] For code, I have run `make test_all`
- [ ] For configurations, I have update the documentation
- [ ] I added TODOs where applicable
