### PR TITLE
[DATA] Adjusting legacy fields to use milliseconds instead of seconds

### DIFF
--- a/data/legacy_gateway.go
+++ b/data/legacy_gateway.go
@@ -63,7 +63,7 @@ func setLegacyFieldsFromGatewayObservations(
 	legacyRecord.RequestTimestamp = formatTimestampPbForBigQueryJSON(observations.ReceivedTime)
 
 	// Request processing time, in seconds.
-	legacyRecord.RequestRoundTripTime = observations.CompletedTime.AsTime().Sub(observations.ReceivedTime.AsTime()).Seconds()
+	legacyRecord.RequestRoundTripTime = observations.CompletedTime.AsTime().Sub(observations.ReceivedTime.AsTime()).Milliseconds()
 
 	return legacyRecord
 }

--- a/data/legacy_protocol.go
+++ b/data/legacy_protocol.go
@@ -75,7 +75,7 @@ func setLegacyFieldsFromMorseProtocolObservations(
 	legacyRecord.NodeReceiveTimestamp = formatTimestampPbForBigQueryJSON(endpointObservation.EndpointResponseTimestamp)
 
 	// track time spent waiting for the endpoint: required for calculating the `PortalTripTime` legacy field.
-	legacyRecord.endpointTripTime = endpointObservation.EndpointResponseTimestamp.AsTime().Sub(endpointObservation.EndpointQueryTimestamp.AsTime()).Seconds()
+	legacyRecord.endpointTripTime = endpointObservation.EndpointResponseTimestamp.AsTime().Sub(endpointObservation.EndpointQueryTimestamp.AsTime()).Milliseconds()
 
 	// Set endpoint address
 	legacyRecord.NodeAddress = endpointObservation.EndpointAddr


### PR DESCRIPTION
## Summary

Adjusting legacy fields to use milliseconds instead of seconds

### Primary Changes:

- Alter the `legacy_gateway.go` to count the relay trip time in milliseconds
- Adjust `legacy_protocol.go` to count the relay trip time in milliseconds
- Doesn't touch any actual reporter code as of the first commit.

## Type of change

Select one or more from the following:

- [ ] New feature, functionality or library
- [x] Bug fix
- [ ] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

### E2E Validation & Tests

- [ ] `make path_up`
- [ ] `make test_e2e_evm_shannon`
- [ ] `make test_e2e_evm_morse`

### Observability

- [ ] 1. `make path_up`
- [ ] 2. Run one of the following:
  - For `Shannon` with `anvil`: `make test_request__shannon_relay_util_100`
  - For `Morse` with `F00C`: `make test_request__morse_relay_util_100`
- [ ] 3. Visit [PATH Relay Grafana Dashboard](http://localhost:3003/d/relays/path-service-requests) to view results

## Sanity Checklist

- [ ] I have updated the GitHub Issue `assignees`, `reviewers`, `labels`, `project`, `iteration` and `milestone`
- [ ] For docs, I have run `make docusaurus_start`
- [ ] For code, I have run `make test_all`
- [ ] For configurations, I have updated the documentation
- [ ] I added `TODO`s where applicable
