### PR TITLE
docs(`chea_sheet_shannon`): remove `pkd` alias for `poktrolld` full name in docs

### DIFF
--- a/docusaurus/docs/develop/path/cheat_sheet_shannon.md
+++ b/docusaurus/docs/develop/path/cheat_sheet_shannon.md
@@ -63,8 +63,8 @@ EOF
 **Create gateway and application accounts in your keyring**
 
 ```bash
-pkd keys add gateway
-pkd keys add application
+poktrolld keys add gateway
+poktrolld keys add application
 ```
 
 Fund the accounts by visiting the tools & faucets [here](https://dev.poktroll.com/explore/tools).
@@ -72,8 +72,8 @@ Fund the accounts by visiting the tools & faucets [here](https://dev.poktroll.co
 For **Grove employees only**, you can manually fund the accounts:
 
 ```bash
-pkd_beta_tx tx bank send faucet_beta $(pkd keys show -a application) 6900000000042upokt
-pkd_beta_tx tx bank send faucet_beta $(pkd keys show -a gateway) 6900000000042upokt
+pkd_beta_tx tx bank send faucet_beta $(poktrolld keys show -a application) 6900000000042upokt
+pkd_beta_tx tx bank send faucet_beta $(poktrolld keys show -a gateway) 6900000000042upokt
 ```
 
 **Stake the gateway:**
@@ -118,10 +118,10 @@ You can validate it like so:
 poktrolld keys list
 
 # Gateway only
-pkd keys show -a gateway
+poktrolld keys show -a gateway
 
 # Application only
-pkd keys show -a application
+poktrolld keys show -a application
 ```
 
 ## 2. Configure PATH for Shannon


### PR DESCRIPTION
## Summary

This PR removes `pkd` alias for `poktrolld` for clarity purposes.
## Issue

- Issue: #154 

## Type of change

Select one or more from the following:

- [ ] New feature, functionality or library
- [ ] Bug fix
- [ ] Code health or cleanup
- [x] Documentation
- [ ] Other (specify)

## QoS Checklist

- [ ] 1. `make path_up` or `make path_run`
- [ ] 2. Run one of the following:
  - For `path_run` with `anvil` on `Shannon`: `make test_request__relay_util_1000`
  - For `path_up` with `anvil` on `Shannon`: `make test_request__envoy_relay_util_100`
  - For `path_up` with `F00C` on `Morse`: `make test_request__relay_util_100_F00C_via_envoy`
- [ ] 3. Visit [PATH Relay Grafana Dashboard](http://localhost:3000/d/relays/path-service-requests) to view results

## Sanity Checklist

- [ ] I have updated the GitHub Issue `assignees`, `reviewers`, `labels`, `project`, `iteration` and `milestone`
- [ ] For docs, I have run `make docusaurus_start`
- [ ] For code, I have run `make test_all`
- [ ] For configurations, I have update the documentation
- [ ] I added TODOs where applicable
