### PR TITLE
Fix EVM QoS block number validation: add a nil check

### DIFF
--- a/gateway/hydrator.go
+++ b/gateway/hydrator.go
@@ -145,7 +145,11 @@ func (eph *EndpointHydrator) run() {
 }
 
 func (eph *EndpointHydrator) performChecks(serviceID protocol.ServiceID, serviceQoS QoSService) error {
-	logger := eph.Logger.With("service_id", string(serviceID))
+	logger := eph.Logger.With(
+		"component", "hydrator",
+		"method", "perform_checks",
+		"service_id", string(serviceID),
+	)
 
 	// Passing a nil as the HTTP request, because we assume the hydrator uses "Centralized Operation Mode".
 	// This implies there is no need to specifying a specific app.
@@ -157,7 +161,10 @@ func (eph *EndpointHydrator) performChecks(serviceID protocol.ServiceID, service
 
 	// Ensure there is at least one endpoint available for the service.
 	if len(availableEndpoints) == 0 {
-		return fmt.Errorf("performChecks: no endpoints available for service %s when running hydrator checks", serviceID)
+		logger.Warn().Msg("no endpoints available for service when running hydrator checks.")
+		// No endpoints available: skip.
+		// do NOT return an error: hydrator and PATH should not report unhealthy status if a single service is unavailable.
+		return nil
 	}
 
 	logger = logger.With("number_of_endpoints", len(availableEndpoints))

--- a/qos/evm/endpoint_selection.go
+++ b/qos/evm/endpoint_selection.go
@@ -126,6 +126,10 @@ func (ss *serviceState) isBlockNumberValid(check endpointCheckBlockNumber) error
 		return errNoBlockNumberObs
 	}
 
+	if check.parsedBlockNumberResponse == nil {
+		return errNoBlockNumberObs
+	}
+
 	// If the endpoint's block height is less than the perceived block height minus the sync allowance,
 	// then the endpoint is behind the chain and should be filtered out.
 	minAllowedBlockNumber := ss.perceivedBlockNumber - ss.serviceConfig.getSyncAllowance()


### PR DESCRIPTION
## Summary

- Add a nil check in QoS EVM block number check processing
- Hydrator health status is not set to degraded with any single service failure.

### Primary Changes:
- QoS EVM Block number checks now includes a nil check.
- Hydrator health status is not modified based on a single service error.

## Issue

QoS EVM block number check causes panic if a parsed block number value is not set.

- Issue or PR: #{ISSUE_OR_PR_NUMBER}

## Type of change

Select one or more from the following:

- [ ] New feature, functionality or library
- [x] Bug fix
- [ ] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## QoS Checklist

### E2E Validation & Tests

- [ ] `make path_up`
- [ ] `make test_e2e_evm_shannon`
- [ ] `make test_e2e_evm_morse`

### Observability

- [x] 1. `make path_up`
- [x] 2. Run one of the following:
  - For `Shannon` with `anvil`: `make test_request__shannon_relay_util_100`
  - For `Morse` with `F00C`: `make test_request__morse_relay_util_100`
- [ ] 3. Visit [PATH Relay Grafana Dashboard](http://localhost:3003/d/relays/path-service-requests) to view results

## Sanity Checklist

- [ ] I have updated the GitHub Issue `assignees`, `reviewers`, `labels`, `project`, `iteration` and `milestone`
- [ ] For docs, I have run `make docusaurus_start`
- [ ] For code, I have run `make test_all`
- [ ] For configurations, I have updated the documentation
- [ ] I added `TODO`s where applicable
