### PR TITLE
[Bug] Remove duplicate trigger and docker build from Tiltfile to fix localnet

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -190,37 +190,6 @@ WORKDIR /app
     trigger='.tilt-build-trigger',  # Rebuild when this file changes
 )
 
-# Make sure path-binary runs before the Docker build
-local_resource(
-    "path-trigger",
-    """
-    echo "Triggering Docker build after binary build"
-    touch .tilt-build-trigger
-    """,
-    resource_deps=["path-binary"],
-    auto_init=False,
-    trigger_mode=TRIGGER_MODE_MANUAL,
-    labels=["hot-reloading"],
-)
-
-# Build an image with the PATH binary
-docker_build_with_restart(
-    "path-image",
-    context=".",
-    dockerfile_contents="""FROM golang:1.23.0
-RUN apt-get -q update && apt-get install -qyy curl jq less
-RUN mkdir -p /app/config
-COPY bin/path /app/path
-RUN chmod +x /app/path
-WORKDIR /app
-""",
-    # only=["/app/path"],
-    entrypoint=["/app/path"],
-    live_update=[sync("bin/path", "/app/path")],
-    trigger='.tilt-build-trigger',  # Rebuild when this file changes
-)
-
-
 # Tilt will run the Helm Chart with the following flags by default.
 #
 # For example:


### PR DESCRIPTION
## 🌿 Summary

Fix localnet setup by removing duplicate Docker build trigger and configuration from Tiltfile.

### 🌱 Primary Changes:
- Remove duplicate `local_resource` trigger for Docker builds
- Remove redundant `docker_build_with_restart` configuration for PATH binary

### 🍃 Secondary changes:
- Clean up merge conflict remnants in Tiltfile

## 🛠️ Type of change

Select one or more from the following:

- [ ] New feature, functionality or library
- [ ] Bug fix
- [ ] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## 🤯 Sanity Checklist

- [ ] I have updated the GitHub Issue 'assignees', 'reviewers', 'labels', 'project', 'iteration' and 'milestone'
- [ ] For docs, I have run 'make docusaurus_start'
- [ ] For code, I have run 'make test_all'
- [ ] For configurations, I have update the documentation
- [ ] I added TODOs where applicable
