### PR TITLE
Fix: update Morse pocketcore error pattern match rules

### DIFF
--- a/protocol/morse/errors.go
+++ b/protocol/morse/errors.go
@@ -191,7 +191,7 @@ func isEndpointPocketCoreError(errStr string) bool {
 		[]string{
 			"codespace: sdk",
 			"code: 1",
-			"codespace: pocketcore",
+			"Codespace: sdk",
 		},
 	)
 }


### PR DESCRIPTION
## Summary

Fix the Morse integration error pattern rule on SDK errors.

### Primary Changes:

Fix the Morse integration error pattern rule on SDK errors.

## Issue

Endpoint errors not captured due to incorrect pattern used for sanctioning endpoints with errors.

- Issue or PR: #{ISSUE_OR_PR_NUMBER}

## Type of change

Select one or more from the following:

- [ ] New feature, functionality or library
- [x] Bug fix
- [ ] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## QoS Checklist

### E2E Validation & Tests

- [x] `make path_up`
- [ ] `make test_e2e_evm_shannon`
- [ ] `make test_e2e_evm_morse`

### Observability

- [x] 1. `make path_up`
- [x] 2. Run one of the following:
  - For `Shannon` with `anvil`: `make test_request__shannon_relay_util_100`
  - For `Morse` with `F00C`: `make test_request__morse_relay_util_100`
- [ ] 3. Visit [PATH Relay Grafana Dashboard](http://localhost:3003/d/relays/path-service-requests) to view results

## Sanity Checklist

- [x] I have updated the GitHub Issue `assignees`, `reviewers`, `labels`, `project`, `iteration` and `milestone`
- [ ] For docs, I have run `make docusaurus_start`
- [ ] For code, I have run `make test_all`
- [ ] For configurations, I have updated the documentation
- [ ] I added `TODO`s where applicable
