### PR TITLE
[Bug][QoS] Fix race condition in hydrator by creating a new request context per request to ensure correct endpoint selection and observation application.


### DIFF
--- a/gateway/hydrator.go
+++ b/gateway/hydrator.go
@@ -141,6 +141,24 @@ func (eph *EndpointHydrator) performChecks(serviceID protocol.ServiceID, service
 		return err
 	}
 
+	// TODO_REFACTOR(@adshmh): Unify protocol interface across gateway and hydrator:
+	// 1. Modify `gateway.Protocol`:
+	//   - Add: `AvailableEndpoints(ServiceID, http.Request) []protocol.EndpointAddr`
+	//   - Remove: `BuildRequestContext()`
+	//   - Add: `BuildRequestContextForEndpoint(ServiceID, protocol.EndpointAddr)`
+	// 2. Update `gateway.ProtocolRequestContext`:
+	//   - Remove: `SelectEndpoint()` and `AvailableEndpoints()`
+	// 3. In Hydrator:
+	//   - Get endpoints: `protocol.AvailableEndpoints(svcID, nil)`
+	//   - For each endpoint: `BuildRequestContextForEndpointAddr(svcID, endpointAddr)`
+	// 4. In Gateway:
+	//   - Get endpoints: `protocol.AvailableEndpoints(svcID, nil)`
+	//   - Select endpoint: `qos.SelectEndpoint(availableEndpoints)`
+	//   - Build context: `BuildRequestContextForEndpointAddr(svcID, selectedEndpointAddr)`
+	// Benefits:
+	//   - Single protocol entry point
+	//   - Consistent usage in both Hydrator and Gateway
+	//   - Explicit QoS endpoint selection in Gateway code
 	uniqueEndpoints, err := protocolRequestCtx.AvailableEndpoints()
 	if err != nil {
 		logger.Warn().Err(err).Msg("Failed to get the list of available endpoints")

--- a/gateway/hydrator.go
+++ b/gateway/hydrator.go
@@ -191,7 +191,7 @@ func (eph *EndpointHydrator) performChecks(serviceID protocol.ServiceID, service
 				for _, serviceRequestCtx := range requiredQoSChecks {
 					// Create a new protocol request context with a pre-selected endpoint for each request.
 					// This is to avoid race conditions or concurrent access problems when running concurrent QoS checks.
-					hydratorRequestCtx, err := eph.Protocol.BuildHydratorRequestContextForEndpoint(serviceID, endpoint.Addr())
+					hydratorRequestCtx, err := eph.Protocol.BuildRequestContextForEndpoint(serviceID, endpoint.Addr())
 					if err != nil {
 						logger.Error().Err(err).Msg("Failed to build a protocol request context for the endpoint")
 						continue

--- a/gateway/hydrator.go
+++ b/gateway/hydrator.go
@@ -164,7 +164,7 @@ func (eph *EndpointHydrator) performChecks(serviceID protocol.ServiceID, service
 				endpointLogger.Info().Msg("running checks against the endpoint")
 
 				// Retrieve all the required QoS checks for the endpoint.
-				requiredQoSChecks := serviceQoS.GetRequiredQualityChecks(endpoint.Addr())
+				requiredQoSChecks := serviceQoS.GetRequiredQualityChecks()
 				if len(requiredQoSChecks) == 0 {
 					endpointLogger.Warn().Msg("service QoS returned 0 required checks")
 					continue

--- a/gateway/hydrator.go
+++ b/gateway/hydrator.go
@@ -182,7 +182,7 @@ func (eph *EndpointHydrator) performChecks(serviceID protocol.ServiceID, service
 				endpointLogger.Info().Msg("running checks against the endpoint")
 
 				// Retrieve all the required QoS checks for the endpoint.
-				requiredQoSChecks := serviceQoS.GetRequiredQualityChecks()
+				requiredQoSChecks := serviceQoS.GetRequiredQualityChecks(endpoint.Addr())
 				if len(requiredQoSChecks) == 0 {
 					endpointLogger.Warn().Msg("service QoS returned 0 required checks")
 					continue

--- a/gateway/protocol.go
+++ b/gateway/protocol.go
@@ -17,9 +17,8 @@ type Protocol interface {
 	// request, which matches the provided Service ID.
 	BuildRequestContext(protocol.ServiceID, *http.Request) (ProtocolRequestContext, error)
 
-	// BuildHydratorRequestContextForEndpoint builds and returns a ProtocolRequestContext interface
-	// for handling a single service request, which matches the provided Service ID and Endpoint.
-	// This method is used only in the hydrator to allow performing QoS checks on a specific pre-selected endpoint.
+	// BuildHydratorRequestContextForEndpoint builds and returns a ProtocolRequestContext containing only a single possible endpoint.
+	// This method is used to build a request context for the hydrator and enforces performing QoS checks on a single endpoint.
 	BuildHydratorRequestContextForEndpoint(protocol.ServiceID, protocol.EndpointAddr) (ProtocolRequestContext, error)
 
 	// SupportedGamewayModes returns the Gateway modes supported by the protocol instance.

--- a/gateway/protocol.go
+++ b/gateway/protocol.go
@@ -17,9 +17,9 @@ type Protocol interface {
 	// request, which matches the provided Service ID.
 	BuildRequestContext(protocol.ServiceID, *http.Request) (ProtocolRequestContext, error)
 
-	// BuildHydratorRequestContextForEndpoint builds and returns a ProtocolRequestContext containing only a single possible endpoint.
+	// BuildRequestContextForEndpoint builds and returns a ProtocolRequestContext containing only a single possible endpoint.
 	// This method is used to build a request context for the hydrator and enforces performing QoS checks on a single endpoint.
-	BuildHydratorRequestContextForEndpoint(protocol.ServiceID, protocol.EndpointAddr) (ProtocolRequestContext, error)
+	BuildRequestContextForEndpoint(protocol.ServiceID, protocol.EndpointAddr) (ProtocolRequestContext, error)
 
 	// SupportedGamewayModes returns the Gateway modes supported by the protocol instance.
 	// See protocol/gateway_mode.go for more details.

--- a/gateway/protocol.go
+++ b/gateway/protocol.go
@@ -18,10 +18,10 @@ type Protocol interface {
 	BuildRequestContext(protocol.ServiceID, *http.Request) (ProtocolRequestContext, error)
 
 	// BuildRequestContextForEndpoint builds and returns a ProtocolRequestContext containing only a single possible endpoint.
-	// This method is used to build a request context for the hydrator and enforces performing QoS checks on a single endpoint.
+	// Used to build a request context for the hydrator and enforces performing QoS checks on a single endpoint.
 	BuildRequestContextForEndpoint(protocol.ServiceID, protocol.EndpointAddr) (ProtocolRequestContext, error)
 
-	// SupportedGamewayModes returns the Gateway modes supported by the protocol instance.
+	// SupportedGatewayModes returns the Gateway modes supported by the protocol instance.
 	// See protocol/gateway_mode.go for more details.
 	SupportedGatewayModes() []protocol.GatewayMode
 

--- a/gateway/protocol.go
+++ b/gateway/protocol.go
@@ -17,6 +17,11 @@ type Protocol interface {
 	// request, which matches the provided Service ID.
 	BuildRequestContext(protocol.ServiceID, *http.Request) (ProtocolRequestContext, error)
 
+	// BuildHydratorRequestContextForEndpoint builds and returns a ProtocolRequestContext interface
+	// for handling a single service request, which matches the provided Service ID and Endpoint.
+	// This method is used only in the hydrator to allow performing QoS checks on a specific pre-selected endpoint.
+	BuildHydratorRequestContextForEndpoint(protocol.ServiceID, protocol.EndpointAddr) (ProtocolRequestContext, error)
+
 	// SupportedGamewayModes returns the Gateway modes supported by the protocol instance.
 	// See protocol/gateway_mode.go for more details.
 	SupportedGatewayModes() []protocol.GatewayMode

--- a/gateway/qos.go
+++ b/gateway/qos.go
@@ -84,11 +84,9 @@ type QoSEndpointCheckGenerator interface {
 	//
 	// GetRequiredQualityChecks returns the set of quality checks required by
 	// the a QoS instance to assess the validity of an endpoint.
-	// The endpoint address is passed here because it allows the QoS instance to
-	// make a decision based on the specific endpoint.
-	// e.g. An EVM-based blockchain service QoS may decide to skip quering an endpoint on
+	// e.g. An EVM-based blockchain service QoS may decide to skip querying an endpoint on
 	// its current block height if it has already failed the chain ID check.
-	GetRequiredQualityChecks(protocol.EndpointAddr) []RequestQoSContext
+	GetRequiredQualityChecks() []RequestQoSContext
 }
 
 // TODO_IMPLEMENT: Add one QoS instance per service that is to be supported by the gateway, implementing the QoSService interface below.

--- a/gateway/qos.go
+++ b/gateway/qos.go
@@ -86,7 +86,7 @@ type QoSEndpointCheckGenerator interface {
 	// the a QoS instance to assess the validity of an endpoint.
 	// e.g. An EVM-based blockchain service QoS may decide to skip querying an endpoint on
 	// its current block height if it has already failed the chain ID check.
-	GetRequiredQualityChecks() []RequestQoSContext
+	GetRequiredQualityChecks(protocol.EndpointAddr) []RequestQoSContext
 }
 
 // TODO_IMPLEMENT: Add one QoS instance per service that is to be supported by the gateway, implementing the QoSService interface below.

--- a/protocol/morse/protocol.go
+++ b/protocol/morse/protocol.go
@@ -114,11 +114,10 @@ func (p *Protocol) BuildRequestContext(
 }
 
 // BuildHydratorRequestContextForEndpoint builds a new request context for a given service ID and endpoint address.
-// This method is used only in the hydrator to allow performing QoS checks on a specific pre-selected endpoint.
-// The QoS EndpointSelector will select only the provided endpoint and the hydrator will use this method to build a request context for the endpoint.
+// This method is used only in the hydrator to enforce performing QoS checks on a specific pre-selected endpoint.
 func (p *Protocol) BuildHydratorRequestContextForEndpoint(
 	serviceID protocol.ServiceID,
-	preselectedEndpointAddr protocol.EndpointAddr,
+	preSelectedEndpointAddr protocol.EndpointAddr,
 ) (gateway.ProtocolRequestContext, error) {
 	endpoints, err := p.getEndpoints(serviceID)
 	if err != nil {
@@ -131,14 +130,14 @@ func (p *Protocol) BuildHydratorRequestContextForEndpoint(
 		"component", "request_context",
 	)
 
-	preselectedEndpoint, ok := endpoints[preselectedEndpointAddr]
+	preselectedEndpoint, ok := endpoints[preSelectedEndpointAddr]
 	if !ok {
-		return nil, fmt.Errorf("BuildHydratorRequestContextForEndpoint: no pre-selected endpoint found for service %s and endpoint address %s", serviceID, preselectedEndpointAddr)
+		return nil, fmt.Errorf("BuildHydratorRequestContextForEndpoint: no pre-selected endpoint found for service %s and endpoint address %s", serviceID, preSelectedEndpointAddr)
 	}
 
-	// Create an endpoint map containing only the selected endpoint
+	// Create an endpoint map containing only the selected endpoint to ensure the QoS check is performed on the selected endpoint.
 	preselectedEndpointMap := map[protocol.EndpointAddr]endpoint{
-		preselectedEndpointAddr: preselectedEndpoint,
+		preSelectedEndpointAddr: preselectedEndpoint,
 	}
 
 	// Return new request context with fullNode, endpointStore, and logger

--- a/protocol/morse/protocol.go
+++ b/protocol/morse/protocol.go
@@ -145,6 +145,7 @@ func (p *Protocol) BuildRequestContextForEndpoint(
 		logger:                   ctxLogger,
 		fullNode:                 p.fullNode,
 		sanctionedEndpointsStore: p.sanctionedEndpointsStore,
+		selectedEndpoint:         &preselectedEndpoint,
 		endpoints:                preselectedEndpointMap,
 		serviceID:                serviceID,
 	}, nil

--- a/protocol/morse/protocol.go
+++ b/protocol/morse/protocol.go
@@ -87,21 +87,22 @@ type Protocol struct {
 
 // BuildRequestContext builds a new request context for a given service ID.
 // The request context contains all the information needed to process a single service request.
+//
 // Implements the gateway.Protocol interface.
 func (p *Protocol) BuildRequestContext(
 	serviceID protocol.ServiceID,
 	_ *http.Request,
 ) (gateway.ProtocolRequestContext, error) {
-	endpoints, err := p.getEndpoints(serviceID)
-	if err != nil {
-		return nil, fmt.Errorf("BuildRequestContext: error getting endpoints for service %s: %w", serviceID, err)
-	}
-
 	// Create a logger specifically for this request context
 	ctxLogger := p.logger.With(
 		"service_id", string(serviceID),
 		"component", "request_context",
 	)
+
+	endpoints, err := p.getEndpoints(serviceID)
+	if err != nil {
+		return nil, fmt.Errorf("BuildRequestContext: error getting endpoints for service %s: %w", serviceID, err)
+	}
 
 	// Return new request context with fullNode, endpointStore, and logger
 	return &requestContext{
@@ -114,33 +115,41 @@ func (p *Protocol) BuildRequestContext(
 }
 
 // BuildRequestContextForEndpoint builds a new request context for a given service ID and endpoint address.
-// This method is used only in the hydrator to enforce performing QoS checks on a specific pre-selected endpoint.
+//
+// DEV_NOTE: This method is **intended** to only be used in the hydrator to enforce performing QoS checks on a specific pre-selected endpoint.
+//
+// Implements the gateway.Protocol interface.
 func (p *Protocol) BuildRequestContextForEndpoint(
 	serviceID protocol.ServiceID,
 	preSelectedEndpointAddr protocol.EndpointAddr,
 ) (gateway.ProtocolRequestContext, error) {
+	// Create a logger specifically for this request context
+	ctxLogger := p.logger.With(
+		"service_id", string(serviceID),
+		"component", "request_context_for_endpoint",
+	)
+
+	// Retrieve the list of endpoints (i.e. backend service URLs by external operators)
+	// that can service RPC requests for the given service ID.
 	endpoints, err := p.getEndpoints(serviceID)
 	if err != nil {
 		return nil, fmt.Errorf("BuildRequestContextForEndpoint: error getting endpoints for service %s: %w", serviceID, err)
 	}
 
-	// Create a logger specifically for this request context
-	ctxLogger := p.logger.With(
-		"service_id", string(serviceID),
-		"component", "request_context",
-	)
-
+	// Select the endpoint that matches the pre-selected address.
+	// This ensures QoS checks are performed on the selected endpoint.
 	preselectedEndpoint, ok := endpoints[preSelectedEndpointAddr]
 	if !ok {
 		return nil, fmt.Errorf("BuildRequestContextForEndpoint: no pre-selected endpoint found for service %s and endpoint address %s", serviceID, preSelectedEndpointAddr)
 	}
 
-	// Create an endpoint map containing only the selected endpoint to ensure the QoS check is performed on the selected endpoint.
+	// Create an endpoint map containing only the selected endpoint to ensure
+	// the QoS check is performed on the selected endpoint.
 	preselectedEndpointMap := map[protocol.EndpointAddr]endpoint{
 		preSelectedEndpointAddr: preselectedEndpoint,
 	}
 
-	// Return new request context with fullNode, endpointStore, and logger
+	// Return new request context for the pre-selected endpoint
 	return &requestContext{
 		logger:                   ctxLogger,
 		fullNode:                 p.fullNode,

--- a/protocol/morse/protocol.go
+++ b/protocol/morse/protocol.go
@@ -113,15 +113,15 @@ func (p *Protocol) BuildRequestContext(
 	}, nil
 }
 
-// BuildHydratorRequestContextForEndpoint builds a new request context for a given service ID and endpoint address.
+// BuildRequestContextForEndpoint builds a new request context for a given service ID and endpoint address.
 // This method is used only in the hydrator to enforce performing QoS checks on a specific pre-selected endpoint.
-func (p *Protocol) BuildHydratorRequestContextForEndpoint(
+func (p *Protocol) BuildRequestContextForEndpoint(
 	serviceID protocol.ServiceID,
 	preSelectedEndpointAddr protocol.EndpointAddr,
 ) (gateway.ProtocolRequestContext, error) {
 	endpoints, err := p.getEndpoints(serviceID)
 	if err != nil {
-		return nil, fmt.Errorf("BuildHydratorRequestContextForEndpoint: error getting endpoints for service %s: %w", serviceID, err)
+		return nil, fmt.Errorf("BuildRequestContextForEndpoint: error getting endpoints for service %s: %w", serviceID, err)
 	}
 
 	// Create a logger specifically for this request context
@@ -132,7 +132,7 @@ func (p *Protocol) BuildHydratorRequestContextForEndpoint(
 
 	preselectedEndpoint, ok := endpoints[preSelectedEndpointAddr]
 	if !ok {
-		return nil, fmt.Errorf("BuildHydratorRequestContextForEndpoint: no pre-selected endpoint found for service %s and endpoint address %s", serviceID, preSelectedEndpointAddr)
+		return nil, fmt.Errorf("BuildRequestContextForEndpoint: no pre-selected endpoint found for service %s and endpoint address %s", serviceID, preSelectedEndpointAddr)
 	}
 
 	// Create an endpoint map containing only the selected endpoint to ensure the QoS check is performed on the selected endpoint.

--- a/protocol/shannon/context.go
+++ b/protocol/shannon/context.go
@@ -33,8 +33,11 @@ type RelayRequestSigner interface {
 
 // requestContext captures all the data required for handling a single service request.
 type requestContext struct {
-	fullNode           FullNode
-	serviceID          protocol.ServiceID
+	fullNode FullNode
+	// TODO_TECHDEBT(@adshmh): add sanctionedEndpointsStore to the request context.
+	serviceID protocol.ServiceID
+	// TODO_TECHDEBT(@adshmh): add logger to the request context.
+
 	relayRequestSigner RelayRequestSigner
 
 	// endpoints contains all the candidate endpoints available for processing a service request.
@@ -42,6 +45,8 @@ type requestContext struct {
 	// selectedEndpoint is the endpoint that has been selected for sending a relay.
 	// Sending a relay will fail if this field is not set through a call to the SelectEndpoint method.
 	selectedEndpoint *endpoint
+
+	// TODO_TECHDEBT(@adshmh): add endpointObservations to the request context.
 }
 
 // SelectEndpoint satisfies the gateway package's ProtocolRequestContext interface.

--- a/protocol/shannon/mode_centralized.go
+++ b/protocol/shannon/mode_centralized.go
@@ -54,7 +54,7 @@ func appIsStakedForService(serviceID protocol.ServiceID, app *apptypes.Applicati
 
 // getCentralizedGatewayModeApps returns the set of permitted apps under the Centralized gateway mode.
 func (p *Protocol) getCentralizedGatewayModeApps(ctx context.Context, serviceID protocol.ServiceID) ([]*apptypes.Application, error) {
-	logger := p.Logger.With(
+	logger := p.logger.With(
 		"service_id", string(serviceID),
 		"gateway_addr", p.gatewayAddr,
 		"gateway_mode", protocol.GatewayModeCentralized,

--- a/protocol/shannon/protocol.go
+++ b/protocol/shannon/protocol.go
@@ -162,6 +162,7 @@ func (p *Protocol) BuildRequestContextForEndpoint(
 	return &requestContext{
 		fullNode:           p.FullNode,
 		endpoints:          preselectedEndpointMap,
+		selectedEndpoint:   &preselectedEndpoint,
 		serviceID:          serviceID,
 		relayRequestSigner: permittedSigner,
 	}, nil

--- a/protocol/shannon/protocol.go
+++ b/protocol/shannon/protocol.go
@@ -128,25 +128,25 @@ func (p *Protocol) BuildRequestContext(
 	}, nil
 }
 
-// BuildHydratorRequestContextForEndpoint builds a new request context for a given service ID and endpoint address.
+// BuildRequestContextForEndpoint builds a new request context for a given service ID and endpoint address.
 // This method is used only in the hydrator to enforce performing QoS checks on a specific pre-selected endpoint.
-func (p *Protocol) BuildHydratorRequestContextForEndpoint(
+func (p *Protocol) BuildRequestContextForEndpoint(
 	serviceID protocol.ServiceID,
 	preSelectedEndpointAddr protocol.EndpointAddr,
 ) (gateway.ProtocolRequestContext, error) {
 	permittedApps, err := p.getGatewayModePermittedApps(context.TODO(), serviceID, nil)
 	if err != nil {
-		return nil, fmt.Errorf("BuildHydratorRequestContextForEndpoint: error building the permitted apps list for service %s gateway mode %s: %w", serviceID, p.gatewayMode, err)
+		return nil, fmt.Errorf("BuildRequestContextForEndpoint: error building the permitted apps list for service %s gateway mode %s: %w", serviceID, p.gatewayMode, err)
 	}
 
 	endpoints, err := p.getAppsUniqueEndpoints(serviceID, permittedApps)
 	if err != nil {
-		return nil, fmt.Errorf("BuildHydratorRequestContextForEndpoint: error getting endpoints for service %s: %w", serviceID, err)
+		return nil, fmt.Errorf("BuildRequestContextForEndpoint: error getting endpoints for service %s: %w", serviceID, err)
 	}
 
 	preselectedEndpoint, ok := endpoints[preSelectedEndpointAddr]
 	if !ok {
-		return nil, fmt.Errorf("BuildHydratorRequestContextForEndpoint: no pre-selected endpoint found for service %s and endpoint address %s", serviceID, preSelectedEndpointAddr)
+		return nil, fmt.Errorf("BuildRequestContextForEndpoint: no pre-selected endpoint found for service %s and endpoint address %s", serviceID, preSelectedEndpointAddr)
 	}
 
 	// Create an endpoint map containing only the selected endpoint to ensure the QoS check is performed on the selected endpoint.
@@ -156,7 +156,7 @@ func (p *Protocol) BuildHydratorRequestContextForEndpoint(
 
 	permittedSigner, err := p.getGatewayModePermittedRelaySigner(p.gatewayMode)
 	if err != nil {
-		return nil, fmt.Errorf("BuildHydratorRequestContextForEndpoint: error getting the permitted signer for gateway mode %s: %w", p.gatewayMode, err)
+		return nil, fmt.Errorf("BuildRequestContextForEndpoint: error getting the permitted signer for gateway mode %s: %w", p.gatewayMode, err)
 	}
 
 	return &requestContext{

--- a/protocol/shannon/protocol.go
+++ b/protocol/shannon/protocol.go
@@ -129,11 +129,10 @@ func (p *Protocol) BuildRequestContext(
 }
 
 // BuildHydratorRequestContextForEndpoint builds a new request context for a given service ID and endpoint address.
-// This method is used only in the hydrator to allow performing QoS checks on a specific pre-selected endpoint.
-// The QoS EndpointSelector will select only the provided endpoint and the hydrator will use this method to build a request context for the endpoint.
+// This method is used only in the hydrator to enforce performing QoS checks on a specific pre-selected endpoint.
 func (p *Protocol) BuildHydratorRequestContextForEndpoint(
 	serviceID protocol.ServiceID,
-	preselectedEndpointAddr protocol.EndpointAddr,
+	preSelectedEndpointAddr protocol.EndpointAddr,
 ) (gateway.ProtocolRequestContext, error) {
 	permittedApps, err := p.getGatewayModePermittedApps(context.TODO(), serviceID, nil)
 	if err != nil {
@@ -145,14 +144,14 @@ func (p *Protocol) BuildHydratorRequestContextForEndpoint(
 		return nil, fmt.Errorf("BuildHydratorRequestContextForEndpoint: error getting endpoints for service %s: %w", serviceID, err)
 	}
 
-	preselectedEndpoint, ok := endpoints[preselectedEndpointAddr]
+	preselectedEndpoint, ok := endpoints[preSelectedEndpointAddr]
 	if !ok {
-		return nil, fmt.Errorf("BuildHydratorRequestContextForEndpoint: no pre-selected endpoint found for service %s and endpoint address %s", serviceID, preselectedEndpointAddr)
+		return nil, fmt.Errorf("BuildHydratorRequestContextForEndpoint: no pre-selected endpoint found for service %s and endpoint address %s", serviceID, preSelectedEndpointAddr)
 	}
 
-	// Create an endpoint map containing only the selected endpoint
+	// Create an endpoint map containing only the selected endpoint to ensure the QoS check is performed on the selected endpoint.
 	preselectedEndpointMap := map[protocol.EndpointAddr]endpoint{
-		preselectedEndpointAddr: preselectedEndpoint,
+		preSelectedEndpointAddr: preselectedEndpoint,
 	}
 
 	permittedSigner, err := p.getGatewayModePermittedRelaySigner(p.gatewayMode)

--- a/protocol/shannon/protocol.go
+++ b/protocol/shannon/protocol.go
@@ -49,6 +49,8 @@ func NewProtocol(
 	fullNode FullNode,
 	config GatewayConfig,
 ) (*Protocol, error) {
+	shannonLogger := logger.With("protocol", "shannon")
+
 	// Derive the address of apps owned by the gateway operator using the supplied apps' private keys.
 	// This only applies to Centralized gateway mode and needs to be done during initialization to ensure it is possible to send relays in Centralized mode.
 	ownedAppsAddr, err := getCentralizedModeOwnedAppsAddr(config.OwnedAppsPrivateKeysHex)
@@ -62,7 +64,7 @@ func NewProtocol(
 	}
 
 	return &Protocol{
-		Logger: logger,
+		logger: shannonLogger,
 
 		FullNode: fullNode,
 
@@ -78,7 +80,7 @@ func NewProtocol(
 
 // Protocol provides the functionality needed by the gateway package for sending a relay to a specific endpoint.
 type Protocol struct {
-	Logger polylog.Logger
+	logger polylog.Logger
 	FullNode
 
 	// gatewayMode is the gateway mode in which the current instance of the Shannon protocol integration operates.
@@ -99,6 +101,8 @@ type Protocol struct {
 }
 
 // BuildRequestContext builds and returns a Shannon-specific request context, which can be used to send relays.
+//
+// Implements the gateway.Protocol interface.
 func (p *Protocol) BuildRequestContext(
 	serviceID protocol.ServiceID,
 	httpReq *http.Request,
@@ -129,36 +133,48 @@ func (p *Protocol) BuildRequestContext(
 }
 
 // BuildRequestContextForEndpoint builds a new request context for a given service ID and endpoint address.
-// This method is used only in the hydrator to enforce performing QoS checks on a specific pre-selected endpoint.
+//
+// DEV_NOTE: This method is **intended** to only be used in the hydrator to enforce performing QoS checks on a specific pre-selected endpoint.
+//
+// Implements the gateway.Protocol interface.
 func (p *Protocol) BuildRequestContextForEndpoint(
 	serviceID protocol.ServiceID,
 	preSelectedEndpointAddr protocol.EndpointAddr,
 ) (gateway.ProtocolRequestContext, error) {
+	// TODO_TECHDEBT: Assuming that the gateway is operating in Centralized mode, which is why we can pass in a nil request.
+	// Retrieve the list of applications this gateway can relay on behalf of for the given service ID.
 	permittedApps, err := p.getGatewayModePermittedApps(context.TODO(), serviceID, nil)
 	if err != nil {
 		return nil, fmt.Errorf("BuildRequestContextForEndpoint: error building the permitted apps list for service %s gateway mode %s: %w", serviceID, p.gatewayMode, err)
 	}
 
+	// Retrieve the list of endpoints (i.e. backend service URLs by external operators)
+	// that can service RPC requests for the given service ID for the given apps.
 	endpoints, err := p.getAppsUniqueEndpoints(serviceID, permittedApps)
 	if err != nil {
 		return nil, fmt.Errorf("BuildRequestContextForEndpoint: error getting endpoints for service %s: %w", serviceID, err)
 	}
 
+	// Select the endpoint that matches the pre-selected address.
+	// This ensures QoS checks are performed on the selected endpoint.
 	preselectedEndpoint, ok := endpoints[preSelectedEndpointAddr]
 	if !ok {
 		return nil, fmt.Errorf("BuildRequestContextForEndpoint: no pre-selected endpoint found for service %s and endpoint address %s", serviceID, preSelectedEndpointAddr)
 	}
 
-	// Create an endpoint map containing only the selected endpoint to ensure the QoS check is performed on the selected endpoint.
+	// Create an endpoint map containing only the selected endpoint to ensure
+	// the QoS check is performed on the selected endpoint.
 	preselectedEndpointMap := map[protocol.EndpointAddr]endpoint{
 		preSelectedEndpointAddr: preselectedEndpoint,
 	}
 
+	// Retrieve the relay request signer for the current gateway mode.
 	permittedSigner, err := p.getGatewayModePermittedRelaySigner(p.gatewayMode)
 	if err != nil {
 		return nil, fmt.Errorf("BuildRequestContextForEndpoint: error getting the permitted signer for gateway mode %s: %w", p.gatewayMode, err)
 	}
 
+	// Return new request context for the pre-selected endpoint
 	return &requestContext{
 		fullNode:           p.FullNode,
 		endpoints:          preselectedEndpointMap,
@@ -203,7 +219,7 @@ func (p *Protocol) getAppsUniqueEndpoints(
 	serviceID protocol.ServiceID,
 	permittedApps []*apptypes.Application,
 ) (map[protocol.EndpointAddr]endpoint, error) {
-	logger := p.Logger.With("service", serviceID)
+	logger := p.logger.With("service", serviceID)
 
 	var endpoints = make(map[protocol.EndpointAddr]endpoint)
 	for _, app := range permittedApps {

--- a/qos/cometbft/check.go
+++ b/qos/cometbft/check.go
@@ -32,10 +32,9 @@ func getEndpointCheck(
 	options ...func(*requestContext),
 ) *requestContext {
 	requestCtx := requestContext{
-		logger:                  logger,
-		endpointStore:           endpointStore,
-		isValid:                 true,
-		preSelectedEndpointAddr: endpointAddr,
+		logger:        logger,
+		endpointStore: endpointStore,
+		isValid:       true,
 	}
 
 	for _, option := range options {

--- a/qos/cometbft/check.go
+++ b/qos/cometbft/check.go
@@ -6,6 +6,7 @@ import (
 	"github.com/pokt-network/poktroll/pkg/polylog"
 
 	"github.com/buildwithgrove/path/gateway"
+	"github.com/buildwithgrove/path/protocol"
 )
 
 // EndpointStore provides the endpoint check generator required by
@@ -13,7 +14,9 @@ import (
 // using synthetic service requests.
 var _ gateway.QoSEndpointCheckGenerator = &EndpointStore{}
 
-func (es *EndpointStore) GetRequiredQualityChecks() []gateway.RequestQoSContext {
+// TODO_IMPROVE(@commoddity): implement QoS check expiry functionality and use protocol.EndpointAddr
+// to filter out checks for any endpoint which has acurrently valid QoS data point.
+func (es *EndpointStore) GetRequiredQualityChecks(_ protocol.EndpointAddr) []gateway.RequestQoSContext {
 	// TODO_IMPROVE(@adshmh): skip any checks for which the endpoint already has
 	// a valid (i.e. not expired) QoS data point.
 

--- a/qos/cometbft/check.go
+++ b/qos/cometbft/check.go
@@ -6,7 +6,6 @@ import (
 	"github.com/pokt-network/poktroll/pkg/polylog"
 
 	"github.com/buildwithgrove/path/gateway"
-	"github.com/buildwithgrove/path/protocol"
 )
 
 // EndpointStore provides the endpoint check generator required by
@@ -14,13 +13,13 @@ import (
 // using synthetic service requests.
 var _ gateway.QoSEndpointCheckGenerator = &EndpointStore{}
 
-func (es *EndpointStore) GetRequiredQualityChecks(endpointAddr protocol.EndpointAddr) []gateway.RequestQoSContext {
+func (es *EndpointStore) GetRequiredQualityChecks() []gateway.RequestQoSContext {
 	// TODO_IMPROVE(@adshmh): skip any checks for which the endpoint already has
 	// a valid (i.e. not expired) QoS data point.
 
 	return []gateway.RequestQoSContext{
-		getEndpointCheck(es.logger, es, endpointAddr, withHealthCheck),
-		getEndpointCheck(es.logger, es, endpointAddr, withStatusCheck),
+		getEndpointCheck(es.logger, es, withHealthCheck),
+		getEndpointCheck(es.logger, es, withStatusCheck),
 	}
 }
 
@@ -28,7 +27,6 @@ func (es *EndpointStore) GetRequiredQualityChecks(endpointAddr protocol.Endpoint
 func getEndpointCheck(
 	logger polylog.Logger,
 	endpointStore *EndpointStore,
-	endpointAddr protocol.EndpointAddr,
 	options ...func(*requestContext),
 ) *requestContext {
 	requestCtx := requestContext{

--- a/qos/cometbft/context.go
+++ b/qos/cometbft/context.go
@@ -1,7 +1,6 @@
 package cometbft
 
 import (
-	"fmt"
 	"net/http"
 
 	"github.com/pokt-network/poktroll/pkg/polylog"
@@ -47,10 +46,6 @@ type requestContext struct {
 	// isValid indicates if the user request was valid when parsed.
 	// Set by QoS instance during request context creation.
 	isValid bool
-
-	// preSelectedEndpointAddr overrides default endpoint selection with specific address.
-	// Used when building request context to check specific endpoint.
-	preSelectedEndpointAddr protocol.EndpointAddr
 
 	// endpointResponses contains responses from endpoints handling this service request
 	// NOTE: Currently only supports responses associated with a single JSON-RPC request.
@@ -159,11 +154,6 @@ func (rc *requestContext) GetEndpointSelector() protocol.EndpointSelector {
 // Select returns the address of an endpoint using the request context's endpoint store.
 // Implements the protocol.EndpointSelector interface.
 func (rc *requestContext) Select(allEndpoints []protocol.Endpoint) (protocol.EndpointAddr, error) {
-	// If set, override the selection with the pre-selected endpoint address.
-	if rc.preSelectedEndpointAddr != "" {
-		return preSelectedEndpoint(rc.preSelectedEndpointAddr, allEndpoints)
-	}
-
 	// Select an endpoint from the available endpoints using the endpoint store.
 	return rc.endpointStore.Select(allEndpoints)
 }
@@ -172,19 +162,4 @@ func (rc *requestContext) Select(allEndpoints []protocol.Endpoint) (protocol.End
 // Reference: https://docs.cometbft.com/v1.0/spec/rpc/
 func (rc *requestContext) isJSONRPCRequest() bool {
 	return len(rc.jsonrpcRequestBz) > 0
-}
-
-// preSelectedEndpoint returns the pre-selected endpoint address if it exists in the list of available endpoints.
-// It is used to override the default endpoint selection with a specific address.
-func preSelectedEndpoint(
-	preSelectedEndpointAddr protocol.EndpointAddr,
-	allEndpoints []protocol.Endpoint,
-) (protocol.EndpointAddr, error) {
-	for _, endpoint := range allEndpoints {
-		if endpoint.Addr() == preSelectedEndpointAddr {
-			return preSelectedEndpointAddr, nil
-		}
-	}
-
-	return protocol.EndpointAddr(""), fmt.Errorf("singleEndpointSelector: endpoint %s not found in available endpoints", preSelectedEndpointAddr)
 }

--- a/qos/evm/check.go
+++ b/qos/evm/check.go
@@ -4,7 +4,6 @@ import (
 	"github.com/pokt-network/poktroll/pkg/polylog"
 
 	"github.com/buildwithgrove/path/gateway"
-	"github.com/buildwithgrove/path/protocol"
 	"github.com/buildwithgrove/path/qos/jsonrpc"
 )
 
@@ -21,13 +20,13 @@ const (
 // using synthetic service requests.
 var _ gateway.QoSEndpointCheckGenerator = &EndpointStore{}
 
-func (es *EndpointStore) GetRequiredQualityChecks(endpointAddr protocol.EndpointAddr) []gateway.RequestQoSContext {
+func (es *EndpointStore) GetRequiredQualityChecks() []gateway.RequestQoSContext {
 	// TODO_IMPROVE(@adshmh): skip any checks for which the endpoint already has
 	// a valid (i.e. not expired) QoS data point.
 
 	return []gateway.RequestQoSContext{
-		getEndpointCheck(es.logger, es, endpointAddr, withChainIDCheck),
-		getEndpointCheck(es.logger, es, endpointAddr, withBlockHeightCheck),
+		getEndpointCheck(es.logger, es, withChainIDCheck),
+		getEndpointCheck(es.logger, es, withBlockHeightCheck),
 		// TODO_FUTURE: add an archival endpoint check.
 	}
 }
@@ -36,7 +35,6 @@ func (es *EndpointStore) GetRequiredQualityChecks(endpointAddr protocol.Endpoint
 func getEndpointCheck(
 	logger polylog.Logger,
 	endpointStore *EndpointStore,
-	endpointAddr protocol.EndpointAddr,
 	options ...func(*requestContext),
 ) *requestContext {
 	requestCtx := requestContext{

--- a/qos/evm/check.go
+++ b/qos/evm/check.go
@@ -40,9 +40,8 @@ func getEndpointCheck(
 	options ...func(*requestContext),
 ) *requestContext {
 	requestCtx := requestContext{
-		logger:                  logger,
-		endpointStore:           endpointStore,
-		preSelectedEndpointAddr: endpointAddr,
+		logger:        logger,
+		endpointStore: endpointStore,
 	}
 
 	for _, option := range options {

--- a/qos/evm/check.go
+++ b/qos/evm/check.go
@@ -4,6 +4,7 @@ import (
 	"github.com/pokt-network/poktroll/pkg/polylog"
 
 	"github.com/buildwithgrove/path/gateway"
+	"github.com/buildwithgrove/path/protocol"
 	"github.com/buildwithgrove/path/qos/jsonrpc"
 )
 
@@ -20,10 +21,9 @@ const (
 // using synthetic service requests.
 var _ gateway.QoSEndpointCheckGenerator = &EndpointStore{}
 
-func (es *EndpointStore) GetRequiredQualityChecks() []gateway.RequestQoSContext {
-	// TODO_IMPROVE(@adshmh): skip any checks for which the endpoint already has
-	// a valid (i.e. not expired) QoS data point.
-
+// TODO_IMPROVE(@commoddity): implement QoS check expiry functionality and use protocol.EndpointAddr
+// to filter out checks for any endpoint which has acurrently valid QoS data point.
+func (es *EndpointStore) GetRequiredQualityChecks(_ protocol.EndpointAddr) []gateway.RequestQoSContext {
 	return []gateway.RequestQoSContext{
 		getEndpointCheck(es.logger, es, withChainIDCheck),
 		getEndpointCheck(es.logger, es, withBlockHeightCheck),

--- a/qos/evm/context.go
+++ b/qos/evm/context.go
@@ -2,7 +2,6 @@ package evm
 
 import (
 	"encoding/json"
-	"fmt"
 	"net/http"
 
 	"github.com/pokt-network/poktroll/pkg/polylog"
@@ -66,12 +65,6 @@ type requestContext struct {
 
 	// TODO_TECHDEBT(@adshmh): support batch JSONRPC requests
 	jsonrpcReq jsonrpc.Request
-
-	// preSelectedEndpointAddr allows overriding the default
-	// endpoint selector with a specific endpoint's addresss.
-	// This is used when building a request context as a check
-	// for a specific endpoint.
-	preSelectedEndpointAddr protocol.EndpointAddr
 
 	// endpointResponses is the set of responses received from one or
 	// more endpoints as part of handling this service request.
@@ -191,22 +184,5 @@ func (rc *requestContext) GetEndpointSelector() protocol.EndpointSelector {
 // Select returns the address of an endpoint using the request context's endpoint store.
 // Implements the protocol.EndpointSelector interface.
 func (rc *requestContext) Select(allEndpoints []protocol.Endpoint) (protocol.EndpointAddr, error) {
-	if rc.preSelectedEndpointAddr != "" {
-		return preSelectedEndpoint(rc.preSelectedEndpointAddr, allEndpoints)
-	}
-
 	return rc.endpointStore.Select(allEndpoints)
-}
-
-func preSelectedEndpoint(
-	preSelectedEndpointAddr protocol.EndpointAddr,
-	allEndpoints []protocol.Endpoint,
-) (protocol.EndpointAddr, error) {
-	for _, endpoint := range allEndpoints {
-		if endpoint.Addr() == preSelectedEndpointAddr {
-			return preSelectedEndpointAddr, nil
-		}
-	}
-
-	return protocol.EndpointAddr(""), fmt.Errorf("singleEndpointSelector: endpoint %s not found in available endpoints", preSelectedEndpointAddr)
 }

--- a/qos/noop/noop.go
+++ b/qos/noop/noop.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/buildwithgrove/path/gateway"
 	qosobservations "github.com/buildwithgrove/path/observation/qos"
-	"github.com/buildwithgrove/path/protocol"
 )
 
 // TODO_TECHDEBT(@adshmh): support customization of the endpoint response's timeout.
@@ -55,7 +54,7 @@ func (NoOpQoS) ApplyObservations(_ *qosobservations.Observations) error {
 
 // GetRequiredQualityChecks on noop QoS only fulfills the interface requirements and does not perform any actions.
 // Implements the gateway.QoSService interface.
-func (NoOpQoS) GetRequiredQualityChecks(_ protocol.EndpointAddr) []gateway.RequestQoSContext {
+func (NoOpQoS) GetRequiredQualityChecks() []gateway.RequestQoSContext {
 	return nil
 }
 

--- a/qos/noop/noop.go
+++ b/qos/noop/noop.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/buildwithgrove/path/gateway"
 	qosobservations "github.com/buildwithgrove/path/observation/qos"
+	"github.com/buildwithgrove/path/protocol"
 )
 
 // TODO_TECHDEBT(@adshmh): support customization of the endpoint response's timeout.
@@ -54,7 +55,7 @@ func (NoOpQoS) ApplyObservations(_ *qosobservations.Observations) error {
 
 // GetRequiredQualityChecks on noop QoS only fulfills the interface requirements and does not perform any actions.
 // Implements the gateway.QoSService interface.
-func (NoOpQoS) GetRequiredQualityChecks() []gateway.RequestQoSContext {
+func (NoOpQoS) GetRequiredQualityChecks(_ protocol.EndpointAddr) []gateway.RequestQoSContext {
 	return nil
 }
 

--- a/qos/solana/check.go
+++ b/qos/solana/check.go
@@ -4,6 +4,7 @@ import (
 	"github.com/pokt-network/poktroll/pkg/polylog"
 
 	"github.com/buildwithgrove/path/gateway"
+	"github.com/buildwithgrove/path/protocol"
 	"github.com/buildwithgrove/path/qos/jsonrpc"
 )
 
@@ -21,10 +22,9 @@ const (
 // using synthetic service requests.
 var _ gateway.QoSEndpointCheckGenerator = &EndpointStore{}
 
-func (es *EndpointStore) GetRequiredQualityChecks() []gateway.RequestQoSContext {
-	// TODO_IMPROVE(@adshmh): skip any checks for which the endpoint already has
-	// a valid (i.e. not expired) QoS data point.
-
+// TODO_IMPROVE(@commoddity): implement QoS check expiry functionality and use protocol.EndpointAddr
+// to filter out checks for any endpoint which has acurrently valid QoS data point.
+func (es *EndpointStore) GetRequiredQualityChecks(_ protocol.EndpointAddr) []gateway.RequestQoSContext {
 	return []gateway.RequestQoSContext{
 		getEndpointCheck(es.logger, es, withGetHealth),
 		getEndpointCheck(es.logger, es, withGetEpochInfo),

--- a/qos/solana/check.go
+++ b/qos/solana/check.go
@@ -4,7 +4,6 @@ import (
 	"github.com/pokt-network/poktroll/pkg/polylog"
 
 	"github.com/buildwithgrove/path/gateway"
-	"github.com/buildwithgrove/path/protocol"
 	"github.com/buildwithgrove/path/qos/jsonrpc"
 )
 
@@ -22,13 +21,13 @@ const (
 // using synthetic service requests.
 var _ gateway.QoSEndpointCheckGenerator = &EndpointStore{}
 
-func (es *EndpointStore) GetRequiredQualityChecks(endpointAddr protocol.EndpointAddr) []gateway.RequestQoSContext {
+func (es *EndpointStore) GetRequiredQualityChecks() []gateway.RequestQoSContext {
 	// TODO_IMPROVE(@adshmh): skip any checks for which the endpoint already has
 	// a valid (i.e. not expired) QoS data point.
 
 	return []gateway.RequestQoSContext{
-		getEndpointCheck(es.logger, endpointAddr, es, withGetHealth),
-		getEndpointCheck(es.logger, endpointAddr, es, withGetEpochInfo),
+		getEndpointCheck(es.logger, es, withGetHealth),
+		getEndpointCheck(es.logger, es, withGetEpochInfo),
 		// TODO_MVP(@adshmh): Add a check for a `getBlock` request
 	}
 }
@@ -36,7 +35,6 @@ func (es *EndpointStore) GetRequiredQualityChecks(endpointAddr protocol.Endpoint
 // getEndpointCheck prepares a request context for a specific endpoint check.
 func getEndpointCheck(
 	logger polylog.Logger,
-	endpointAddr protocol.EndpointAddr,
 	endpointStore *EndpointStore,
 	options ...func(*requestContext),
 ) *requestContext {

--- a/qos/solana/check.go
+++ b/qos/solana/check.go
@@ -41,10 +41,9 @@ func getEndpointCheck(
 	options ...func(*requestContext),
 ) *requestContext {
 	requestCtx := requestContext{
-		logger:                  logger,
-		endpointStore:           endpointStore,
-		isValid:                 true,
-		preSelectedEndpointAddr: endpointAddr,
+		logger:        logger,
+		endpointStore: endpointStore,
+		isValid:       true,
 	}
 
 	for _, option := range options {

--- a/qos/solana/context.go
+++ b/qos/solana/context.go
@@ -2,7 +2,6 @@ package solana
 
 import (
 	"encoding/json"
-	"fmt"
 	"net/http"
 
 	"github.com/pokt-network/poktroll/pkg/polylog"
@@ -56,12 +55,6 @@ type requestContext struct {
 	// when creating this request context during the parsing
 	// of the user request.
 	isValid bool
-
-	// preSelectedEndpointAddr allows overriding the default
-	// endpoint selector with a specific endpoint's addresss.
-	// This is used when building a request context as a check
-	// for a specific endpoint.
-	preSelectedEndpointAddr protocol.EndpointAddr
 
 	// endpointResponses is the set of responses received from one or
 	// more endpoints as part of handling this service request.
@@ -170,22 +163,5 @@ func (rc *requestContext) GetEndpointSelector() protocol.EndpointSelector {
 // Select chooses an endpoint from the list of supplied endpoints, using the perceived (using endpoints' responses) state of the Solana chain.
 // It is required to satisfy the protocol package's EndpointSelector interface.
 func (rc *requestContext) Select(allEndpoints []protocol.Endpoint) (protocol.EndpointAddr, error) {
-	if rc.preSelectedEndpointAddr != "" {
-		return preSelectedEndpoint(rc.preSelectedEndpointAddr, allEndpoints)
-	}
-
 	return rc.endpointStore.Select(allEndpoints)
-}
-
-func preSelectedEndpoint(
-	preSelectedEndpointAddr protocol.EndpointAddr,
-	allEndpoints []protocol.Endpoint,
-) (protocol.EndpointAddr, error) {
-	for _, endpoint := range allEndpoints {
-		if endpoint.Addr() == preSelectedEndpointAddr {
-			return preSelectedEndpointAddr, nil
-		}
-	}
-
-	return protocol.EndpointAddr(""), fmt.Errorf("singleEndpointSelector: endpoint %s not found in available endpoints", preSelectedEndpointAddr)
 }


### PR DESCRIPTION
## 🌿 Summary

Fix race condition in hydrator by creating a new request context per request to ensure correct endpoint selection and observation application, along with comprehensive HTTP status code handling improvements.

### 🌱 Primary Changes:
- Added `BuildHydratorRequestContextForEndpoint` to protocol interfaces to create dedicated request contexts for hydrator QoS checks
- Implemented `BuildHydratorRequestContextForEndpoint` in Morse and Shannon packages to create a per-request protocol context containing only a single endpoints for hydrator checks.

### 🍃 Secondary changes:
- Removed `preSelectedEndpointAddr` logic from QoS as it's now handled inside the protocol packages with the `BuildHydratorRequestContextForEndpoint` method.

## 🛠️ Type of change

Select one or more from the following:

- [x] New feature, functionality or library
- [x] Bug fix

## 🤯 Sanity Checklist

- [x] I have updated the GitHub Issue 'assignees', 'reviewers', 'labels', 'project', 'iteration' and 'milestone'
- [x] I added TODOs where applicable
