### PR TITLE
feat(local/scripts/shannon_populate_config.sh): improve path discovery for shannon config + improve doc

### DIFF
--- a/docusaurus/docs/develop/path/cheat_sheet_shannon.md
+++ b/docusaurus/docs/develop/path/cheat_sheet_shannon.md
@@ -134,6 +134,14 @@ Run the following command to generate a Shannon config at `local/path/config/.co
 make shannon_populate_config
 ```
 
+:::important Command configuration
+This command relies on `poktrolld` command line interface to export the Gateway and Application address from your keyring backend.
+
+To override the keyring backend, you can export the `POKTROLL_TEST_KEYRING_BACKEND` environment variable (default 'test').
+
+To override the poktrolld home directory, you can export the `POKTROLL_HOME_PROD` environment variable (default '$HOME').
+:::
+
 Note that running `make shannon_populate_config` is equivalent to running the following commands:
 
 ```bash

--- a/local/scripts/shannon_populate_config.sh
+++ b/local/scripts/shannon_populate_config.sh
@@ -7,7 +7,7 @@ CONFIG_FILE="./local/path/.config.yaml"
 
 # Wrapper function for poktrolld with overridden flags
 pkd() {
-    poktrolld --keyring-backend="${POKTROLL_TEST_KEYRING_BACKEND:-test}" --home="${POKTROLL_HOME_PROD:-/Users/$(whoami)/.poktroll}" "$@"
+    poktrolld --keyring-backend="${POKTROLL_TEST_KEYRING_BACKEND:-test}" --home="${POKTROLL_HOME_PROD:-${HOME}/.poktroll}" "$@"
 }
 
 # Function to check if a command exists on the system


### PR DESCRIPTION
## Summary

This PR improves the automatic home path discovery for `poktrolld` when executing the shannon configuration generator (using `make shannon_populate_config`), and adds more information into the documentation to override the poktrolld home directory and the keyring backend to use.

## Issue

- Issue: #154 

## Type of change

Select one or more from the following:

- [x] New feature, functionality or library
- [ ] Bug fix
- [ ] Code health or cleanup
- [x] Documentation
- [ ] Other (specify)

## QoS Checklist

- [ ] 1. `make path_up` or `make path_run`
- [ ] 2. Run one of the following:
  - For `path_run` with `anvil` on `Shannon`: `make test_request__relay_util_1000`
  - For `path_up` with `anvil` on `Shannon`: `make test_request__envoy_relay_util_100`
  - For `path_up` with `F00C` on `Morse`: `make test_request__relay_util_100_F00C_via_envoy`
- [ ] 3. Visit [PATH Relay Grafana Dashboard](http://localhost:3000/d/relays/path-service-requests) to view results

## Sanity Checklist

- [ ] I have updated the GitHub Issue `assignees`, `reviewers`, `labels`, `project`, `iteration` and `milestone`
- [ ] For docs, I have run `make docusaurus_start`
- [ ] For code, I have run `make test_all`
- [ ] For configurations, I have update the documentation
- [ ] I added TODOs where applicable
