### PR TITLE
Fix: update protocol observations returns after update

### DIFF
--- a/gateway/request_context.go
+++ b/gateway/request_context.go
@@ -449,6 +449,7 @@ func (rc *requestContext) updateProtocolObservations(protocolContextSetupErrorOb
 	if rc.protocolCtx != nil {
 		observations := rc.protocolCtx.GetObservations()
 		rc.protocolObservations = &observations
+		return
 	}
 
 	// This should never happen: either protocol context is setup, or an observation is reported to use directly for the request.


### PR DESCRIPTION
## Summary

Bug fix: missing return was causing incorrect log lines on protocol observation update.

### Primary Changes:

- Added a missing return.


## Issue

Missing return was causing incorrect log lines on protocol observation update.

- Issue or PR: #{ISSUE_OR_PR_NUMBER}

## Type of change

Select one or more from the following:

- [ ] New feature, functionality or library
- [x] Bug fix
- [ ] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## QoS Checklist

### E2E Validation & Tests

- [x] `make path_up`
- [ ] `make test_e2e_evm_shannon`
- [ ] `make test_e2e_evm_morse`

### Observability

- [ ] 1. `make path_up`
- [ ] 2. Run one of the following:
  - For `Shannon` with `anvil`: `make test_request__shannon_relay_util_100`
  - For `Morse` with `F00C`: `make test_request__morse_relay_util_100`
- [ ] 3. Visit [PATH Relay Grafana Dashboard](http://localhost:3003/d/relays/path-service-requests) to view results

## Sanity Checklist

- [x] I have updated the GitHub Issue `assignees`, `reviewers`, `labels`, `project`, `iteration` and `milestone`
- [ ] For docs, I have run `make docusaurus_start`
- [ ] For code, I have run `make test_all`
- [ ] For configurations, I have updated the documentation
- [ ] I added `TODO`s where applicable
