### PR TITLE
[Data] Add configurable HTTP POST timeout for data reporter

### DIFF
--- a/cmd/data.go
+++ b/cmd/data.go
@@ -29,5 +29,6 @@ func setupHTTPDataReporter(
 	return &data.DataReporterHTTP{
 		Logger:           logger,
 		DataProcessorURL: config.TargetURL,
+		PostTimeoutMS:    config.PostTimeoutMS,
 	}, nil
 }

--- a/config/config.schema.yaml
+++ b/config/config.schema.yaml
@@ -244,3 +244,7 @@ properties:
         description: "The URL where the data will be reported to."
         type: string
         pattern: "^(http|https)://.*$"
+      post_timeout_ms:
+        description: "Timeout in milliseconds for HTTP POST operations. If zero or negative, a default timeout of 10000ms (10s) is used."
+        type: integer
+        default: 10000

--- a/config/data_reporter.go
+++ b/config/data_reporter.go
@@ -7,4 +7,8 @@ type HTTPDataReporterConfig struct {
 	// HTTP endpoint for data delivery.
 	// Example: Fluentd HTTP input plugin address.
 	TargetURL string `yaml:"target_url"`
+
+	// Timeout in milliseconds for HTTP POST operations.
+	// If zero or negative, a default timeout will be used.
+	PostTimeoutMS int `yaml:"post_timeout_ms"`
 }

--- a/docusaurus/docs/develop/path/5_configurations_path.md
+++ b/docusaurus/docs/develop/path/5_configurations_path.md
@@ -25,6 +25,7 @@ A `PATH` stack is configured via two files:
   - [Manually Disable QoS Checks for a Service](#manually-disable-qos-checks-for-a-service)
 - [`router_config` (optional)](#router_config-optional)
 - [`logger_config` (optional)](#logger_config-optional)
+- [`data_reporter_config` (optional)](#data_reporter_config-optional)
 
 All configuration for the `PATH` gateway is defined in a single YAML file named `.config.yaml`.
 
@@ -285,3 +286,24 @@ logger_config:
 | Field   | Type   | Required | Default | Description                                                           |
 | ------- | ------ | -------- | ------- | --------------------------------------------------------------------- |
 | `level` | string | No       | "info"  | Minimum log level. Valid values are: "debug", "info", "warn", "error" |
+
+---
+
+## `data_reporter_config` (optional)
+
+Configures HTTP-based data reporting to external services like BigQuery via data pipelines (e.g., Fluentd with HTTP input and BigQuery output plugins).
+
+```yaml
+data_reporter_config:
+  target_url: "https://fluentd-service.example.com/http-input"
+  post_timeout_ms: 5000
+```
+
+| Field            | Type    | Required | Default | Description                                                                                         |
+| ---------------- | ------- | -------- | ------- | --------------------------------------------------------------------------------------------------- |
+| `target_url`     | string  | Yes      | -       | HTTP endpoint URL where data will be reported (must start with http:// or https://)                 |
+| `post_timeout_ms`| integer | No       | 10000   | Timeout in milliseconds for HTTP POST operations. If zero or negative, default of 10000ms is used   |
+
+:::info
+Currently, only JSON-accepting data pipelines are supported as of PR #215.
+:::


### PR DESCRIPTION
## Summary

Add configurable HTTP POST timeout for data reporter

### Primary Changes:

- Add PostTimeoutMS field to DataReporterHTTP struct
- Implement configurable timeout for HTTP POST operations with default of 10 seconds
- Create custom HTTP client with timeout instead of using standard http.Post

### Secondary changes:

- Add YAML configuration option post_timeout_ms to HTTPDataReporterConfig
- Include proper cleanup with defer resp.Body.Close() in HTTP request handler
- Add documentation for timeout configuration parameters

## Issue

Increase in number of goroutines if the Data Pipeline is turned off.

- Issue or PR: #{ISSUE_OR_PR_NUMBER}

## Type of change

Select one or more from the following:

- [x] New feature, functionality or library
- [ ] Bug fix
- [x] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## QoS Checklist

### E2E Validation & Tests

- [x] `make path_up`
- [ ] `make test_e2e_evm_shannon`
- [x] `make test_e2e_evm_morse`

### Observability

- [x] 1. `make path_up`
- [x] 2. Run one of the following:
  - For `Shannon` with `anvil`: `make test_request__shannon_relay_util_100`
  - For `Morse` with `F00C`: `make test_request__morse_relay_util_100`
- [ ] 3. Visit [PATH Relay Grafana Dashboard](http://localhost:3003/d/relays/path-service-requests) to view results

## Sanity Checklist

- [x] I have updated the GitHub Issue `assignees`, `reviewers`, `labels`, `project`, `iteration` and `milestone`
- [ ] For docs, I have run `make docusaurus_start`
- [ ] For code, I have run `make test_all`
- [ ] For configurations, I have updated the documentation
- [ ] I added `TODO`s where applicable