### PR TITLE
[Metrics] Fix metrics cardinality

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -34,7 +34,7 @@ Select one or more from the following:
 
 ## QoS Checklist
 
-### E2E Tests
+### E2E Validation & Tests
 
 - [ ] `make path_up`
 - [ ] `make test_e2e_evm_shannon`
@@ -44,7 +44,7 @@ Select one or more from the following:
 
 - [ ] 1. `make path_up`
 - [ ] 2. Run one of the following:
-  - For `Shannon` with `anvil`: `make test_request__envoy_relay_util_100`
+  - For `Shannon` with `anvil`: `make test_request__shannon_relay_util_100`
   - For `Morse` with `F00C`: `make test_request__morse_relay_util_100`
 - [ ] 3. Visit [PATH Relay Grafana Dashboard](http://localhost:3003/d/relays/path-service-requests) to view results
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -28,7 +28,7 @@ Select one or more from the following:
 - [ ] 2. Run one of the following:
   - For `Shannon` with `anvil`: `make test_request__envoy_relay_util_100`
   - For `Morse` with `F00C`: `make test_request__morse_relay_util_100`
-- [ ] 3. Visit [PATH Relay Grafana Dashboard](http://localhost:3000/d/relays/path-service-requests) to view results
+- [ ] 3. Visit [PATH Relay Grafana Dashboard](http://localhost:3003/d/relays/path-service-requests) to view results
 
 ## Sanity Checklist
 

--- a/Makefile
+++ b/Makefile
@@ -57,13 +57,15 @@ path_up: check_path_config k8s_prepare_local_env ## Brings up local Tilt develop
 	tilt up
 
 .PHONY: path_down
-path_down: dev_down ## Tears down local Tilt development environment which includes PATH and all related dependencies (using kind cluster)
+path_down: ## Tears down local Tilt development environment which includes PATH and all related dependencies (using kind cluster)
+	tilt down
 
 .PHONY: path_help
 path_help: ## Prints help commands if you cannot start path
 	@echo "################################################################";
 	@echo "If you're hitting issues running PATH, try running following commands:";
 	@echo "	make path_down";
+	@echo "	make k8s_cleanup_local_env";
 	@echo "	make path_up";
 	@echo "################################################################";
 

--- a/Tiltfile
+++ b/Tiltfile
@@ -1,6 +1,7 @@
 # Load necessary Tilt extensions
 load("ext://restart_process", "docker_build_with_restart")
 load("ext://helm_resource", "helm_resource", "helm_repo")
+load('ext://k8s_attach', 'k8s_attach')
 load("ext://configmap", "configmap_create")
 
 # A list of directories where changes trigger a hot-reload of PATH.
@@ -314,18 +315,4 @@ local_resource(
     resource_deps=["path-stack"]
 )
 
-# --------------------------------------------------------------------------- #
-#                          Port Forwarding Resources                          #
-# --------------------------------------------------------------------------- #
-# 1. Grafana container port                                                   #
-# --------------------------------------------------------------------------- #
-# Grafana port
-# k8s_resource(workload="path-grafana", port_forwards=3000)
-# Create a local_resource for port forwarding to Grafana
-local_resource(
-    "path-grafana-portforward",
-    # Use port 3003:3000 is used by kind control plane.
-    serve_cmd="kubectl port-forward deployment/path-grafana 3003:3000",
-    resource_deps=["path-stack"],  # This ensures the port-forward starts after the Helm chart is deployed
-    labels=["grafana"]
-)
+k8s_attach('path-grafana', 'deployment/path-grafana', namespace='path', port_forwards="3003:3000", resource_deps=["path-stack"])

--- a/Tiltfile
+++ b/Tiltfile
@@ -128,6 +128,8 @@ local_resource(
 #
 # For more context, see the comments at:
 # `./local/scripts/patch_envoy_gateway.sh`.
+#
+# TODO_TECHDEBT(@okdas): Remove this and the associated script once helm charts are updated.
 local_resource(
     "patch-envoy-gateway",
     "./local/scripts/patch_envoy_gateway.sh",
@@ -276,6 +278,16 @@ k8s_resource(
     labels=["path"]
 )
 
+# Attach the proper port forwards to Grafana
+# TODO_TECHDEBT(@okdas): Remove admin/password requirements.
+k8s_attach(
+    'path-grafana',
+    'deployment/path-grafana',
+    namespace='path',
+    port_forwards="3003:3000",
+    resource_deps=["path-stack"]
+)
+
 # 2. GUARD Logs - Waits for container readiness before following logs
 local_resource(
     "guard-logs",
@@ -314,5 +326,3 @@ local_resource(
     labels=["k8s_logs"],
     resource_deps=["path-stack"]
 )
-
-k8s_attach('path-grafana', 'deployment/path-grafana', namespace='path', port_forwards="3003:3000", resource_deps=["path-stack"])

--- a/makefiles/localnet.mk
+++ b/makefiles/localnet.mk
@@ -46,14 +46,12 @@ k8s_prepare_local_env: check_kind
 		echo "[DEBUG] Cluster 'path-localnet' already exists. Skipping creation."; \
 	fi
 
-.PHONY: dev_down
-# Internal helper: Tears down kind cluster
-dev_down:
-# @echo "Tearing down local environment..."
-	@tilt down
-# @kind delete cluster --name path-localnet
-# @if kubectl config get-contexts kind-path-localnet > /dev/null 2>&1; then \
-# 	kubectl config delete-context kind-path-localnet; \
-# else \
-# 	echo "Context kind-path-localnet not found in kubeconfig. Skipping deletion."; \
-# fi
+.PHONY: k8s_cleanup_local_env
+# Internal helper: Cleans up kind cluster and kubeconfig context for path-localnet
+k8s_cleanup_local_env:
+	@echo "[INFO] Cleaning up local k8s environment for 'path-localnet'..."
+	@kind delete cluster --name path-localnet || echo "[DEBUG] Cluster 'path-localnet' not found. Skipping deletion."
+	@kubectl config get-contexts kind-path-localnet > /dev/null 2>&1 && \
+		kubectl config delete-context kind-path-localnet || \
+		echo "[DEBUG] Context 'kind-path-localnet' not found. Skipping deletion."
+	@kubectl config get-contexts | grep -q 'kind-path-localnet' || echo "[INFO] Cleanup complete."

--- a/makefiles/test.mk
+++ b/makefiles/test.mk
@@ -10,9 +10,9 @@ test_unit: ## Run all unit tests
 	go test ./... -short -count=1
 
 .PHONY: test_e2e_evm_morse
-test_e2e_evm_morse: morse_e2e_config_warning ## Run an E2E Morse relay test
+test_e2e_evm_morse: morse_e2e_config_warning debug_view_results_links ## Run an E2E Morse relay test
 	(cd ./e2e && TEST_PROTOCOL=morse go test -tags=e2e -count=1 -run Test_PATH_E2E_EVM)
 
 .PHONY: test_e2e_evm_shannon
-test_e2e_evm_shannon: shannon_e2e_config_warning ## Run an E2E Shannon relay test
+test_e2e_evm_shannon: shannon_e2e_config_warning debug_view_results_links ## Run an E2E Shannon relay test
 	(cd ./e2e && TEST_PROTOCOL=shannon go test -tags=e2e -count=1 -run Test_PATH_E2E_EVM)

--- a/makefiles/test_requests.mk
+++ b/makefiles/test_requests.mk
@@ -13,6 +13,25 @@ debug_relayminer_supplier_info_msg:
 	@echo "########################################################################################################################################"
 	@echo ""
 
+.PHONY: debug_view_results_links
+# Internal helper: Displays links to view results in local dashboards
+debug_view_results_links:
+	@echo "##########################################################################################################"
+	@echo "####   VIEW RESULTS IN LOCAL DASHBOARDS   ####"
+	@echo ""
+	@echo "1. Path Service Requests:"
+	@echo "   http://localhost:3003/d/relays/path-service-requests?orgId=1&from=now-15m&to=now&timezone=browser"
+	@echo ""
+	@echo "2. Path Gateway Metrics:"
+	@echo "   http://localhost:3003/d/gateway/path-path-gateway?orgId=1&from=now-1h&to=now&timezone=browser&var-path=path-metrics&refresh=5s"
+	@echo ""
+	@echo "3. Morse Relay Requests:"
+	@echo "   http://localhost:3003/d/morse/morse-relay-requests?orgId=1&from=now-3h&to=now&timezone=browser&refresh=10s"
+	@echo ""
+	@echo "Login with: admin / admin (for now)"
+	@echo "##########################################################################################################"
+	@echo ""
+
 .PHONY: check_path_up
 # Internal helper: Checks if PATH is running at localhost:3070
 check_path_up:
@@ -81,7 +100,7 @@ test_request__morse_service_id_header: check_path_up ## Test request with API ke
 ##################################
 
 .PHONY: test_request__shannon_relay_util_100
-test_request__shannon_relay_util_100: check_path_up check_relay_util  ## Test anvil PATH behind GUARD with 10 eth_blockNumber requests using relay-util
+test_request__shannon_relay_util_100: check_path_up check_relay_util debug_view_results_links  ## Test anvil PATH behind GUARD with 10 eth_blockNumber requests using relay-util
 	relay-util \
 		-u http://localhost:3070/v1 \
 		-H "target-service-id: anvil" \
@@ -91,7 +110,7 @@ test_request__shannon_relay_util_100: check_path_up check_relay_util  ## Test an
 		-b
 
 .PHONY: test_request__morse_relay_util_100
-test_request__morse_relay_util_100: check_path_up check_relay_util  ## Test F00C (Eth MainNet on Morse) via PATH behind GUARD with 10,000 eth_blockNumber requests using relay-util
+test_request__morse_relay_util_100: check_path_up check_relay_util debug_view_results_links  ## Test F00C (Eth MainNet on Morse) via PATH behind GUARD with 10,000 eth_blockNumber requests using relay-util
 	relay-util \
 		-u http://localhost:3070/v1 \
 		-H "target-service-id: F00C" \

--- a/metrics/protocol/morse/metrics.go
+++ b/metrics/protocol/morse/metrics.go
@@ -14,7 +14,6 @@ const (
 	pathProcess = "path"
 
 	// The list of metrics being tracked for Morse protocol
-	// TODO: Make sure this is doing what we expect to.
 	relaysTotalMetric       = "morse_relays_total"
 	relaysErrorsTotalMetric = "morse_relay_errors_total"
 )
@@ -28,51 +27,52 @@ var (
 	// relaysTotal tracks the total Morse relay requests processed.
 	// Labels:
 	//   - service_id: Target service identifier (i.e. chain id in Morse)
-	//   - app_address: Application address that signed the relay
 	//   - success: Whether the relay was successful (true if at least one endpoint had no error)
+	//
+	// Exemplars:
+	//   - app_address: Application address that signed the relay
 	//   - endpoint_addr: Address of the endpoint (from the last entry in observations list)
-	//     NOTE: Currently only using a single endpoint (the last one) for this metric.
-	//     TODO_FUTURE: This needs to be revisited when retry mechanism is implemented at protocol level.
 	//   - session_height: Height of the session (from the last entry in observations list)
-	//     NOTE: Using the same endpoint entry as endpoint_addr above.
-	//     TODO_FUTURE: This needs to be revisited when retry mechanism is implemented at protocol level.
+	//
+	// Low-cardinality labels are used for core metrics while high-cardinality data is
+	// moved to exemplars to reduce Prometheus storage and query overhead while still
+	// preserving detailed information for troubleshooting.
 	//
 	// Use to analyze:
 	//   - Request volume by service
-	//   - Request distribution across applications
-	//   - Success rates by service and application
-	//   - Endpoint participation
-	//   - Session height distribution
+	//   - Success rates by service
+	//   - Detailed endpoint and app data available via exemplars when needed
 	relaysTotal = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Subsystem: pathProcess,
 			Name:      relaysTotalMetric,
 			Help:      "Total number of relays processed by Morse protocol instance(s)",
 		},
-		[]string{"service_id", "app_address", "success", "endpoint_addr", "session_height"},
+		[]string{"service_id", "success"},
 	)
 
 	// relaysErrorsTotal tracks relay errors by error type.
 	// Labels:
 	//   - service_id: Target service identifier
-	//   - app_address: Application address that signed the relay
 	//   - error_type: Type of error encountered (connection, timeout, etc.)
-	//   - endpoint_addr: Address of the endpoint that returned an error
-	//   - session_height: Height of the session when the error occurred
 	//   - sanction_type: Type of sanction recommended for this error (if any)
 	//
+	// Exemplars:
+	//   - app_address: Application address that signed the relay
+	//   - endpoint_addr: Address of the endpoint that returned an error
+	//   - session_height: Height of the session when the error occurred
+	//
 	// Use to analyze:
-	//   - Error patterns by service and endpoint
-	//   - Error patterns by application
-	//   - Session height correlation with errors
+	//   - Error patterns by service
 	//   - Sanction distribution for different error types
+	//   - Detailed endpoint and app data available via exemplars when needed
 	relaysErrorsTotal = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Subsystem: pathProcess,
 			Name:      relaysErrorsTotalMetric,
-			Help:      "Total relay errors by type, service, endpoint, and session height",
+			Help:      "Total relay errors by type, service and sanction type",
 		},
-		[]string{"service_id", "app_address", "error_type", "endpoint_addr", "session_height", "sanction_type"},
+		[]string{"service_id", "error_type", "sanction_type"},
 	)
 )
 
@@ -106,8 +106,7 @@ func PublishMetrics(observations *protocol.MorseObservationsList) {
 	}
 }
 
-// recordRelayTotal records the total relays metric collected.
-// See relaysTotal above for details on additional metadata and use-cases.
+// recordRelayTotal tracks relay counts with exemplars for high-cardinality data.
 func recordRelayTotal(serviceID string, observations []*protocol.MorseEndpointObservation) {
 	// Skip if there are no observations
 	if len(observations) == 0 {
@@ -118,31 +117,35 @@ func recordRelayTotal(serviceID string, observations []*protocol.MorseEndpointOb
 	success := isAnyObservationSuccessful(observations)
 
 	// Get the last observation for endpoint address and session height
-	// TODO_TECHDEBT(@adshmh): Currently using the last entry in observations list for endpoint_addr and session_height.
-	// This is a simplified approach that will need review when implementing retry mechanisms:
-	//   - Split metrics: total relays vs service requests
-	//   - Track relay attempts per service request
 	lastObs := observations[len(observations)-1]
 
-	// Extract values for labels
+	// Extract values for core labels (low cardinality)
+	successLabel := fmt.Sprintf("%t", success)
+
+	// Extract high-cardinality values for exemplars
 	appAddress := lastObs.GetAppAddress()
 	endpointAddr := lastObs.GetEndpointAddr()
 	sessionHeight := fmt.Sprintf("%d", lastObs.GetSessionHeight())
 
-	// Increment the relay total counter
+	// Create exemplar with high-cardinality data
+	exLabels := prometheus.Labels{
+		"app_address":    appAddress,
+		"endpoint_addr":  endpointAddr,
+		"session_height": sessionHeight,
+	}
+
+	// Increment the relay total counter with exemplars
 	relaysTotal.With(
 		prometheus.Labels{
-			"service_id":     serviceID,
-			"app_address":    appAddress,
-			"success":        fmt.Sprintf("%t", success),
-			"endpoint_addr":  endpointAddr,
-			"session_height": sessionHeight,
+			"service_id": serviceID,
+			"success":    successLabel,
 		},
-	).Inc()
+	// This dynamic type cast is safe:
+	// https://pkg.go.dev/github.com/prometheus/client_golang@v1.22.0/prometheus#NewCounter
+	).(prometheus.ExemplarAdder).AddWithExemplar(float64(1), exLabels)
 }
 
-// isAnyObservationSuccessful checks if at least one of the observations has no error
-// (indicating success)
+// isAnyObservationSuccessful returns true if any observation succeeded (no error)
 func isAnyObservationSuccessful(observations []*protocol.MorseEndpointObservation) bool {
 	for _, obs := range observations {
 		if obs.GetErrorType() != protocol.MorseEndpointErrorType_MORSE_ENDPOINT_ERROR_UNSPECIFIED {
@@ -152,7 +155,7 @@ func isAnyObservationSuccessful(observations []*protocol.MorseEndpointObservatio
 	return false
 }
 
-// processEndpointErrors iterates through endpoint observations to record error metrics
+// processEndpointErrors records error metrics with exemplars for high-cardinality data
 func processEndpointErrors(serviceID string, observations []*protocol.MorseEndpointObservation) {
 	for _, endpointObs := range observations {
 		// Skip if there's no error
@@ -160,10 +163,7 @@ func processEndpointErrors(serviceID string, observations []*protocol.MorseEndpo
 			continue
 		}
 
-		// Extract base labels
-		appAddress := endpointObs.GetAppAddress()
-		endpointAddr := endpointObs.GetEndpointAddr()
-		sessionHeight := fmt.Sprintf("%d", endpointObs.GetSessionHeight())
+		// Extract low-cardinality labels
 		errorType := endpointObs.GetErrorType().String()
 
 		// Extract sanction type (if any)
@@ -172,16 +172,27 @@ func processEndpointErrors(serviceID string, observations []*protocol.MorseEndpo
 			sanctionType = endpointObs.GetRecommendedSanction().String()
 		}
 
-		// Record relay error
+		// Extract high-cardinality values for exemplars
+		appAddress := endpointObs.GetAppAddress()
+		endpointAddr := endpointObs.GetEndpointAddr()
+		sessionHeight := fmt.Sprintf("%d", endpointObs.GetSessionHeight())
+
+		// Create exemplar with high-cardinality data
+		exLabels := prometheus.Labels{
+			"app_address":    appAddress,
+			"endpoint_addr":  endpointAddr,
+			"session_height": sessionHeight,
+		}
+
+		// Record relay error with exemplars
 		relaysErrorsTotal.With(
 			prometheus.Labels{
-				"service_id":     serviceID,
-				"app_address":    appAddress,
-				"error_type":     errorType,
-				"endpoint_addr":  endpointAddr,
-				"session_height": sessionHeight,
-				"sanction_type":  sanctionType,
+				"service_id":    serviceID,
+				"error_type":    errorType,
+				"sanction_type": sanctionType,
 			},
-		).Inc()
+		// This dynamic type cast is safe:
+		// https://pkg.go.dev/github.com/prometheus/client_golang@v1.22.0/prometheus#NewCounter
+		).(prometheus.ExemplarAdder).AddWithExemplar(float64(1), exLabels)
 	}
 }


### PR DESCRIPTION
# Summary

Reduce Metrics cardinality by using Prometheus Exemplars for high cardinality values.

Changes:

- Use Prometheus Exemplars in PATH Morse metrics (low cardinality elsewhere)
- Fix the Port-forwading to Grafana issue in Local development environment.

## Issue

- Description: High cardinality of PATH metrics
- Issue: #219 

## Type of change

Select one or more from the following:

- [ ] New feature, functionality or library
- [ ] Bug fix
- [x] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## QoS Checklist

- [x] 1. `make path_up`
- [x] 2. Run one of the following:
  - For `Shannon` with `anvil`: `make test_request__envoy_relay_util_100`
  - For `Morse` with `F00C`: `make test_request__morse_relay_util_100`
- [x] 3. Visit [PATH Relay Grafana Dashboard](http://localhost:3000/d/relays/path-service-requests) to view results

## Sanity Checklist

- [x] I have updated the GitHub Issue `assignees`, `reviewers`, `labels`, `project`, `iteration` and `milestone`
- [ ] For docs, I have run `make docusaurus_start`
- [ ] For code, I have run `make test_all`
- [ ] For configurations, I have update the documentation
- [ ] I added TODOs where applicable
