### PR TITLE
[WIP][Shannon][Migration][Protocol] Add possible sanctions for shannon

### DIFF
--- a/protocol/shannon/errors.go
+++ b/protocol/shannon/errors.go
@@ -14,6 +14,20 @@ var (
 	// endpoint timeout
 	RelayErrEndpointTimeout = errors.New("timeout waiting for endpoint response")
 
+	// endpoint unexpected EOF error:
+	// - Connection closed unexpectedly during relay
+	RelayErrEndpointUnexpectedEOF = errors.New("endpoint connection closed unexpectedly")
+
+	// endpoint protocol error:
+	// - Protocol parsing/decoding errors
+	// - Invalid protobuf wireType or format errors
+	RelayErrEndpointProtocolError = errors.New("endpoint protocol parsing error")
+
+	// endpoint invalid session error:
+	// - Invalid or malformed session headers
+	// - Empty or invalid application addresses in session
+	RelayErrEndpointInvalidSession = errors.New("endpoint invalid session header")
+
 	// Request context setup errors.
 	// Used to build observations:
 	// There is no request context to provide observations.
@@ -62,6 +76,21 @@ func extractErrFromRelayError(err error) error {
 	// endpoint timeout
 	if strings.Contains(err.Error(), "context deadline exceeded") {
 		return RelayErrEndpointTimeout
+	}
+
+	// endpoint unexpected EOF
+	if strings.Contains(err.Error(), "unexpected EOF") {
+		return RelayErrEndpointUnexpectedEOF
+	}
+
+	// endpoint protocol parsing errors
+	if strings.Contains(err.Error(), "proto: illegal wireType") {
+		return RelayErrEndpointProtocolError
+	}
+
+	// endpoint invalid session header errors
+	if strings.Contains(err.Error(), "invalid session header") {
+		return RelayErrEndpointInvalidSession
 	}
 
 	// No known patterns matched.

--- a/protocol/shannon/sanctions.go
+++ b/protocol/shannon/sanctions.go
@@ -34,6 +34,21 @@ func classifyRelayError(logger polylog.Logger, err error) (protocolobservations.
 		return protocolobservations.ShannonEndpointErrorType_SHANNON_ENDPOINT_ERROR_TIMEOUT,
 			protocolobservations.ShannonSanctionType_SHANNON_SANCTION_SESSION
 
+	// endpoint unexpected EOF error
+	case RelayErrEndpointUnexpectedEOF:
+		return protocolobservations.ShannonEndpointErrorType_SHANNON_ENDPOINT_ERROR_INTERNAL,
+			protocolobservations.ShannonSanctionType_SHANNON_SANCTION_SESSION
+
+	// endpoint protocol parsing error
+	case RelayErrEndpointProtocolError:
+		return protocolobservations.ShannonEndpointErrorType_SHANNON_ENDPOINT_ERROR_INTERNAL,
+			protocolobservations.ShannonSanctionType_SHANNON_SANCTION_SESSION
+
+	// endpoint invalid session header error
+	case RelayErrEndpointInvalidSession:
+		return protocolobservations.ShannonEndpointErrorType_SHANNON_ENDPOINT_ERROR_INTERNAL,
+			protocolobservations.ShannonSanctionType_SHANNON_SANCTION_SESSION
+
 	default:
 		// Unknown error: log and return generic internal error.
 		// TODO_IMPROVE: Automate tracking and code updates for unrecognized errors.


### PR DESCRIPTION
## 🌿 Summary

Introduce initial set of endpoint-level sanctions handling for Shannon protocol based on observed errors from beta testing.

### 🌱 Primary Changes:
- Added new `Relay` error types for common endpoint issues in Shannon:
  - Unexpected EOF during relay
  - Protocol parsing errors (e.g., malformed protobuf)
  - Invalid session headers
- Introduced handling logic to assign appropriate sanctions to each error within `sanctions.go`
- Mapped all new error types to internal endpoint errors with `SHANNON_SANCTION_SESSION` sanction classification

### 🍃 Secondary changes:
- Added inline documentation for new error types to clarify context and mapping
- Improved resilience and observability of Shannon relay error handling mechanisms

## 🛠️ Type of change

Select one or more from the following:

- [x] New feature, functionality or library
- [x] Bug fix
- [ ] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## 🤯 Sanity Checklist

- [x] I have updated the GitHub Issue 'assignees', 'reviewers', 'labels', 'project', 'iteration' and 'milestone'
- [ ] For docs, I have run 'make docusaurus_start'
- [x] For code, I have run 'make test_all'
- [x] For configurations, I have update the documentation
- [x] I added TODOs where applicable
