### PR TITLE
[Protocol][Shannon][Observability]Fix: protocol observations are not empty in any scenario

### DIFF
--- a/gateway/errors.go
+++ b/gateway/errors.go
@@ -1,0 +1,8 @@
+package gateway
+
+import (
+	"errors"
+)
+
+// Gateway request error indicating no service ID was provided by the user.
+var GatewayErrNoServiceIDProvided = errors.New("no service ID provided")

--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -102,16 +102,9 @@ func (g Gateway) handleHTTPServiceRequest(ctx context.Context, httpReq *http.Req
 		gatewayRequestCtx.WriteHTTPUserResponse(w)
 	}()
 
-	// Initialize the GatewayRequestContext struct using the HTTP request.
-	// e.g. extract the target service ID from the HTTP request.
-	err := gatewayRequestCtx.InitFromHTTPRequest(httpReq)
-	if err != nil {
-		return
-	}
-
 	// TODO_TECHDEBT(@adshmh): Pass the context with deadline to QoS once it can handle deadlines.
 	// Build the QoS context for the target service ID using the HTTP request's payload.
-	err = gatewayRequestCtx.BuildQoSContextFromHTTP(httpReq)
+	err := gatewayRequestCtx.BuildQoSContextFromHTTP(httpReq)
 	if err != nil {
 		return
 	}

--- a/gateway/hydrator.go
+++ b/gateway/hydrator.go
@@ -135,7 +135,8 @@ func (eph *EndpointHydrator) performChecks(serviceID protocol.ServiceID, service
 	// Passing a nil as the HTTP request, because we assume the hydrator uses "Centralized Operation Mode".
 	// This implies there is no need to specify a specific app.
 	// TODO_TECHDEBT(@adshmh): support specifying the app(s) used for sending/signing synthetic relay requests by the hydrator.
-	availableEndpoints, err := eph.Protocol.AvailableEndpoints(context.TODO(), serviceID, nil)
+	// TODO_FUTURE(@adshmh): consider publishing observations if endpoint lookup fails.
+	availableEndpoints, _, err := eph.Protocol.AvailableEndpoints(context.TODO(), serviceID, nil)
 	if err != nil || len(availableEndpoints) == 0 {
 		// No session found or no endpoints available for service: skip.
 		logger.Warn().Msg("no session found or no endpoints available for service when running hydrator checks.")
@@ -176,7 +177,8 @@ func (eph *EndpointHydrator) performChecks(serviceID protocol.ServiceID, service
 					// Passing a nil as the HTTP request, because we assume the Centralized Operation Mode being used by the hydrator,
 					// which means there is no need for specifying a specific app.
 					// TODO_FUTURE(@adshmh): support specifying the app(s) used for sending/signing synthetic relay requests by the hydrator.
-					hydratorRequestCtx, err := eph.Protocol.BuildRequestContextForEndpoint(context.TODO(), serviceID, endpointAddr, nil)
+					// TODO_FUTURE(@adshmh): consider publishing observations here.
+					hydratorRequestCtx, _, err := eph.Protocol.BuildRequestContextForEndpoint(context.TODO(), serviceID, endpointAddr, nil)
 					if err != nil {
 						logger.Error().Err(err).Msg("Failed to build a protocol request context for the endpoint")
 						continue

--- a/gateway/protocol.go
+++ b/gateway/protocol.go
@@ -19,7 +19,12 @@ type Protocol interface {
 	// (Shannon only: in Delegated mode, the staked application is passed in the request header, which
 	// filters the list of available endpoints. In all other modes, *http.Request will be nil.)
 	// Context may contain a deadline that protocol should respect on best-effort basis.
-	AvailableEndpoints(context.Context, protocol.ServiceID, *http.Request) (protocol.EndpointAddrList, error)
+	// Should return an observation to use if the endpoint lookup fails.
+	AvailableEndpoints(
+		context.Context,
+		protocol.ServiceID,
+		*http.Request,
+	) (protocol.EndpointAddrList, protocolobservations.Observations, error)
 
 	// BuildRequestContextForEndpoint builds and returns a ProtocolRequestContext containing a single selected endpoint.
 	// One `ProtocolRequestContext` correspond to a single request, which is sent to a single endpoint.
@@ -27,7 +32,13 @@ type Protocol interface {
 	// (Shannon only: in Delegated mode, the staked application is passed in the request header, which
 	// filters the list of available endpoints. In all other modes, *http.Request will be nil.)
 	// Context may contain a deadline that protocol should respect on best-effort basis.
-	BuildRequestContextForEndpoint(context.Context, protocol.ServiceID, protocol.EndpointAddr, *http.Request) (ProtocolRequestContext, error)
+	// Should return an observation to use if the context setup fails.
+	BuildRequestContextForEndpoint(
+		context.Context,
+		protocol.ServiceID,
+		protocol.EndpointAddr,
+		*http.Request,
+	) (ProtocolRequestContext, protocolobservations.Observations, error)
 
 	// SupportedGatewayModes returns the Gateway modes supported by the protocol instance.
 	// See protocol/gateway_mode.go for more details.

--- a/metrics/prometheus_reporter.go
+++ b/metrics/prometheus_reporter.go
@@ -26,7 +26,15 @@ func (pmr *PrometheusMetricsReporter) Publish(observations *observation.RequestR
 	// https://www.notion.so/buildwithgrove/PATH-Metrics-130a36edfff680febab5d31ee871af87
 
 	// Publish Gateway observations
-	publishGatewayMetrics(observations.GetGateway())
+	gatewayObservations := observations.GetGateway()
+	isRequestValid := publishGatewayMetrics(gatewayObservations)
+
+	// Request was invalid: skip Protocol and QoS observations.
+	// e.g.: no service ID was specified by the HTTP header.
+	if !isRequestValid {
+		pmr.Logger.Info().Msg("Invalid request: No Protocol or QoS observations were made.")
+		return
+	}
 
 	// Publish QoS observations
 	qos.PublishQoSMetrics(pmr.Logger, observations.GetQos())

--- a/observation/gateway.pb.go
+++ b/observation/gateway.pb.go
@@ -33,8 +33,10 @@ type RequestType int32
 
 const (
 	RequestType_REQUEST_TYPE_UNSPECIFIED RequestType = 0
-	RequestType_REQUEST_TYPE_ORGANIC     RequestType = 1 // Service request sent by a user.
-	RequestType_REQUEST_TYPE_SYNTHETIC   RequestType = 2 // Service request sent by the endpoint hydrator: see gateway/hydrator.go.
+	// Organic: Service request sent by a user.
+	RequestType_REQUEST_TYPE_ORGANIC RequestType = 1
+	// Synthetic: Service request sent by the endpoint hydrator: see gateway/hydrator.go.
+	RequestType_REQUEST_TYPE_SYNTHETIC RequestType = 2
 )
 
 // Enum value maps for RequestType.
@@ -78,13 +80,60 @@ func (RequestType) EnumDescriptor() ([]byte, []int) {
 	return file_path_gateway_proto_rawDescGZIP(), []int{0}
 }
 
+type GatewayRequestErrorKind int32
+
+const (
+	GatewayRequestErrorKind_GATEWAY_REQUEST_ERROR_KIND_UNSPECIFIED GatewayRequestErrorKind = 0
+	// Service ID not specified.
+	GatewayRequestErrorKind_GATEWAY_REQUEST_ERROR_KIND_MISSING_SERVICE_ID GatewayRequestErrorKind = 1
+)
+
+// Enum value maps for GatewayRequestErrorKind.
+var (
+	GatewayRequestErrorKind_name = map[int32]string{
+		0: "GATEWAY_REQUEST_ERROR_KIND_UNSPECIFIED",
+		1: "GATEWAY_REQUEST_ERROR_KIND_MISSING_SERVICE_ID",
+	}
+	GatewayRequestErrorKind_value = map[string]int32{
+		"GATEWAY_REQUEST_ERROR_KIND_UNSPECIFIED":        0,
+		"GATEWAY_REQUEST_ERROR_KIND_MISSING_SERVICE_ID": 1,
+	}
+)
+
+func (x GatewayRequestErrorKind) Enum() *GatewayRequestErrorKind {
+	p := new(GatewayRequestErrorKind)
+	*p = x
+	return p
+}
+
+func (x GatewayRequestErrorKind) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (GatewayRequestErrorKind) Descriptor() protoreflect.EnumDescriptor {
+	return file_path_gateway_proto_enumTypes[1].Descriptor()
+}
+
+func (GatewayRequestErrorKind) Type() protoreflect.EnumType {
+	return &file_path_gateway_proto_enumTypes[1]
+}
+
+func (x GatewayRequestErrorKind) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use GatewayRequestErrorKind.Descriptor instead.
+func (GatewayRequestErrorKind) EnumDescriptor() ([]byte, []int) {
+	return file_path_gateway_proto_rawDescGZIP(), []int{1}
+}
+
 // GatewayObservations is the set of observations on a service request, made from the perspective of a gateway.
 // Examples include the geographic region of the request, the request type, etc.
 type GatewayObservations struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// request_auth stores any fields related to the identification/authentication of the request.
 	RequestAuth *RequestAuth `protobuf:"bytes,1,opt,name=request_auth,json=requestAuth,proto3" json:"request_auth,omitempty"`
-	// Specifies the request type.
+	// Specifies the request origin.
 	// For example, wWhether the request was sent by a user or synthetically generated (e.g. by the endpoint hydrator).
 	RequestType RequestType `protobuf:"varint,2,opt,name=request_type,json=requestType,proto3,enum=path.RequestType" json:"request_type,omitempty"`
 	// service_id is the identifier specified via custom HTTP header.
@@ -95,7 +144,10 @@ type GatewayObservations struct {
 	// completed_time is when request processing finished and response was returned
 	CompletedTime *timestamppb.Timestamp `protobuf:"bytes,5,opt,name=completed_time,json=completedTime,proto3" json:"completed_time,omitempty"`
 	// response_size is the size in bytes of the response payload
-	ResponseSize  uint64 `protobuf:"varint,6,opt,name=response_size,json=responseSize,proto3" json:"response_size,omitempty"`
+	ResponseSize uint64 `protobuf:"varint,6,opt,name=response_size,json=responseSize,proto3" json:"response_size,omitempty"`
+	// gateway-level request error, if any.
+	// e.g. no service ID specified.
+	RequestError  *GatewayRequestError `protobuf:"bytes,7,opt,name=request_error,json=requestError,proto3,oneof" json:"request_error,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -172,11 +224,74 @@ func (x *GatewayObservations) GetResponseSize() uint64 {
 	return 0
 }
 
+func (x *GatewayObservations) GetRequestError() *GatewayRequestError {
+	if x != nil {
+		return x.RequestError
+	}
+	return nil
+}
+
+// Tracks any errors encountered at the gateway level.
+// e.g.: No Service ID specified by the request's HTTP headers.
+type GatewayRequestError struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Categorizes the error
+	ErrorKind GatewayRequestErrorKind `protobuf:"varint,1,opt,name=error_kind,json=errorKind,proto3,enum=path.GatewayRequestErrorKind" json:"error_kind,omitempty"`
+	// Detailed reason
+	Details       string `protobuf:"bytes,2,opt,name=details,proto3" json:"details,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GatewayRequestError) Reset() {
+	*x = GatewayRequestError{}
+	mi := &file_path_gateway_proto_msgTypes[1]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GatewayRequestError) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GatewayRequestError) ProtoMessage() {}
+
+func (x *GatewayRequestError) ProtoReflect() protoreflect.Message {
+	mi := &file_path_gateway_proto_msgTypes[1]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GatewayRequestError.ProtoReflect.Descriptor instead.
+func (*GatewayRequestError) Descriptor() ([]byte, []int) {
+	return file_path_gateway_proto_rawDescGZIP(), []int{1}
+}
+
+func (x *GatewayRequestError) GetErrorKind() GatewayRequestErrorKind {
+	if x != nil {
+		return x.ErrorKind
+	}
+	return GatewayRequestErrorKind_GATEWAY_REQUEST_ERROR_KIND_UNSPECIFIED
+}
+
+func (x *GatewayRequestError) GetDetails() string {
+	if x != nil {
+		return x.Details
+	}
+	return ""
+}
+
 var File_path_gateway_proto protoreflect.FileDescriptor
 
 const file_path_gateway_proto_rawDesc = "" +
 	"\n" +
-	"\x12path/gateway.proto\x12\x04path\x1a\x1fgoogle/protobuf/timestamp.proto\x1a\x0fpath/auth.proto\"\xc9\x02\n" +
+	"\x12path/gateway.proto\x12\x04path\x1a\x1fgoogle/protobuf/timestamp.proto\x1a\x0fpath/auth.proto\"\xa0\x03\n" +
 	"\x13GatewayObservations\x124\n" +
 	"\frequest_auth\x18\x01 \x01(\v2\x11.path.RequestAuthR\vrequestAuth\x124\n" +
 	"\frequest_type\x18\x02 \x01(\x0e2\x11.path.RequestTypeR\vrequestType\x12\x1d\n" +
@@ -184,11 +299,20 @@ const file_path_gateway_proto_rawDesc = "" +
 	"service_id\x18\x03 \x01(\tR\tserviceId\x12?\n" +
 	"\rreceived_time\x18\x04 \x01(\v2\x1a.google.protobuf.TimestampR\freceivedTime\x12A\n" +
 	"\x0ecompleted_time\x18\x05 \x01(\v2\x1a.google.protobuf.TimestampR\rcompletedTime\x12#\n" +
-	"\rresponse_size\x18\x06 \x01(\x04R\fresponseSize*a\n" +
+	"\rresponse_size\x18\x06 \x01(\x04R\fresponseSize\x12C\n" +
+	"\rrequest_error\x18\a \x01(\v2\x19.path.GatewayRequestErrorH\x00R\frequestError\x88\x01\x01B\x10\n" +
+	"\x0e_request_error\"m\n" +
+	"\x13GatewayRequestError\x12<\n" +
+	"\n" +
+	"error_kind\x18\x01 \x01(\x0e2\x1d.path.GatewayRequestErrorKindR\terrorKind\x12\x18\n" +
+	"\adetails\x18\x02 \x01(\tR\adetails*a\n" +
 	"\vRequestType\x12\x1c\n" +
 	"\x18REQUEST_TYPE_UNSPECIFIED\x10\x00\x12\x18\n" +
 	"\x14REQUEST_TYPE_ORGANIC\x10\x01\x12\x1a\n" +
-	"\x16REQUEST_TYPE_SYNTHETIC\x10\x02B,Z*github.com/buildwithgrove/path/observationb\x06proto3"
+	"\x16REQUEST_TYPE_SYNTHETIC\x10\x02*x\n" +
+	"\x17GatewayRequestErrorKind\x12*\n" +
+	"&GATEWAY_REQUEST_ERROR_KIND_UNSPECIFIED\x10\x00\x121\n" +
+	"-GATEWAY_REQUEST_ERROR_KIND_MISSING_SERVICE_ID\x10\x01B,Z*github.com/buildwithgrove/path/observationb\x06proto3"
 
 var (
 	file_path_gateway_proto_rawDescOnce sync.Once
@@ -202,24 +326,28 @@ func file_path_gateway_proto_rawDescGZIP() []byte {
 	return file_path_gateway_proto_rawDescData
 }
 
-var file_path_gateway_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_path_gateway_proto_msgTypes = make([]protoimpl.MessageInfo, 1)
+var file_path_gateway_proto_enumTypes = make([]protoimpl.EnumInfo, 2)
+var file_path_gateway_proto_msgTypes = make([]protoimpl.MessageInfo, 2)
 var file_path_gateway_proto_goTypes = []any{
 	(RequestType)(0),              // 0: path.RequestType
-	(*GatewayObservations)(nil),   // 1: path.GatewayObservations
-	(*RequestAuth)(nil),           // 2: path.RequestAuth
-	(*timestamppb.Timestamp)(nil), // 3: google.protobuf.Timestamp
+	(GatewayRequestErrorKind)(0),  // 1: path.GatewayRequestErrorKind
+	(*GatewayObservations)(nil),   // 2: path.GatewayObservations
+	(*GatewayRequestError)(nil),   // 3: path.GatewayRequestError
+	(*RequestAuth)(nil),           // 4: path.RequestAuth
+	(*timestamppb.Timestamp)(nil), // 5: google.protobuf.Timestamp
 }
 var file_path_gateway_proto_depIdxs = []int32{
-	2, // 0: path.GatewayObservations.request_auth:type_name -> path.RequestAuth
+	4, // 0: path.GatewayObservations.request_auth:type_name -> path.RequestAuth
 	0, // 1: path.GatewayObservations.request_type:type_name -> path.RequestType
-	3, // 2: path.GatewayObservations.received_time:type_name -> google.protobuf.Timestamp
-	3, // 3: path.GatewayObservations.completed_time:type_name -> google.protobuf.Timestamp
-	4, // [4:4] is the sub-list for method output_type
-	4, // [4:4] is the sub-list for method input_type
-	4, // [4:4] is the sub-list for extension type_name
-	4, // [4:4] is the sub-list for extension extendee
-	0, // [0:4] is the sub-list for field type_name
+	5, // 2: path.GatewayObservations.received_time:type_name -> google.protobuf.Timestamp
+	5, // 3: path.GatewayObservations.completed_time:type_name -> google.protobuf.Timestamp
+	3, // 4: path.GatewayObservations.request_error:type_name -> path.GatewayRequestError
+	1, // 5: path.GatewayRequestError.error_kind:type_name -> path.GatewayRequestErrorKind
+	6, // [6:6] is the sub-list for method output_type
+	6, // [6:6] is the sub-list for method input_type
+	6, // [6:6] is the sub-list for extension type_name
+	6, // [6:6] is the sub-list for extension extendee
+	0, // [0:6] is the sub-list for field type_name
 }
 
 func init() { file_path_gateway_proto_init() }
@@ -228,13 +356,14 @@ func file_path_gateway_proto_init() {
 		return
 	}
 	file_path_auth_proto_init()
+	file_path_gateway_proto_msgTypes[0].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_path_gateway_proto_rawDesc), len(file_path_gateway_proto_rawDesc)),
-			NumEnums:      1,
-			NumMessages:   1,
+			NumEnums:      2,
+			NumMessages:   2,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/observation/protocol/shannon.pb.go
+++ b/observation/protocol/shannon.pb.go
@@ -28,6 +28,26 @@ type ShannonRequestErrorType int32
 const (
 	ShannonRequestErrorType_SHANNON_REQUEST_ERROR_UNSPECIFIED ShannonRequestErrorType = 0
 	ShannonRequestErrorType_SHANNON_REQUEST_ERROR_INTERNAL    ShannonRequestErrorType = 1 // Internal error.
+	// No endpoints available for the service
+	// Due to one or more of the following:
+	// - Any of the gateway mode errors above
+	// - Error fetching a session for one or more apps.
+	// - One or more available endpoints are sanctioned.
+	ShannonRequestErrorType_SHANNON_REQUEST_ERROR_INTERNAL_NO_ENDPOINTS_AVAILABLE ShannonRequestErrorType = 2
+	// Centralized gateway mode: Error fetching the app.
+	ShannonRequestErrorType_SHANNON_REQUEST_ERROR_INTERNAL_CENTRALIZED_MODE_APP_FETCH_ERR ShannonRequestErrorType = 3
+	// Centralized gateway mode app does not delegate to the gateway.
+	ShannonRequestErrorType_SHANNON_REQUEST_ERROR_INTERNAL_CENTRALIZED_MODE_APP_DELEGATION ShannonRequestErrorType = 4
+	// Centralized gateway mode: no permitted apps found for service.
+	ShannonRequestErrorType_SHANNON_REQUEST_ERROR_INTERNAL_CENTRALIZED_MODE_NO_APPS ShannonRequestErrorType = 5
+	// Delegated gateway mode: could not extract app address from HTTP request
+	ShannonRequestErrorType_SHANNON_REQUEST_ERROR_INTERNAL_DELEGATED_GET_APP_HTTP ShannonRequestErrorType = 6
+	// Delegated gateway mode: error fetching the app
+	ShannonRequestErrorType_SHANNON_REQUEST_ERROR_INTERNAL_DELEGATED_FETCH_APP ShannonRequestErrorType = 7
+	// Delegated gateway mode: app does not delegate to the gateway
+	ShannonRequestErrorType_SHANNON_REQUEST_ERROR_INTERNAL_DELEGATED_APP_DOES_NOT_DELEGATE ShannonRequestErrorType = 8
+	// Error initializing a signer for the selected gateway mode.
+	ShannonRequestErrorType_SHANNON_REQUEST_ERROR_INTERNAL_SIGNER_SETUP_ERROR ShannonRequestErrorType = 9
 )
 
 // Enum value maps for ShannonRequestErrorType.
@@ -35,10 +55,26 @@ var (
 	ShannonRequestErrorType_name = map[int32]string{
 		0: "SHANNON_REQUEST_ERROR_UNSPECIFIED",
 		1: "SHANNON_REQUEST_ERROR_INTERNAL",
+		2: "SHANNON_REQUEST_ERROR_INTERNAL_NO_ENDPOINTS_AVAILABLE",
+		3: "SHANNON_REQUEST_ERROR_INTERNAL_CENTRALIZED_MODE_APP_FETCH_ERR",
+		4: "SHANNON_REQUEST_ERROR_INTERNAL_CENTRALIZED_MODE_APP_DELEGATION",
+		5: "SHANNON_REQUEST_ERROR_INTERNAL_CENTRALIZED_MODE_NO_APPS",
+		6: "SHANNON_REQUEST_ERROR_INTERNAL_DELEGATED_GET_APP_HTTP",
+		7: "SHANNON_REQUEST_ERROR_INTERNAL_DELEGATED_FETCH_APP",
+		8: "SHANNON_REQUEST_ERROR_INTERNAL_DELEGATED_APP_DOES_NOT_DELEGATE",
+		9: "SHANNON_REQUEST_ERROR_INTERNAL_SIGNER_SETUP_ERROR",
 	}
 	ShannonRequestErrorType_value = map[string]int32{
-		"SHANNON_REQUEST_ERROR_UNSPECIFIED": 0,
-		"SHANNON_REQUEST_ERROR_INTERNAL":    1,
+		"SHANNON_REQUEST_ERROR_UNSPECIFIED":                              0,
+		"SHANNON_REQUEST_ERROR_INTERNAL":                                 1,
+		"SHANNON_REQUEST_ERROR_INTERNAL_NO_ENDPOINTS_AVAILABLE":          2,
+		"SHANNON_REQUEST_ERROR_INTERNAL_CENTRALIZED_MODE_APP_FETCH_ERR":  3,
+		"SHANNON_REQUEST_ERROR_INTERNAL_CENTRALIZED_MODE_APP_DELEGATION": 4,
+		"SHANNON_REQUEST_ERROR_INTERNAL_CENTRALIZED_MODE_NO_APPS":        5,
+		"SHANNON_REQUEST_ERROR_INTERNAL_DELEGATED_GET_APP_HTTP":          6,
+		"SHANNON_REQUEST_ERROR_INTERNAL_DELEGATED_FETCH_APP":             7,
+		"SHANNON_REQUEST_ERROR_INTERNAL_DELEGATED_APP_DOES_NOT_DELEGATE": 8,
+		"SHANNON_REQUEST_ERROR_INTERNAL_SIGNER_SETUP_ERROR":              9,
 	}
 )
 
@@ -524,10 +560,18 @@ const file_path_protocol_shannon_proto_rawDesc = "" +
 	"\x0e_error_detailsB\x17\n" +
 	"\x15_recommended_sanction\"h\n" +
 	"\x17ShannonObservationsList\x12M\n" +
-	"\fobservations\x18\x01 \x03(\v2).path.protocol.ShannonRequestObservationsR\fobservations*d\n" +
+	"\fobservations\x18\x01 \x03(\v2).path.protocol.ShannonRequestObservationsR\fobservations*\xd1\x04\n" +
 	"\x17ShannonRequestErrorType\x12%\n" +
 	"!SHANNON_REQUEST_ERROR_UNSPECIFIED\x10\x00\x12\"\n" +
-	"\x1eSHANNON_REQUEST_ERROR_INTERNAL\x10\x01*\xae\x01\n" +
+	"\x1eSHANNON_REQUEST_ERROR_INTERNAL\x10\x01\x129\n" +
+	"5SHANNON_REQUEST_ERROR_INTERNAL_NO_ENDPOINTS_AVAILABLE\x10\x02\x12A\n" +
+	"=SHANNON_REQUEST_ERROR_INTERNAL_CENTRALIZED_MODE_APP_FETCH_ERR\x10\x03\x12B\n" +
+	">SHANNON_REQUEST_ERROR_INTERNAL_CENTRALIZED_MODE_APP_DELEGATION\x10\x04\x12;\n" +
+	"7SHANNON_REQUEST_ERROR_INTERNAL_CENTRALIZED_MODE_NO_APPS\x10\x05\x129\n" +
+	"5SHANNON_REQUEST_ERROR_INTERNAL_DELEGATED_GET_APP_HTTP\x10\x06\x126\n" +
+	"2SHANNON_REQUEST_ERROR_INTERNAL_DELEGATED_FETCH_APP\x10\a\x12B\n" +
+	">SHANNON_REQUEST_ERROR_INTERNAL_DELEGATED_APP_DOES_NOT_DELEGATE\x10\b\x125\n" +
+	"1SHANNON_REQUEST_ERROR_INTERNAL_SIGNER_SETUP_ERROR\x10\t*\xae\x01\n" +
 	"\x18ShannonEndpointErrorType\x12&\n" +
 	"\"SHANNON_ENDPOINT_ERROR_UNSPECIFIED\x10\x00\x12#\n" +
 	"\x1fSHANNON_ENDPOINT_ERROR_INTERNAL\x10\x01\x12!\n" +

--- a/proto/path/gateway.proto
+++ b/proto/path/gateway.proto
@@ -15,8 +15,16 @@ import "path/auth.proto"; // import RequestAuth message.
 //  2. Synthetic: internal infrastructure generated the service request for simulation and data purposes.
 enum RequestType {
   REQUEST_TYPE_UNSPECIFIED = 0;
-  REQUEST_TYPE_ORGANIC = 1;  // Service request sent by a user.
-  REQUEST_TYPE_SYNTHETIC = 2; // Service request sent by the endpoint hydrator: see gateway/hydrator.go.
+  // Organic: Service request sent by a user.
+  REQUEST_TYPE_ORGANIC = 1;
+  // Synthetic: Service request sent by the endpoint hydrator: see gateway/hydrator.go.
+  REQUEST_TYPE_SYNTHETIC = 2;
+}
+
+enum GatewayRequestErrorKind {
+  GATEWAY_REQUEST_ERROR_KIND_UNSPECIFIED = 0;
+  // Service ID not specified.
+  GATEWAY_REQUEST_ERROR_KIND_MISSING_SERVICE_ID = 1;
 }
 
 // GatewayObservations is the set of observations on a service request, made from the perspective of a gateway.
@@ -25,7 +33,7 @@ message GatewayObservations {
   // request_auth stores any fields related to the identification/authentication of the request.
   RequestAuth request_auth = 1;
 
-  // Specifies the request type.
+  // Specifies the request origin.
   // For example, wWhether the request was sent by a user or synthetically generated (e.g. by the endpoint hydrator).
   RequestType request_type = 2;
 
@@ -41,4 +49,17 @@ message GatewayObservations {
 
   // response_size is the size in bytes of the response payload
   uint64 response_size = 6;
+
+  // gateway-level request error, if any.
+  // e.g. no service ID specified.
+  optional GatewayRequestError request_error = 7;
+}
+
+// Tracks any errors encountered at the gateway level.
+// e.g.: No Service ID specified by the request's HTTP headers.
+message GatewayRequestError {
+  // Categorizes the error
+  GatewayRequestErrorKind error_kind = 1;
+  // Detailed reason
+  string details = 2;
 }

--- a/proto/path/protocol/shannon.proto
+++ b/proto/path/protocol/shannon.proto
@@ -9,6 +9,26 @@ import "google/protobuf/timestamp.proto";
 enum ShannonRequestErrorType {
   SHANNON_REQUEST_ERROR_UNSPECIFIED = 0;
   SHANNON_REQUEST_ERROR_INTERNAL = 1; // Internal error.
+  // No endpoints available for the service
+  // Due to one or more of the following:
+  // - Any of the gateway mode errors above
+  // - Error fetching a session for one or more apps.
+  // - One or more available endpoints are sanctioned.
+  SHANNON_REQUEST_ERROR_INTERNAL_NO_ENDPOINTS_AVAILABLE = 2;
+  // Centralized gateway mode: Error fetching the app.
+  SHANNON_REQUEST_ERROR_INTERNAL_CENTRALIZED_MODE_APP_FETCH_ERR = 3;
+  // Centralized gateway mode app does not delegate to the gateway.
+  SHANNON_REQUEST_ERROR_INTERNAL_CENTRALIZED_MODE_APP_DELEGATION = 4;
+  // Centralized gateway mode: no permitted apps found for service.
+  SHANNON_REQUEST_ERROR_INTERNAL_CENTRALIZED_MODE_NO_APPS = 5;
+  // Delegated gateway mode: could not extract app address from HTTP request
+  SHANNON_REQUEST_ERROR_INTERNAL_DELEGATED_GET_APP_HTTP = 6;
+  // Delegated gateway mode: error fetching the app
+  SHANNON_REQUEST_ERROR_INTERNAL_DELEGATED_FETCH_APP = 7;
+  // Delegated gateway mode: app does not delegate to the gateway
+  SHANNON_REQUEST_ERROR_INTERNAL_DELEGATED_APP_DOES_NOT_DELEGATE = 8;
+  // Error initializing a signer for the selected gateway mode.
+  SHANNON_REQUEST_ERROR_INTERNAL_SIGNER_SETUP_ERROR = 9;
 }
 
 // ShannonRequestError stores details of any errors encountered processing the request.

--- a/protocol/shannon/errors.go
+++ b/protocol/shannon/errors.go
@@ -13,6 +13,38 @@ var (
 
 	// endpoint timeout
 	RelayErrEndpointTimeout = errors.New("timeout waiting for endpoint response")
+
+	// Request context setup errors.
+	// Used to build observations:
+	// There is no request context to provide observations.
+	//
+	// Unsupported gateway mode
+	errProtocolContextSetupUnsupportedGatewayMode = errors.New("unsupported gateway mode.")
+	// Centralized gateway mode: Error getting onchain data for app
+	errProtocolContextSetupCentralizedAppFetchErr = errors.New("error getting onchain data for app owned by the gateway.")
+	// Centralized gateway mode app does not delegate to the gateway.
+	errProtocolContextSetupCentralizedAppDelegation = errors.New("centralized gateway mode app does not delegate to the gateway.")
+	// Centralized gateway mode: no permitted apps found for service.
+	errProtocolContextSetupCentralizedNoApps = errors.New("No apps mathed the request for service.")
+
+	// Delegated gateway mode: could not extract app from HTTP request.
+	errProtocolContextSetupGetAppFromHTTPReq = errors.New("error getting the selected app from the HTTP request.")
+	// Delegated gateway mode: could not fetch app using the SDK
+	errProtocolContextSetupFetchApp = errors.New("error getting the selected app data from the SDK.")
+	// Delegated gateway mode: gateway does not have delegation for the app.
+	errProtocolContextSetupAppDoesNotDelegate = errors.New("gateway does not have delegation for app.")
+	// No endpoints available for the service.
+	// Can be due to one or more of the following:
+	// - Any of the gateway mode errors above.
+	// - Error fetching a session for an app.
+	errProtocolContextSetupNoEndpoints = errors.New("no endpoints found for service: relay request will fail.")
+	// Selected endpoint is no longer available.
+	// Can happen due to:
+	// - Bug in endpoint selection logic.
+	// - Endpoint sanctioned due to an observation while selection logic was running.
+	errRequestContextSetupInvalidEndpointSelected = errors.New("selected endpoint is not available: relay request will fail.")
+	// Error initializing a signer for the current gateway mode.
+	errRequestContextSetupErrSignerSetup = errors.New("error getting the permitted signe: relay request will fail.")
 )
 
 // extractErrFromRelayError:

--- a/protocol/shannon/gateway_mode.go
+++ b/protocol/shannon/gateway_mode.go
@@ -50,7 +50,7 @@ func (p *Protocol) getGatewayModePermittedApps(
 	//	return getPermissionlessGatewayModeApps(p.ownedAppsAddr), nil
 
 	default:
-		return nil, fmt.Errorf("unsupported gateway mode: %s", p.gatewayMode)
+		return nil, fmt.Errorf("%w: %s", errProtocolContextSetupUnsupportedGatewayMode, p.gatewayMode)
 	}
 }
 

--- a/protocol/shannon/mode_delegated.go
+++ b/protocol/shannon/mode_delegated.go
@@ -25,22 +25,29 @@ func (p *Protocol) getDelegatedGatewayModeApps(ctx context.Context, httpReq *htt
 
 	selectedAppAddr, err := getAppAddrFromHTTPReq(httpReq)
 	if err != nil {
-		logger.Error().Err(err).Msgf("error extracting the selected app from the HTTP request. Relay request will fail: %+v", httpReq)
-		return nil, fmt.Errorf("error getting the selected app from the HTTP request: %w", err)
+		// Wrap the context setup error: used for observations.
+		err = fmt.Errorf("%w: %+v: %w. ", errProtocolContextSetupGetAppFromHTTPReq, httpReq, err)
+		logger.Error().Err(err).Msg("error getting the app address from the HTTP request. Relay request will fail.")
+		return nil, err
 	}
 
 	logger.Debug().Msgf("fetching the app with the selected address %s.", selectedAppAddr)
 
 	selectedApp, err := p.FullNode.GetApp(ctx, selectedAppAddr)
 	if err != nil {
-		logger.Error().Err(err).Msgf("error fetching the selected app %s: relay request will fail.", selectedAppAddr)
-		return nil, fmt.Errorf("error getting the selected app %s data from the SDK: %w", selectedAppAddr, err)
+		// Wrap the context setup error: used for observations.
+		err = fmt.Errorf("%w: app %s: %w. Relay request will fail.", errProtocolContextSetupFetchApp, selectedAppAddr, err)
+		logger.Error().Err(err).Msg("error fetching the app. Relay request will fail.")
+		return nil, err
 	}
+
 	logger.Debug().Msgf("fetched the app with the selected address %s.", selectedApp.Address)
 
 	if !gatewayHasDelegationForApp(p.gatewayAddr, selectedApp) {
-		logger.Error().Msgf("gateway %s does not have delegation for app %s: relay request will fail.", p.gatewayAddr, selectedApp.Address)
-		return nil, fmt.Errorf("gateway %s does not have delegation for app %s", p.gatewayAddr, selectedApp.Address)
+		// Wrap the context setup error: used for observations.
+		err = fmt.Errorf("%w: gateway %s app %s. Relay request will fail.", errProtocolContextSetupAppDoesNotDelegate, p.gatewayAddr, selectedApp.Address)
+		logger.Error().Err(err).Msg("Gateway does noth ave deletation for the app. Relay request will fail.")
+		return nil, err
 	}
 
 	logger.Debug().Msgf("successfully verified the gateway has delegation for the selected app with address %s.", selectedApp.Address)

--- a/protocol/shannon/observation.go
+++ b/protocol/shannon/observation.go
@@ -1,6 +1,7 @@
 package shannon
 
 import (
+	"errors"
 	"time"
 
 	"github.com/pokt-network/poktroll/pkg/polylog"
@@ -8,7 +9,88 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	protocolobservations "github.com/buildwithgrove/path/observation/protocol"
+	"github.com/buildwithgrove/path/protocol"
 )
+
+// buildSuccessfulEndpointLookupObservation builds a minimum observation to indicate the endpoint lookup was successful.
+// Used when endpoint lookup succeeds but endpoint selection fails.
+func buildSuccessfulEndpointLookupObservation(
+	serviceID protocol.ServiceID,
+) protocolobservations.Observations {
+	return protocolobservations.Observations{
+		Protocol: &protocolobservations.Observations_Shannon{
+			Shannon: &protocolobservations.ShannonObservationsList{
+				Observations: []*protocolobservations.ShannonRequestObservations{
+					{
+						ServiceId: string(serviceID),
+					},
+				},
+			},
+		},
+	}
+}
+
+// buildProtocolContextSetupErrorObservation builds a protocol observation from the supplied error.
+// Used if any steps of building a protocol context fails:
+// - Getting available endpoints.
+// - Setting up the request context for a specific endpoint.
+func buildProtocolContextSetupErrorObservation(
+	serviceID protocol.ServiceID,
+	err error,
+) protocolobservations.Observations {
+	return protocolobservations.Observations{
+		Protocol: &protocolobservations.Observations_Shannon{
+			Shannon: &protocolobservations.ShannonObservationsList{
+				Observations: []*protocolobservations.ShannonRequestObservations{
+					{
+						ServiceId: string(serviceID),
+						RequestError: &protocolobservations.ShannonRequestError{
+							ErrorType:    translateContextSetupErrorToRequestErrorType(err),
+							ErrorDetails: err.Error(),
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+// translateContextSetupErrorToRequestErrorType maps the supplied error to a request error type.
+// Used to generate the request error field of the observation.
+func translateContextSetupErrorToRequestErrorType(err error) protocolobservations.ShannonRequestErrorType {
+	switch {
+	// Centralized gateway mode: error fetching app
+	case errors.Is(err, errProtocolContextSetupCentralizedAppFetchErr):
+		return protocolobservations.ShannonRequestErrorType_SHANNON_REQUEST_ERROR_INTERNAL_CENTRALIZED_MODE_APP_FETCH_ERR
+	// Centralized gateway mode: app does not delegate to the gateway
+	case errors.Is(err, errProtocolContextSetupCentralizedAppDelegation):
+		return protocolobservations.ShannonRequestErrorType_SHANNON_REQUEST_ERROR_INTERNAL_CENTRALIZED_MODE_APP_DELEGATION
+	// Centralized gateway mode: no apps found for service
+	case errors.Is(err, errProtocolContextSetupCentralizedNoApps):
+		return protocolobservations.ShannonRequestErrorType_SHANNON_REQUEST_ERROR_INTERNAL_CENTRALIZED_MODE_NO_APPS
+	// Delegated gateway mode: could not extract app from HTTP request.
+	case errors.Is(err, errProtocolContextSetupGetAppFromHTTPReq):
+		return protocolobservations.ShannonRequestErrorType_SHANNON_REQUEST_ERROR_INTERNAL_DELEGATED_GET_APP_HTTP
+	// Delegated gateway mode: error fetching onchain app data
+	case errors.Is(err, errProtocolContextSetupFetchApp):
+		return protocolobservations.ShannonRequestErrorType_SHANNON_REQUEST_ERROR_INTERNAL_DELEGATED_FETCH_APP
+	// Delegated gateway mode: pp does not delegate to the gateway
+	case errors.Is(err, errProtocolContextSetupAppDoesNotDelegate):
+		return protocolobservations.ShannonRequestErrorType_SHANNON_REQUEST_ERROR_INTERNAL_DELEGATED_APP_DOES_NOT_DELEGATE
+	// No endpoints available for the service
+	// Due to one or more of the following:
+	// - Any of the gateway mode errors above
+	// - Error fetching a session for one or more apps.
+	// - One or more available endpoints are sanctioned.
+	case errors.Is(err, errProtocolContextSetupNoEndpoints):
+		return protocolobservations.ShannonRequestErrorType_SHANNON_REQUEST_ERROR_INTERNAL_NO_ENDPOINTS_AVAILABLE
+	case errors.Is(err, errRequestContextSetupErrSignerSetup):
+		return protocolobservations.ShannonRequestErrorType_SHANNON_REQUEST_ERROR_INTERNAL_SIGNER_SETUP_ERROR
+	// Should NOT happen: use the INTERNAL type to track and resolve via metrics.
+	default:
+		return protocolobservations.ShannonRequestErrorType_SHANNON_REQUEST_ERROR_INTERNAL
+	}
+}
 
 // builds a Shannon endpoint success observation to include:
 // - endpoint details: address, url, app

--- a/protocol/shannon/protocol.go
+++ b/protocol/shannon/protocol.go
@@ -2,7 +2,6 @@ package shannon
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"net/http"
 
@@ -125,7 +124,7 @@ func (p *Protocol) AvailableEndpoints(
 	ctx context.Context,
 	serviceID protocol.ServiceID,
 	httpReq *http.Request,
-) (protocol.EndpointAddrList, error) {
+) (protocol.EndpointAddrList, protocolobservations.Observations, error) {
 	// hydrate the logger.
 	logger := p.logger.With(
 		"service", serviceID,
@@ -136,9 +135,8 @@ func (p *Protocol) AvailableEndpoints(
 	// TODO_TECHDEBT(@adshmh): validate "serviceID" is a valid onchain Shannon service.
 	permittedApps, err := p.getGatewayModePermittedApps(ctx, serviceID, httpReq)
 	if err != nil {
-		errMsg := "Relay request will fail: error building the permitted apps list for service."
-		logger.Error().Err(err).Msg(errMsg)
-		return nil, errors.New(errMsg)
+		logger.Error().Err(err).Msg("Relay request will fail: error building the permitted apps list for service.")
+		return nil, buildProtocolContextSetupErrorObservation(serviceID, err), err
 	}
 
 	logger = logger.With("number_of_permitted_apps", len(permittedApps))
@@ -148,9 +146,8 @@ func (p *Protocol) AvailableEndpoints(
 	// owns and can send relays on behalf of.
 	endpoints, err := p.getAppsUniqueEndpoints(ctx, serviceID, permittedApps)
 	if err != nil {
-		errMsg := "error getting the set of all endpoints: relay request will fail."
-		logger.Error().Err(err).Msg(errMsg)
-		return nil, errors.New(errMsg)
+		logger.Error().Err(err).Msg(err.Error())
+		return nil, buildProtocolContextSetupErrorObservation(serviceID, err), err
 	}
 
 	logger = logger.With("number_of_unique_endpoints", len(endpoints))
@@ -162,11 +159,15 @@ func (p *Protocol) AvailableEndpoints(
 		endpointAddrs = append(endpointAddrs, endpointAddr)
 	}
 
-	return endpointAddrs, nil
+	return endpointAddrs, buildSuccessfulEndpointLookupObservation(serviceID), nil
 }
 
 // BuildRequestContextForEndpoint builds a new request context for a given service ID and endpoint address.
 // Takes the HTTP request as an argument for Delegate mode to get permitted apps from the HTTP request's headers.
+// Returns:
+// - An initialized request context.
+// - An observation to use if the context initialization failed.
+// - An error if the context initialization failed.
 //
 // Implements the gateway.Protocol interface.
 func (p *Protocol) BuildRequestContextForEndpoint(
@@ -174,30 +175,45 @@ func (p *Protocol) BuildRequestContextForEndpoint(
 	serviceID protocol.ServiceID,
 	selectedEndpointAddr protocol.EndpointAddr,
 	httpReq *http.Request,
-) (gateway.ProtocolRequestContext, error) {
+) (gateway.ProtocolRequestContext, protocolobservations.Observations, error) {
+	logger := p.logger.With(
+		"method", "BuildRequestContextForEndpoint",
+		"service_id", serviceID,
+		"endpoint_addr", selectedEndpointAddr,
+	)
+
 	permittedApps, err := p.getGatewayModePermittedApps(ctx, serviceID, httpReq)
 	if err != nil {
-		return nil, fmt.Errorf("BuildRequestContextForEndpoint: error building the permitted apps list for service %s gateway mode %s: %w", serviceID, p.gatewayMode, err)
+		logger.Error().Err(err).Msg("BuildRequestContextForEndpoint: error building the permitted apps list for service. Relay request will fail")
+		return nil, buildProtocolContextSetupErrorObservation(serviceID, err), err
 	}
 
 	// Retrieve the list of endpoints (i.e. backend service URLs by external operators)
 	// that can service RPC requests for the given service ID for the given apps.
 	endpoints, err := p.getAppsUniqueEndpoints(ctx, serviceID, permittedApps)
 	if err != nil {
-		return nil, fmt.Errorf("BuildRequestContextForEndpoint: error getting endpoints for service %s: %w", serviceID, err)
+		logger.Error().Err(err).Msg(err.Error())
+		return nil, buildProtocolContextSetupErrorObservation(serviceID, err), err
 	}
 
 	// Select the endpoint that matches the pre-selected address.
 	// This ensures QoS checks are performed on the selected endpoint.
 	selectedEndpoint, ok := endpoints[selectedEndpointAddr]
 	if !ok {
-		return nil, fmt.Errorf("BuildRequestContextForEndpoint: could not find endpoint for service %s and endpoint address %s", serviceID, selectedEndpointAddr)
+		// Wrap the context setup error.
+		// Used to generate the observation.
+		err := fmt.Errorf("%w: service %s endpoint %s", errRequestContextSetupInvalidEndpointSelected, serviceID, selectedEndpointAddr)
+		logger.Error().Err(err).Msg("Selected endpoint is not available.")
+		return nil, buildProtocolContextSetupErrorObservation(serviceID, err), err
 	}
 
 	// Retrieve the relay request signer for the current gateway mode.
 	permittedSigner, err := p.getGatewayModePermittedRelaySigner(p.gatewayMode)
 	if err != nil {
-		return nil, fmt.Errorf("BuildRequestContextForEndpoint: error getting the permitted signer for gateway mode %s: %w", p.gatewayMode, err)
+		// Wrap the context setup error.
+		// Used to generate the observation.
+		err = fmt.Errorf("%w: gateway mode %s: %w", errRequestContextSetupErrSignerSetup, p.gatewayMode, err)
+		return nil, buildProtocolContextSetupErrorObservation(serviceID, err), err
 	}
 
 	// Return new request context for the pre-selected endpoint
@@ -207,7 +223,7 @@ func (p *Protocol) BuildRequestContextForEndpoint(
 		selectedEndpoint:   &selectedEndpoint,
 		serviceID:          serviceID,
 		relayRequestSigner: permittedSigner,
-	}, nil
+	}, protocolobservations.Observations{}, nil
 }
 
 // ApplyObservations updates protocol instance state based on endpoint observations.
@@ -288,15 +304,18 @@ func (p *Protocol) getAppsUniqueEndpoints(
 		logger.Debug().Msg("processing app.")
 
 		session, err := p.FullNode.GetSession(ctx, serviceID, app.Address)
+		// error fetching a session:
+		// Log an error
+		// skip current app.
 		if err != nil {
-			logger.Error().Err(err).Msg("Internal error: error getting a session for the app. Service request will fail.")
-			return nil, fmt.Errorf("could not get the session for service %s app %s", serviceID, app.Address)
+			logger.Error().Err(err).Msg("Internal error: error getting a session for the app: skipping the app.")
+			continue
 		}
 
 		appEndpoints, err := endpointsFromSession(session)
 		if err != nil {
-			logger.Error().Err(err).Msg("Internal error: error getting all endpoints for app and session. Service request will fail.")
-			return nil, fmt.Errorf("error getting all endpoints for app %s session %s: %w", app.Address, session.SessionId, err)
+			logger.Error().Err(err).Msg("Internal error: error getting all endpoints for app and session: skipping the app.")
+			continue
 		}
 
 		// Filter out any sanctioned endpoints
@@ -320,9 +339,13 @@ func (p *Protocol) getAppsUniqueEndpoints(
 		logger.Info().Msg("Successfully fetched session for application.")
 	}
 
+	// Ensure at least one endpoint is available for the requested service.
 	if len(endpoints) == 0 {
-		logger.Warn().Msg("Internal error: no endpoints available for permitted apps. Service request will fail.")
-		return nil, fmt.Errorf("getAppsUniqueEndpoints: no endpoints found for service %s", serviceID)
+		// Wrap the context setup error.
+		// Used for generating observations.
+		err := fmt.Errorf("%w: service %s", errProtocolContextSetupNoEndpoints, serviceID)
+		logger.Warn().Err(err).Msg("No endpoints available after filtering sanctioned endpoints: relay request will fail.")
+		return nil, err
 	}
 
 	logger.With("num_endpoints", len(endpoints)).Debug().Msg("Successfully fetched endpoints for permitted apps.")

--- a/request/errors.go
+++ b/request/errors.go
@@ -2,13 +2,17 @@ package request
 
 import (
 	"fmt"
+
+	"github.com/buildwithgrove/path/gateway"
+)
+
+var (
+	// Wrap the Gateway error.
+	// Allows the gateway package to recognize the type of error.
+	errNoServiceIDProvided = fmt.Errorf("no service ID provided in '%s' header: %w", HTTPHeaderTargetServiceID, gateway.GatewayErrNoServiceIDProvided)
 )
 
 const parserErrorTemplate = `{"code":%d,"message":"%s"}`
-
-var (
-	errNoServiceIDProvided = fmt.Errorf("no service ID provided in '%s' header", HTTPHeaderTargetServiceID)
-)
 
 /* Parser Error Response */
 

--- a/request/parser.go
+++ b/request/parser.go
@@ -57,8 +57,14 @@ func (p *Parser) GetQoSService(ctx context.Context, req *http.Request) (protocol
 		return serviceID, qosService, nil
 	}
 
-	// If the service does not have a corresponding QoS implementation,
-	// return the NoOp QoS service, which will select a random endpoint.
+	// No matching QoS implementation.
+	// Log a warning.
+	// Return a NoOp QoS implementation.
+	p.Logger.With(
+		"method", "GetQoSService",
+		"service_id", serviceID,
+	).Warn().Msg("No matching QoS implementations found. Using NoOp QoS.")
+
 	return serviceID, noop.NoOpQoS{}, nil
 }
 


### PR DESCRIPTION
## Summary

Implement comprehensive error handling and observability for gateway request failures

### Primary Changes:

- Add GatewayRequestError struct and error tracking to capture gateway-level request failures like missing service IDs
- Update Protocol interface to return observations for endpoint lookup and context setup failures
- Implement protocol-level error observations with detailed Shannon error types for different gateway modes
- Add request validation metrics with request_error_kind label to track invalid requests

### Secondary Changes:

- Skip protocol and QoS observations for invalid requests in metrics reporting
- Add protocol observation tracking to requestContext struct
- Update function signatures across Morse and Shannon protocol implementations
- Add comprehensive error mapping for centralized/delegated gateway mode failures

## Issue

Empty observation structs in the logs and observations.

```bash
{"level":"warn","method":"PublishMetrics","message":"SHOULD NEVER HAPPEN: supplied observations do not match any known Protocol: "}
```

- Issue or PR: #{ISSUE_OR_PR_NUMBER}

## Type of change

Select one or more from the following:

- [x] New feature, functionality or library
- [x] Bug fix
- [ ] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## QoS Checklist

### E2E Validation & Tests

- [x] `make path_up`
- [ ] `make test_e2e_evm_shannon`
- [ ] `make test_e2e_evm_morse`

### Observability

- [ ] 1. `make path_up`
- [ ] 2. Run one of the following:
  - For `Shannon` with `anvil`: `make test_request__shannon_relay_util_100`
  - For `Morse` with `F00C`: `make test_request__morse_relay_util_100`
- [ ] 3. Visit [PATH Relay Grafana Dashboard](http://localhost:3003/d/relays/path-service-requests) to view results

## Sanity Checklist

- [x] I have updated the GitHub Issue `assignees`, `reviewers`, `labels`, `project`, `iteration` and `milestone`
- [ ] For docs, I have run `make docusaurus_start`
- [ ] For code, I have run `make test_all`
- [ ] For configurations, I have updated the documentation
- [x] I added `TODO`s where applicable
