### PR TITLE
[CI] build image on merge to main branch

### DIFF
--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -1,6 +1,9 @@
 name: Build image and push to ghcr.io
 
 on:
+  push:
+    branches:
+      - main
   workflow_run:
     workflows: ["Path tests"]
     types:


### PR DESCRIPTION
So we don't have to trigger manually wait for the new image build.. 