### PR TITLE
[QoS] Fix solana observations panic

### DIFF
--- a/qos/cometbft/cometbft.go
+++ b/qos/cometbft/cometbft.go
@@ -32,8 +32,10 @@ type QoS struct {
 // Returns (context, false) if POST request is not valid JSON-RPC.
 // Implements gateway.QoSService interface.
 func (qos *QoS) ParseHTTPRequest(_ context.Context, req *http.Request) (gateway.RequestQoSContext, bool) {
+	logger := qos.logger.With("qos", "solana")
+
 	requestContext := &requestContext{
-		logger:        qos.logger,
+		logger:        logger,
 		httpReq:       req,
 		endpointStore: qos.EndpointStore,
 		isValid:       true,
@@ -46,7 +48,7 @@ func (qos *QoS) ParseHTTPRequest(_ context.Context, req *http.Request) (gateway.
 		// TODO_IMPROVE(@commoddity): implement JSON-RPC request validation.
 		body, err := io.ReadAll(req.Body)
 		if err != nil {
-			return requestContextFromInternalError(err), false
+			return requestContextFromInternalError(logger, err), false
 		}
 
 		// Store the serialized JSON-RPC request as a byte slice

--- a/qos/cometbft/request.go
+++ b/qos/cometbft/request.go
@@ -1,8 +1,17 @@
 package cometbft
 
-// TODO_MVP(@adshmh): return a request context to handle internal errors.
+import (
+	"github.com/pokt-network/poktroll/pkg/polylog"
+
+	"github.com/buildwithgrove/path/qos"
+	"github.com/buildwithgrove/path/qos/jsonrpc"
+)
+
 // requestContextFromInternalError returns a request context
 // for an internal error, e.g. error on reading the HTTP request body.
-func requestContextFromInternalError(err error) *requestContext {
-	return nil
+func requestContextFromInternalError(logger polylog.Logger, err error) *qos.RequestErrorContext {
+	return &qos.RequestErrorContext{
+		Logger:   logger,
+		Response: jsonrpc.NewErrResponseInternalErr(jsonrpc.ID{}, err),
+	}
 }

--- a/qos/error_context.go
+++ b/qos/error_context.go
@@ -99,7 +99,7 @@ type errorTrackingSelector struct {
 // Select method of an errorTrackingSelector should never be called.
 // It logs a warning and returns an invalid usage error.
 // Implements the protocol.EndpointSelector interface.
-func (ets errorTrackingSelector) Select(endpoints []protocol.EndpointAddr) (protocol.EndpointAddr, error) {
+func (ets errorTrackingSelector) Select(endpoints protocol.EndpointAddrList) (protocol.EndpointAddr, error) {
 	ets.logger.With(
 		"num_endpoints", len(endpoints),
 	).Warn().Msg("Invalid usage: errorTrackingSelector.Select() should never be called.")

--- a/qos/error_context.go
+++ b/qos/error_context.go
@@ -20,7 +20,7 @@ var (
 // RequestErrorContext provides the support required by the gateway package for handling service requests.
 var _ gateway.RequestQoSContext = &RequestErrorContext{}
 
-// RequestErrorContext terminates a JSONRPC-service request processing on errors (internal failures or invalid requests).
+// RequestErrorContext terminates the processing of a JSONRPC-service request on errors (internal failures or invalid requests).
 // Provides:
 //  1. Detailed error response to the user.
 //  2. Log entries to warn on potential incorrect usage.
@@ -38,9 +38,6 @@ type RequestErrorContext struct {
 func (rec *RequestErrorContext) GetHTTPResponse() gateway.HTTPResponse {
 	bz, err := json.Marshal(rec.Response)
 	if err != nil {
-		// TODO_IMPROVE(@adshmh): Standardize logger labels across packages
-		// 1. Create shared label schema for the evm package
-		// 2. Extend schema to other QoS packages
 		rec.Logger.With(
 			"component", "RequestErrorContext",
 			"method", "GetHTTPResponse",

--- a/qos/error_context.go
+++ b/qos/error_context.go
@@ -1,0 +1,111 @@
+package qos
+
+import (
+	"encoding/json"
+	"errors"
+
+	"github.com/pokt-network/poktroll/pkg/polylog"
+
+	"github.com/buildwithgrove/path/gateway"
+	qosobservations "github.com/buildwithgrove/path/observation/qos"
+	"github.com/buildwithgrove/path/protocol"
+	"github.com/buildwithgrove/path/qos/jsonrpc"
+)
+
+var (
+	// Error recording that endpoint selection was attempted but failed due to an invalid request
+	errInvalidSelectorUsage = errors.New("endpoint selection attempted on failed request")
+)
+
+// RequestErrorContext provides the support required by the gateway package for handling service requests.
+var _ gateway.RequestQoSContext = &RequestErrorContext{}
+
+// RequestErrorContext terminates a JSONRPC-service request processing on errors (internal failures or invalid requests).
+// Provides:
+//  1. Detailed error response to the user.
+//  2. Log entries to warn on potential incorrect usage.
+//
+// Implements gateway.RequestQoSContext
+type RequestErrorContext struct {
+	Logger polylog.Logger
+
+	// The response to be returned to the user.
+	Response jsonrpc.Response
+}
+
+// GetHTTPResponse formats the stored JSONRPC error as an HTTP response
+// Implements the gateway.RequestQoSContext interface.
+func (rec *RequestErrorContext) GetHTTPResponse() gateway.HTTPResponse {
+	bz, err := json.Marshal(rec.Response)
+	if err != nil {
+		// TODO_IMPROVE(@adshmh): Standardize logger labels across packages
+		// 1. Create shared label schema for the evm package
+		// 2. Extend schema to other QoS packages
+		rec.Logger.With(
+			"component", "RequestErrorContext",
+			"method", "GetHTTPResponse",
+		).Warn().Err(err).Msg("Failed to serialize client response.")
+	}
+
+	httpStatusCode := rec.Response.GetRecommendedHTTPStatusCode()
+
+	return httpResponse{
+		responsePayload: bz,
+		httpStatusCode:  httpStatusCode,
+	}
+}
+
+// TODO_MVP(@adshmh): Generate observations for the error context.
+// GetObservation returns the QoS observation set for the error context.
+// Implements the gateway.RequestQoSContext interface.
+func (rec *RequestErrorContext) GetObservations() qosobservations.Observations {
+	return qosobservations.Observations{}
+}
+
+// GetServicePayload should never be called.
+// It logs a warning and returns nil.
+// Implements the gateway.RequestQoSContext interface.
+func (rec *RequestErrorContext) GetServicePayload() protocol.Payload {
+	rec.Logger.Warn().Msg("Invalid usage: RequestErrorContext.GetServicePayload() should never be called.")
+	return protocol.Payload{}
+}
+
+// UpdateWithResponse should never be called.
+// Only logs a warning.
+// Implements the gateway.RequestQoSContext interface.
+func (rec *RequestErrorContext) UpdateWithResponse(endpointAddr protocol.EndpointAddr, endpointSerializedResponse []byte) {
+	rec.Logger.With(
+		"endpoint_addr", endpointAddr,
+		"endpoint_response_len", len(endpointSerializedResponse),
+	).Warn().Msg("Invalid usage: RequestErrorContext.UpdateWithResponse() should never be called.")
+}
+
+// UpdateWithResponse should never be called.
+// It logs a warning and returns a failing selector that logs a warning on all selection attempts.
+// Implements the gateway.RequestQoSContext interface.
+func (rec *RequestErrorContext) GetEndpointSelector() protocol.EndpointSelector {
+	rec.Logger.Warn().Msg("Invalid usage: RequestErrorContext.GetEndpointSelector() should never be called.")
+
+	return errorTrackingSelector{
+		logger: rec.Logger,
+	}
+}
+
+// errorTrackingSelector prevents panics in request handling goroutines by:
+// - Intentionally failing all endpoint selection attempts
+// - Logging diagnostic information when endpoint selection is incorrectly attempted on failed requests
+// Acts as a failsafe mechanism for request handling.
+type errorTrackingSelector struct {
+	logger polylog.Logger
+}
+
+// Select method of an errorTrackingSelector should never be called.
+// It logs a warning and returns an invalid usage error.
+// Implements the protocol.EndpointSelector interface.
+func (ets errorTrackingSelector) Select(endpoints []protocol.EndpointAddr) (protocol.EndpointAddr, error) {
+	ets.logger.With(
+		"num_endpoints", len(endpoints),
+	).Warn().Msg("Invalid usage: errorTrackingSelector.Select() should never be called.")
+
+	return protocol.EndpointAddr(""), errInvalidSelectorUsage
+}

--- a/qos/http.go
+++ b/qos/http.go
@@ -1,0 +1,52 @@
+package qos
+
+import (
+	"net/http"
+
+	"github.com/buildwithgrove/path/gateway"
+)
+
+// httpHeadersApplicationJSON is the `Content-Type` HTTP header used in all JSONRPC responses.
+var httpHeadersApplicationJSON = map[string]string{
+	"Content-Type": "application/json",
+}
+
+// httpResponse is used by the RequestContext to provide
+// an JSONRPC-specific implementation of gateway package's HTTPResponse.
+var _ gateway.HTTPResponse = httpResponse{}
+
+// httpResponse encapsulates an HTTP response to be returned to the client
+// including payload data and status code.
+type httpResponse struct {
+	// responsePayload contains the serialized response body.
+	responsePayload []byte
+
+	// httpStatusCode is the HTTP status code to be returned.
+	// If not explicitly set, defaults to http.StatusOK (200).
+	httpStatusCode int
+}
+
+// GetPayload returns the response payload as a byte slice.
+func (hr httpResponse) GetPayload() []byte {
+	return hr.responsePayload
+}
+
+// GetHTTPStatusCode returns the HTTP status code for this response.
+// If no status code was explicitly set, returns http.StatusOK (200).
+// StatusOK is returned by default from QoS because it is the responsibility of the QoS service to decide on the HTTP status code returned to the client.
+func (hr httpResponse) GetHTTPStatusCode() int {
+	// Return the custom status code if set, otherwise default to 200 OK
+	if hr.httpStatusCode != 0 {
+		return hr.httpStatusCode
+	}
+
+	// Default to 200 OK HTTP status code.
+	return http.StatusOK
+}
+
+// GetHTTPHeaders returns the set of headers for the HTTP response.
+// As of PR #72, the only header returned for JSONRPC is `Content-Type`.
+func (r httpResponse) GetHTTPHeaders() map[string]string {
+	// JSONRPC only uses the `Content-Type` HTTP header.
+	return httpHeadersApplicationJSON
+}

--- a/qos/jsonrpc/errors.go
+++ b/qos/jsonrpc/errors.go
@@ -1,0 +1,43 @@
+package jsonrpc
+
+import (
+	"fmt"
+)
+
+// NewErrResponseInternalErr creates a JSON-RPC error response when an internal error has occurred (e.g. reading HTTP request's body)
+// Marks the error as retryable to allow clients to safely retry their request.
+func NewErrResponseInternalErr(requestID ID, err error) Response {
+	return GetErrorResponse(
+		requestID,
+		-32000, // JSON-RPC standard server error code; https://www.jsonrpc.org/historical/json-rpc-2-0.html
+		fmt.Sprintf("internal error: %s", err.Error()), // Error Message
+		map[string]string{
+			"error": err.Error(),
+			// Custom extension - not part of the official JSON-RPC spec
+			// Marks the error as retryable to allow clients to safely retry their request
+			"retryable": "true",
+		},
+	)
+}
+
+// NewErrResponseInvalidRequest returns a JSON-RPC error response for malformed or invalid requests.
+// The error indicates the request cannot be processed due to issues like:
+//   - Failed JSON-RPC deserialization
+//   - Missing required JSON-RPC fields (e.g. `method`)
+//   - Unsupported JSON-RPC method
+//
+// If the request contains a valid JSON-RPC ID, it is included in the error response.
+// The error is marked as permanent since retrying without correcting the request will fail.
+func NewErrResponseInvalidRequest(requestID ID, err error) Response {
+	return GetErrorResponse(
+		requestID, // Use request's original ID if present
+		-32000,    // JSON-RPC standard server error code; https://www.jsonrpc.org/historical/json-rpc-2-0.html
+		fmt.Sprintf("invalid request: %s", err.Error()), // Error Message
+		map[string]string{
+			"error": err.Error(),
+			// Custom extension - not part of the official JSON-RPC spec
+			// Indicates this error is permanent - the request must be corrected as retrying will not succeed
+			"retryable": "false",
+		},
+	)
+}

--- a/qos/solana/request.go
+++ b/qos/solana/request.go
@@ -1,17 +1,28 @@
 package solana
 
-// TODO_MVP(@adshmh): return a request context to handle internal errors.
+import (
+	"github.com/pokt-network/poktroll/pkg/polylog"
+
+	"github.com/buildwithgrove/path/qos"
+	"github.com/buildwithgrove/path/qos/jsonrpc"
+)
+
 // requestContextFromInternalError returns a request context
 // for an internal error, e.g. error on reading the HTTP request body.
-func requestContextFromInternalError(err error) *requestContext {
-	return nil
+func requestContextFromInternalError(logger polylog.Logger, err error) *qos.RequestErrorContext {
+	return &qos.RequestErrorContext{
+		Logger:   logger,
+		Response: jsonrpc.NewErrResponseInternalErr(jsonrpc.ID{}, err),
+	}
 }
 
-// TODO_MVP(@adshmh): return a request context to handle user errors.
 // requestContextFromUserError returns a request context
 // for a user error, e.g. an unmarshaling error is a
 // user error because the request body, provided by the user,
 // cannot be parsed as a valid JSONRPC request.
-func requestContextFromUserError(err error) *requestContext {
-	return nil
+func requestContextFromUserError(logger polylog.Logger, err error) *qos.RequestErrorContext {
+	return &qos.RequestErrorContext{
+		Logger:   logger,
+		Response: jsonrpc.NewErrResponseInternalErr(jsonrpc.ID{}, err),
+	}
 }

--- a/qos/solana/solana.go
+++ b/qos/solana/solana.go
@@ -35,14 +35,16 @@ type QoS struct {
 //
 // Implements the gateway.QoSService interface.
 func (qos *QoS) ParseHTTPRequest(_ context.Context, req *http.Request) (gateway.RequestQoSContext, bool) {
+	logger := qos.logger.With("qos", "solana")
+
 	body, err := io.ReadAll(req.Body)
 	if err != nil {
-		return requestContextFromInternalError(err), false
+		return requestContextFromInternalError(logger, err), false
 	}
 
 	var jsonrpcReq jsonrpc.Request
 	if err := json.Unmarshal(body, &jsonrpcReq); err != nil {
-		return requestContextFromUserError(err), false
+		return requestContextFromUserError(logger, err), false
 	}
 
 	// TODO_TECHDEBT(@adshmh): validate the JSONRPC request to block invalid requests from being sent to endpoints.


### PR DESCRIPTION
## Summary

Implement error context for Solana and CometBFT QoS.

### Primary Changes:

- Added a shared error context to `qos` package.
- Use the new error context in Solana and CometBFT.

## Issue

Panic in Solana and CometBFT on internal errors/invalid requests.

- Issue or PR: #{ISSUE_OR_PR_NUMBER}

## Type of change

Select one or more from the following:

- [x] New feature, functionality or library
- [x] Bug fix
- [ ] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## QoS Checklist

### E2E Validation & Tests

- [x] `make path_up`
- [ ] `make test_e2e_evm_shannon`
- [ ] `make test_e2e_evm_morse`

### Observability

- [x] 1. `make path_up`
- [x] 2. Run one of the following:
  - For `Shannon` with `anvil`: `make test_request__shannon_relay_util_100`
  - For `Morse` with `F00C`: `make test_request__morse_relay_util_100`
- [ ] 3. Visit [PATH Relay Grafana Dashboard](http://localhost:3003/d/relays/path-service-requests) to view results

## Sanity Checklist

- [x] I have updated the GitHub Issue `assignees`, `reviewers`, `labels`, `project`, `iteration` and `milestone`
- [ ] For docs, I have run `make docusaurus_start`
- [ ] For code, I have run `make test_all`
- [ ] For configurations, I have updated the documentation
- [ ] I added `TODO`s where applicable
