### PR TITLE
Fix success label processor in Morse metrics

### DIFF
--- a/metrics/protocol/morse/metrics.go
+++ b/metrics/protocol/morse/metrics.go
@@ -148,7 +148,7 @@ func recordRelayTotal(serviceID string, observations []*protocol.MorseEndpointOb
 // isAnyObservationSuccessful returns true if any observation succeeded (no error)
 func isAnyObservationSuccessful(observations []*protocol.MorseEndpointObservation) bool {
 	for _, obs := range observations {
-		if obs.GetErrorType() != protocol.MorseEndpointErrorType_MORSE_ENDPOINT_ERROR_UNSPECIFIED {
+		if obs.GetErrorType() == protocol.MorseEndpointErrorType_MORSE_ENDPOINT_ERROR_UNSPECIFIED {
 			return true
 		}
 	}


### PR DESCRIPTION
## Summary

Fix bug/typo in Morse metrics success calculation.

### Primary Changes:

- Fix the typo in success calculator function.


## Issue

Incorrect Success label setting.

- Issue or PR: #{ISSUE_OR_PR_NUMBER}

## Type of change

Select one or more from the following:

- [ ] New feature, functionality or library
- [x] Bug fix
- [ ] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## QoS Checklist

### E2E Validation & Tests

- [x] `make path_up`
- [ ] `make test_e2e_evm_shannon`
- [ ] `make test_e2e_evm_morse`

### Observability

- [x] 1. `make path_up`
- [x] 2. Run one of the following:
  - For `Shannon` with `anvil`: `make test_request__shannon_relay_util_100`
  - For `Morse` with `F00C`: `make test_request__morse_relay_util_100`
- [ ] 3. Visit [PATH Relay Grafana Dashboard](http://localhost:3003/d/relays/path-service-requests) to view results

## Sanity Checklist

- [x] I have updated the GitHub Issue `assignees`, `reviewers`, `labels`, `project`, `iteration` and `milestone`
- [ ] For docs, I have run `make docusaurus_start`
- [ ] For code, I have run `make test_all`
- [ ] For configurations, I have updated the documentation
- [ ] I added `TODO`s where applicable
