### PR TITLE
[OPTIMISM][E2E] Correcting service id for `optimism` -> `op`

### DIFF
--- a/e2e/config/services_shannon.yaml
+++ b/e2e/config/services_shannon.yaml
@@ -324,7 +324,7 @@ services:
 
   # Shannon - Optimism (Archival)
   - name: "Shannon - optimism (Optimism) Test"
-    service_id: "optimism"
+    service_id: "op"
     service_type: "evm"
     archival: true
     service_params:
@@ -336,7 +336,7 @@ services:
 
   # Shannon - Optimism Sepolia Testnet (Archival)
   - name: "Shannon - optimism_sep_test (Optimism Sepolia Testnet) Test"
-    service_id: "optimism_sep_test"
+    service_id: "op_sep_test"
     service_type: "evm"
     archival: true
     service_params:


### PR DESCRIPTION
## Summary

< ONE_LINE_SUMMARY>

### Primary Changes:

- Changed service ID for Optimism from `optimism` -> `op`
- Changed service ID for Optimism Sepolia Testnet from `optimism_sep_test` -> `op_sep_test`

## Type of change

Select one or more from the following:

- [ ] New feature, functionality or library
- [x] Bug fix
- [ ] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

### E2E Validation & Tests

- [ ] `make path_up`
- [ ] `make test_e2e_evm_shannon`
- [ ] `make test_e2e_evm_morse`

### Observability

- [ ] 1. `make path_up`
- [ ] 2. Run one of the following:
  - For `Shannon` with `anvil`: `make test_request__shannon_relay_util_100`
  - For `Morse` with `F00C`: `make test_request__morse_relay_util_100`
- [ ] 3. Visit [PATH Relay Grafana Dashboard](http://localhost:3003/d/relays/path-service-requests) to view results

## Sanity Checklist

- [ ] I have updated the GitHub Issue `assignees`, `reviewers`, `labels`, `project`, `iteration` and `milestone`
- [ ] For docs, I have run `make docusaurus_start`
- [ ] For code, I have run `make test_all`
- [ ] For configurations, I have updated the documentation
- [ ] I added `TODO`s where applicable
