### PR TITLE
[docs] Fix embedded helm chart docs to point to main branch of helm repo

### DIFF
--- a/docusaurus/docs/operate/helm/3_guard.md
+++ b/docusaurus/docs/operate/helm/3_guard.md
@@ -6,6 +6,4 @@ description: GUARD Helm Chart
 
 import RemoteMarkdown from '@site/src/components/RemoteMarkdown';
 
-<!-- TODO_MVP(@commoddity): Update this embed to point to `main` branch once PR #62 merged:
-https://github.com/buildwithgrove/helm-charts/pull/62 -->
-<RemoteMarkdown src="https://raw.githubusercontent.com/buildwithgrove/helm-charts/refs/heads/guard-docs/charts/guard/README.md" />
+<RemoteMarkdown src="https://raw.githubusercontent.com/buildwithgrove/helm-charts/refs/heads/main/charts/guard/README.md" />

--- a/docusaurus/docs/operate/helm/5_values.md
+++ b/docusaurus/docs/operate/helm/5_values.md
@@ -8,6 +8,4 @@ This document provides detailed information about the values that can be set for
 
 import RemoteMarkdown from '@site/src/components/RemoteMarkdown';
 
-<!-- TODO_MVP(@commoddity): Update this embed to point to `main` branch once PR #62 merged:
-https://github.com/buildwithgrove/helm-charts/pull/62 -->
-<RemoteMarkdown src="https://raw.githubusercontent.com/buildwithgrove/helm-charts/refs/heads/guard-docs/charts/path/docs/values.md" />
+<RemoteMarkdown src="https://raw.githubusercontent.com/buildwithgrove/helm-charts/refs/heads/main/charts/path/docs/values.md" />


### PR DESCRIPTION
## 🌿 Summary

Update embedded Helm chart documentation links to point to the `main` branch of the Helm repository.

### 🌱 Primary Changes:
- Updated embedded Helm chart documentation links from `guard-docs` branch to `main` branch
- Removed outdated TODO comments referencing the transition from `guard-docs` branch

## 🛠️ Type of change

Select one or more from the following:

- [x] Documentation
