### PR TITLE
[Shannon][FullNode] Update caching full node to allow configuring TTLs through config YAML and set defaults to 5 mins

### DIFF
--- a/cmd/shannon.go
+++ b/cmd/shannon.go
@@ -11,7 +11,7 @@ import (
 )
 
 // getShannonFullNode builds and returns a FullNode implementation for Shannon protocol integration, using the supplied configuration.
-func getShannonFullNode(config shannon.FullNodeConfig) (shannon.FullNode, error) {
+func getShannonFullNode(logger polylog.Logger, config shannon.FullNodeConfig) (shannon.FullNode, error) {
 	// TODO_MVP(@adshmh): rename the variables here once a more accurate name is selected for `LazyFullNode`
 	// LazyFullNode skips all caching and queries the onchain data for serving each relay request.
 	lazyFullNode, err := shannon.NewLazyFullNode(config)
@@ -23,14 +23,14 @@ func getShannonFullNode(config shannon.FullNodeConfig) (shannon.FullNode, error)
 		return lazyFullNode, nil
 	}
 
-	return shannon.NewCachingFullNode(lazyFullNode), nil
+	return shannon.NewCachingFullNode(logger, lazyFullNode), nil
 }
 
 // getShannonProtocol returns an instance of the Shannon protocol using the supplied Shannon-specific configuration.
 func getShannonProtocol(logger polylog.Logger, config *shannonconfig.ShannonGatewayConfig) (gateway.Protocol, error) {
 	logger.Info().Msg("Starting PATH gateway with Shannon protocol")
 
-	fullNode, err := getShannonFullNode(config.FullNodeConfig)
+	fullNode, err := getShannonFullNode(logger, config.FullNodeConfig)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create a Shannon full node instance: %v", err)
 	}

--- a/cmd/shannon.go
+++ b/cmd/shannon.go
@@ -23,7 +23,7 @@ func getShannonFullNode(logger polylog.Logger, config shannon.FullNodeConfig) (s
 		return lazyFullNode, nil
 	}
 
-	return shannon.NewCachingFullNode(logger, lazyFullNode), nil
+	return shannon.NewCachingFullNode(logger, lazyFullNode, config.CacheConfig), nil
 }
 
 // getShannonProtocol returns an instance of the Shannon protocol using the supplied Shannon-specific configuration.

--- a/config/config.schema.yaml
+++ b/config/config.schema.yaml
@@ -149,6 +149,20 @@ properties:
             description: "Indicates if lazy mode is enabled for full node connections."
             type: boolean
             default: true
+          cache_config:
+            description: "Configuration for the cache."
+            type: object
+            additionalProperties: false
+            properties:
+              app_ttl:
+                description: "TTL for the app cache."
+                type: string
+                pattern: "^[0-9]+[smh]$"
+              session_ttl:
+                description: "TTL for the session cache."
+                type: string
+                pattern: "^[0-9]+[smh]$"
+
       gateway_config:
         description: "Configuration for the Shannon gateway, including all required addresses and private keys for all Shannon actors."
         type: object

--- a/config/examples/config.shannon_example.yaml
+++ b/config/examples/config.shannon_example.yaml
@@ -25,6 +25,13 @@ shannon_config:
 
     # Setting this to true disables all caching of full node data.
     lazy_mode: false
+    # If lazy_mode is false, the cache_config is required.
+    # If lazy_mode is true, the cache_config may not be set.
+    cache_config: 
+      # The TTL for the app cache.
+      app_ttl: 5m
+      # The TTL for the session cache.
+      session_ttl: 5m
 
   gateway_config:
     # If this config is used for Shannon E2E tests, do not change gateway_mode

--- a/protocol/shannon/fullnode_cache.go
+++ b/protocol/shannon/fullnode_cache.go
@@ -181,9 +181,8 @@ func (cfn *cachingFullNode) GetApp(ctx context.Context, appAddr string) (*apptyp
 		ctx,
 		getAppCacheKey(appAddr),
 		func(fetchCtx context.Context) (*apptypes.Application, error) {
-			cfn.logger.Debug().Msgf(
-				"cachingFullNode.GetApp: Making request to full node for app %s",
-				getAppCacheKey(appAddr),
+			cfn.logger.Debug().Str("app_key", getAppCacheKey(appAddr)).Msgf(
+				"[cachingFullNode.GetApp] Making request to full node",
 			)
 			return cfn.lazyFullNode.GetApp(fetchCtx, appAddr)
 		},
@@ -210,9 +209,8 @@ func (cfn *cachingFullNode) GetSession(
 		ctx,
 		getSessionCacheKey(serviceID, appAddr),
 		func(fetchCtx context.Context) (sessiontypes.Session, error) {
-			cfn.logger.Debug().Msgf(
-				"cachingFullNode.GetSession: Making request to full node for session %s",
-				getSessionCacheKey(serviceID, appAddr),
+			cfn.logger.Debug().Str("session_key", getSessionCacheKey(serviceID, appAddr)).Msgf(
+				"[cachingFullNode.GetSession] Making request to full node",
 			)
 			return cfn.lazyFullNode.GetSession(fetchCtx, serviceID, appAddr)
 		},


### PR DESCRIPTION
## 🌿 Summary

Update caching full node to allow configuring TTLs through config YAML and set defaults to 5 mins.

### 🌱 Primary Changes:
- Added configurable `app_ttl` and `session_ttl` in YAML config with default values of 5 minutes
- Updated `NewCachingFullNode` to accept `CacheConfig` and hydrate defaults
- Implemented validation for cache config when `lazy_mode` is enabled

### 🍃 Secondary changes:
- Added debug logs for caching full node calls to lazy full node
- Refactored cache delay calculations into a reusable `getCacheDelays` function
- Removed hardcoded TTL values and early refresh delays in favor of dynamic calculation


## 💡 New TODOs 

New TODOs introduced in this PR:
- TODO_MAINNET_MIGRATION(@Olshansk): Ensure applications are invalidated during unstaking. Revisit these values after mainnet migration to ensure no race conditions. - protocol/shannon/fullnode_cache.go
- TODO_MAINNET_MIGRATION(@Olshansk): Revisit these values after mainnet migration to ensure no race conditions. - protocol/shannon/fullnode_cache.go

## 🛠️ Type of change

Select one or more from the following:

- [ ] New feature, functionality or library
- [ ] Bug fix
- [ ] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## 🤯 Sanity Checklist

- [ ] I have updated the GitHub Issue 'assignees', 'reviewers', 'labels', 'project', 'iteration' and 'milestone'
- [ ] For docs, I have run 'make docusaurus_start'
- [ ] For code, I have run 'make test_all'
- [ ] For configurations, I have update the documentation
- [ ] I added TODOs where applicable
