### PR TITLE
Put back erroneously deleted make path_run target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,9 +37,12 @@ check_path_config:
    		exit 1; \
    fi
 
-# The PATH config value can be set via the CONFIG_PATH env variable.
-# Defaults to ./local/path/.config.yaml
+# The PATH config value can be set via the CONFIG_PATH env variable and defaults to ./local/path/.config.yaml
 CONFIG_PATH ?= ../local/path/.config.yaml
+
+.PHONY: path_run
+path_run: path_build check_path_config ## Run the path binary as a standalone binary
+	(cd bin; ./path -config ${CONFIG_PATH})
 
 #################################
 ###  Local PATH make targets  ###


### PR DESCRIPTION
# Summary

< One line summary>

Changes:

- < Change 1 >
- < Change 2 >

## Issue

- Description: < Description >
- Issue: #{ISSUE_NUMBER}

## Type of change

Select one or more from the following:

- [ ] New feature, functionality or library
- [ ] Bug fix
- [ ] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## QoS Checklist

- [ ] 1. `make path_up`
- [ ] 2. Run one of the following:
  - For `Shannon` with `anvil`: `make test_request__envoy_relay_util_100`
  - For `Morse` with `F00C`: `make test_request__morse_relay_util_100`
- [ ] 3. Visit [PATH Relay Grafana Dashboard](http://localhost:3000/d/relays/path-service-requests) to view results

## Sanity Checklist

- [ ] I have updated the GitHub Issue `assignees`, `reviewers`, `labels`, `project`, `iteration` and `milestone`
- [ ] For docs, I have run `make docusaurus_start`
- [ ] For code, I have run `make test_all`
- [ ] For configurations, I have update the documentation
- [ ] I added TODOs where applicable
