### PR TITLE
[CI] disable arm64 builds

### DIFF
--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -50,7 +50,8 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           build-args: IMAGE_TAG=${{ steps.meta.outputs.version }}
-          platforms: linux/amd64,linux/arm64
+          # TODO_TECHDEBT: enable arm64 builds
+          platforms: linux/amd64 # ,linux/arm64
           file: Dockerfile
           cache-from: type=gha
           cache-to: type=gha,mode=max


### PR DESCRIPTION
Disables arm64 container builds which we don't use but they SLOW DOWN CI badly.