### PR TITLE
[QoS][Solana] Fix: Set endpointStore on request context

### DIFF
--- a/qos/solana/qos.go
+++ b/qos/solana/qos.go
@@ -25,10 +25,10 @@ func NewQoSInstance(logger polylog.Logger, serviceConfig SolanaServiceQoSConfig)
 	}
 
 	requestValidator := &requestValidator{
-		logger:       logger,
-		serviceID:    serviceID,
-		chainID:      chainID,
-		serviceState: serviceState,
+		logger:        logger,
+		serviceID:     serviceID,
+		chainID:       chainID,
+		endpointStore: solanaEndpointStore,
 	}
 
 	return &QoS{

--- a/qos/solana/request_validator.go
+++ b/qos/solana/request_validator.go
@@ -27,10 +27,10 @@ const maxErrMessageLen = 1000
 // - Generates request context if validation succeeds
 // - Used as the entry point for HTTP request validation
 type requestValidator struct {
-	logger       polylog.Logger
-	chainID      string
-	serviceID    protocol.ServiceID
-	serviceState *ServiceState
+	logger        polylog.Logger
+	chainID       string
+	serviceID     protocol.ServiceID
+	endpointStore *EndpointStore
 }
 
 // validateHTTPRequest:
@@ -67,6 +67,7 @@ func (rv *requestValidator) validateHTTPRequest(req *http.Request) (gateway.Requ
 		// Set the origin of the request as USER (i.e. organic relay)
 		// The request is from a user.
 		requestOrigin: qosobservations.RequestOrigin_REQUEST_ORIGIN_ORGANIC,
+		endpointStore: rv.endpointStore,
 	}, true
 }
 


### PR DESCRIPTION
## Summary

Set the Endpoint Store on Solana Request Context.

### Primary Changes:

- Set the Endpoint Store on Solana Request Context.


## Issue

Endpoint selection will cause a panic without the endpoint store set.

- Issue or PR: #{ISSUE_OR_PR_NUMBER}

## Type of change

Select one or more from the following:

- [ ] New feature, functionality or library
- [x] Bug fix
- [ ] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## QoS Checklist

### E2E Validation & Tests

- [ ] `make path_up`
- [ ] `make test_e2e_evm_shannon`
- [ ] `make test_e2e_evm_morse`

### Observability

- [x] 1. `make path_up`
- [x] 2. Run one of the following:
  - For `Shannon` with `anvil`: `make test_request__shannon_relay_util_100`
  - For `Morse` with `F00C`: `make test_request__morse_relay_util_100`
- [ ] 3. Visit [PATH Relay Grafana Dashboard](http://localhost:3003/d/relays/path-service-requests) to view results

## Sanity Checklist

- [x] I have updated the GitHub Issue `assignees`, `reviewers`, `labels`, `project`, `iteration` and `milestone`
- [ ] For docs, I have run `make docusaurus_start`
- [ ] For code, I have run `make test_all`
- [ ] For configurations, I have updated the documentation
- [ ] I added `TODO`s where applicable
