### PR TITLE
[Shannon] Source apps from GetSession call to avoid possibility of apps being out of sync from sessions

### DIFF
--- a/cmd/shannon.go
+++ b/cmd/shannon.go
@@ -11,31 +11,38 @@ import (
 )
 
 // getShannonFullNode builds and returns a FullNode implementation for Shannon protocol integration, using the supplied configuration.
-func getShannonFullNode(logger polylog.Logger, config shannon.FullNodeConfig) (shannon.FullNode, error) {
+func getShannonFullNode(logger polylog.Logger, config *shannonconfig.ShannonGatewayConfig) (shannon.FullNode, []shannon.OwnedApp, error) {
+	fullNodeConfig := config.FullNodeConfig
+
 	// TODO_MVP(@adshmh): rename the variables here once a more accurate name is selected for `LazyFullNode`
 	// LazyFullNode skips all caching and queries the onchain data for serving each relay request.
-	lazyFullNode, err := shannon.NewLazyFullNode(config)
+	lazyFullNode, err := shannon.NewLazyFullNode(fullNodeConfig)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create Shannon lazy full node: %v", err)
+		return nil, nil, fmt.Errorf("failed to create Shannon lazy full node: %v", err)
 	}
 
-	if config.LazyMode {
-		return lazyFullNode, nil
+	if fullNodeConfig.LazyMode {
+		return lazyFullNode, nil, nil
 	}
 
-	return shannon.NewCachingFullNode(logger, lazyFullNode, config.CacheConfig), nil
+	ownedApps, err := shannon.GetCentralizedModeOwnedApps(logger, config.GatewayConfig.OwnedAppsPrivateKeysHex, lazyFullNode)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to get app addresses from config: %v", err)
+	}
+
+	return shannon.NewCachingFullNode(logger, lazyFullNode, ownedApps, fullNodeConfig.CacheConfig), ownedApps, nil
 }
 
 // getShannonProtocol returns an instance of the Shannon protocol using the supplied Shannon-specific configuration.
 func getShannonProtocol(logger polylog.Logger, config *shannonconfig.ShannonGatewayConfig) (gateway.Protocol, error) {
 	logger.Info().Msg("Starting PATH gateway with Shannon protocol")
 
-	fullNode, err := getShannonFullNode(logger, config.FullNodeConfig)
+	fullNode, ownedApps, err := getShannonFullNode(logger, config)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create a Shannon full node instance: %v", err)
 	}
 
-	protocol, err := shannon.NewProtocol(logger, fullNode, config.GatewayConfig)
+	protocol, err := shannon.NewProtocol(logger, fullNode, config.GatewayConfig, ownedApps)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create a Shannon protocol instance: %v", err)
 	}

--- a/cmd/shannon.go
+++ b/cmd/shannon.go
@@ -30,7 +30,12 @@ func getShannonFullNode(logger polylog.Logger, config *shannonconfig.ShannonGate
 		return nil, nil, fmt.Errorf("failed to get app addresses from config: %v", err)
 	}
 
-	return shannon.NewCachingFullNode(logger, lazyFullNode, ownedApps, fullNodeConfig.CacheConfig), ownedApps, nil
+	fullNode, err := shannon.NewCachingFullNode(logger, lazyFullNode, ownedApps, fullNodeConfig.CacheConfig)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to create a Shannon caching full node instance: %v", err)
+	}
+
+	return fullNode, ownedApps, nil
 }
 
 // getShannonProtocol returns an instance of the Shannon protocol using the supplied Shannon-specific configuration.

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -69,8 +69,7 @@ func Test_LoadGatewayConfigFromYAML(t *testing.T) {
 						},
 						LazyMode: false,
 						CacheConfig: shannonprotocol.CacheConfig{
-							AppTTL:     12 * time.Minute,
-							SessionTTL: 4 * time.Minute,
+							SessionTTL: 30 * time.Second,
 						},
 					},
 					GatewayConfig: shannonprotocol.GatewayConfig{

--- a/config/examples/config.shannon_example.yaml
+++ b/config/examples/config.shannon_example.yaml
@@ -27,10 +27,8 @@ shannon_config:
     lazy_mode: false
     # If lazy_mode is true, the cache_config may not be set.
     cache_config: 
-      # The TTL for the app cache.
-      app_ttl: 12m
       # The TTL for the session cache.
-      session_ttl: 4m
+      session_ttl: 30s
 
   gateway_config:
     # If this config is used for Shannon E2E tests, do not change gateway_mode

--- a/go.mod
+++ b/go.mod
@@ -15,8 +15,8 @@ require (
 	github.com/ory/dockertest/v3 v3.11.0
 	github.com/patrickmn/go-cache v2.1.0+incompatible
 	github.com/pokt-foundation/pocket-go v0.21.0
-	github.com/pokt-network/poktroll v0.1.13
-	github.com/pokt-network/shannon-sdk v0.0.0-20250601170546-785400478d5f
+	github.com/pokt-network/poktroll v0.1.17
+	github.com/pokt-network/shannon-sdk v0.0.0-20250603210336-969a825fddd5
 	github.com/prometheus/client_golang v1.22.0
 	github.com/stretchr/testify v1.10.0
 	github.com/tsenart/vegeta v12.7.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -519,6 +519,8 @@ github.com/gin-contrib/sse v0.1.0/go.mod h1:RHrZQHXnP2xjPF+u1gW/2HnVO7nvIa9PG3Gm
 github.com/gin-gonic/gin v1.6.3/go.mod h1:75u5sXoLsGZoRN5Sgbi1eraJ4GU3++wFwWzhwvtwp4M=
 github.com/gin-gonic/gin v1.8.1 h1:4+fr/el88TOO3ewCmQr8cx/CtZ/umlIRIs5M4NTNjf8=
 github.com/gin-gonic/gin v1.8.1/go.mod h1:ji8BvRH1azfM+SYow9zQ6SZMvR8qOMZHmsCuWR9tTTk=
+github.com/go-chi/chi/v5 v5.2.1 h1:KOIHODQj58PmL80G2Eak4WdvUzjSJSm0vG72crDCqb8=
+github.com/go-chi/chi/v5 v5.2.1/go.mod h1:L2yAIGWB3H+phAw1NxKwWM+7eUH/lU8pOMm5hHcoops=
 github.com/go-errors/errors v1.4.2 h1:J6MZopCL4uSllY1OfXM374weqZFFItUbrImctkmUxIA=
 github.com/go-errors/errors v1.4.2/go.mod h1:sIVyrIiJhuEF+Pj9Ebtd6P/rEYROXFi3BopGUQ5a5Og=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
@@ -1008,12 +1010,12 @@ github.com/pokt-foundation/pocket-go v0.21.0 h1:LbCPHQWdlaHzWatPrmghRR2+lrh40jmo
 github.com/pokt-foundation/pocket-go v0.21.0/go.mod h1:TyJgMIbfVF9qhjTMU9u+TeiBwYKLq6+YZhq6POLNeHE=
 github.com/pokt-foundation/utils-go v0.7.0 h1:+BwAZj9Wfac6zkD4eQstRoz8lHc+6xBEtySys9WE5Ec=
 github.com/pokt-foundation/utils-go v0.7.0/go.mod h1:VMYNYtm1NKfCceLqzs6QSRhLcivafktirc3FSnB7Hxs=
-github.com/pokt-network/poktroll v0.1.13 h1:yC0FuTzOryxJkSSz0GyEGkTwHRKy+DLzeJPDgfbFTzE=
-github.com/pokt-network/poktroll v0.1.13/go.mod h1:rNRx4WX5oUMAkLvN5Vk75sAwJen00XBCO5T+Lr2imzE=
+github.com/pokt-network/poktroll v0.1.17 h1:wkc8R3QKiyB6t8kGQGh/yzkdP85/4hiRhitHqPaqfmU=
+github.com/pokt-network/poktroll v0.1.17/go.mod h1:8Ukz3y5o5MhEmCVrdVV0/S/IMgRPW5ZZQST+67BQPT4=
 github.com/pokt-network/ring-go v0.1.0 h1:hF7mDR4VVCIqqDAsrloP8azM9y1mprc99YgnTjKSSwk=
 github.com/pokt-network/ring-go v0.1.0/go.mod h1:8NHPH7H3EwrPX3XHfpyRI6bz4gApkE3+fd0XZRbMWP0=
-github.com/pokt-network/shannon-sdk v0.0.0-20250601170546-785400478d5f h1:coffZEKJSgpOCL4o8TqhzFInoOhJZ7bI8rMlhnkKI+w=
-github.com/pokt-network/shannon-sdk v0.0.0-20250601170546-785400478d5f/go.mod h1:2EAmqCZ/gcNGhycZeWMkrtmdpRzfMAJh2//XRS1Mzqs=
+github.com/pokt-network/shannon-sdk v0.0.0-20250603210336-969a825fddd5 h1:TTtN4ln+AWWPb8wbUZESAyZqUWFxV/kQNkNCEE6FgmM=
+github.com/pokt-network/shannon-sdk v0.0.0-20250603210336-969a825fddd5/go.mod h1:D7ZoOsLtOzDD7Vj9bnIIPFDbqfcUBR0Ic995vyfbdQM=
 github.com/pokt-network/smt v0.13.0 h1:C2F8FlJh34aU+DVeRU/Bt8BOkFXn4QjWMK+nbT9PUj4=
 github.com/pokt-network/smt v0.13.0/go.mod h1:S4Ho4OPkK2v2vUCHNtA49XDjqUC/OFYpBbynRVYmxvA=
 github.com/pokt-network/smt/kvstore/pebble v0.0.0-20240822175047-21ea8639c188 h1:QK1WmFKQ/OzNVob/br55Brh+EFbWhcdq41WGC8UMihM=

--- a/protocol/shannon/config.go
+++ b/protocol/shannon/config.go
@@ -64,7 +64,6 @@ type (
 	}
 
 	CacheConfig struct {
-		AppTTL     time.Duration `yaml:"app_ttl"`
 		SessionTTL time.Duration `yaml:"session_ttl"`
 	}
 )
@@ -141,24 +140,17 @@ func (c *GRPCConfig) hydrateDefaults() GRPCConfig {
 	return *c
 }
 
-const (
-	// App do not expire, so we can cache them for a long time.
-	defaultAppCacheTTL = 12 * time.Minute
-	// Session TTL should match the protocol's session length.
-	defaultSessionCacheTTL = 4 * time.Minute
-)
+// Session TTL should match the protocol's session length.
+const defaultSessionCacheTTL = 30 * time.Second
 
 func (c *CacheConfig) validate(lazyMode bool) error {
-	if lazyMode && (c.AppTTL != 0 || c.SessionTTL != 0) {
+	if lazyMode && c.SessionTTL == 0 {
 		return ErrShannonCacheConfigSetForLazyMode
 	}
 	return nil
 }
 
 func (c *CacheConfig) hydrateDefaults() {
-	if c.AppTTL == 0 {
-		c.AppTTL = defaultAppCacheTTL
-	}
 	if c.SessionTTL == 0 {
 		c.SessionTTL = defaultSessionCacheTTL
 	}

--- a/protocol/shannon/errors.go
+++ b/protocol/shannon/errors.go
@@ -33,6 +33,8 @@ var (
 	errProtocolContextSetupFetchApp = errors.New("error getting the selected app data from the SDK")
 	// Delegated gateway mode: gateway does not have delegation for the app.
 	errProtocolContextSetupAppDoesNotDelegate = errors.New("gateway does not have delegation for app")
+	// Delegated gateway mode: app is not staked for the service.
+	errProtocolContextSetupAppNotStaked = errors.New("app is not staked for the service")
 	// No endpoints available for the service.
 	// Can be due to one or more of the following:
 	// - Any of the gateway mode errors above.

--- a/protocol/shannon/fullnode_account_fetcher.go
+++ b/protocol/shannon/fullnode_account_fetcher.go
@@ -43,7 +43,7 @@ type cachingPoktNodeAccountFetcher struct {
 	logger polylog.Logger
 
 	// The underlying account client to delegate to when cache misses occur
-	underlyingAccountClient sdk.PoktNodeAccountFetcher
+	underlyingAccountClient *sdk.AccountClient
 
 	// Cache for account responses
 	accountCache *sturdyc.Client[*accounttypes.QueryAccountResponse]
@@ -86,47 +86,20 @@ func getAccountCacheKey(address string) string {
 	return fmt.Sprintf("%s:%s", accountCacheKeyPrefix, address)
 }
 
-// wrapUnderlyingAccountFetcher wraps the original account fetcher with the caching
-// account fetcher and replaces the lazy full node's account fetcher with the caching one.
+// getCachingAccountClient wraps the original account fetcher with the caching
+// account fetcher and returns a new caching account client.
 //
-// This is used to replace the lazy full node's account fetcher with the caching one.
 // It is used in the NewCachingFullNode function to create a new caching full node.
-func wrapUnderlyingAccountFetcher(
+func getCachingAccountClient(
 	logger polylog.Logger,
-	lazyFullNode *lazyFullNode,
-) {
-	// Create the account cache, which is used to cache account responses from the full node.
-	accountCache := initAccountCache()
-
-	// Wrap the original account fetcher with the caching account fetcher
-	// so that the caching account fetcher can fetch accounts from the full node.
-	originalAccountFetcher := lazyFullNode.accountClient.PoktNodeAccountFetcher
-
-	// Replace the lazy full node's account fetcher with the caching one.
-	lazyFullNode.accountClient = &sdk.AccountClient{
+	accountCache *sturdyc.Client[*accounttypes.QueryAccountResponse],
+	underlyingAccountClient *sdk.AccountClient,
+) *sdk.AccountClient {
+	return &sdk.AccountClient{
 		PoktNodeAccountFetcher: &cachingPoktNodeAccountFetcher{
 			logger:                  logger,
-			underlyingAccountClient: originalAccountFetcher,
 			accountCache:            accountCache,
+			underlyingAccountClient: underlyingAccountClient,
 		},
 	}
-}
-
-// initAccountCache initializes the account cache using SturdyC.
-//
-// Account data never changes, so we can cache it indefinitely.
-//
-// See: https://github.com/viccon/sturdyc?tab=readme-ov-file#creating-a-cache-client
-func initAccountCache() *sturdyc.Client[*accounttypes.QueryAccountResponse] {
-	// Create the account cache, which will be used to cache account responses.
-	// This cache is effectively infinite caching for the lifetime of the application.
-	// Account data never changes, so we can cache it indefinitely.
-	accountCache := sturdyc.New[*accounttypes.QueryAccountResponse](
-		accountCacheCapacity,
-		numShards,
-		accountCacheTTL,
-		evictionPercentage,
-	)
-
-	return accountCache
 }

--- a/protocol/shannon/fullnode_lazy.go
+++ b/protocol/shannon/fullnode_lazy.go
@@ -17,14 +17,14 @@ import (
 	"github.com/buildwithgrove/path/protocol"
 )
 
-// The Shannon FullNode interface is implemented by the lazyFullNode struct below.
+// The Shannon FullNode interface is implemented by the LazyFullNode struct below.
 //
-// A lazyFullNode queries the onchain data for every data item it needs to do an action (e.g. serve a relay request, etc).
+// A LazyFullNode queries the onchain data for every data item it needs to do an action (e.g. serve a relay request, etc).
 // This is done to enable supporting short block times (a few seconds), by avoiding caching
 // which can result in failures due to stale data in the cache.
-var _ FullNode = &lazyFullNode{}
+var _ FullNode = &LazyFullNode{}
 
-// TODO_MVP(@adshmh): Rename `lazyFullNode`: this struct does not perform any caching and should be named accordingly.
+// TODO_MVP(@adshmh): Rename `LazyFullNode`: this struct does not perform any caching and should be named accordingly.
 //
 // LazyFullNode: default implementation of a full node for the Shannon.
 //
@@ -32,7 +32,7 @@ var _ FullNode = &lazyFullNode{}
 // - Intentionally avoids caching:
 //   - Enables support for short block times (e.g. LocalNet)
 //   - Use CachingFullNode struct if caching is desired for performance
-type lazyFullNode struct {
+type LazyFullNode struct {
 	// logger polylog.Logger
 
 	appClient     *sdk.ApplicationClient
@@ -42,7 +42,7 @@ type lazyFullNode struct {
 }
 
 // NewLazyFullNode builds and returns a LazyFullNode using the provided configuration.
-func NewLazyFullNode(config FullNodeConfig) (*lazyFullNode, error) {
+func NewLazyFullNode(config FullNodeConfig) (*LazyFullNode, error) {
 	blockClient, err := newBlockClient(config.RpcURL)
 	if err != nil {
 		return nil, fmt.Errorf("NewSdk: error creating new Shannon block client at URL %s: %w", config.RpcURL, err)
@@ -65,7 +65,7 @@ func NewLazyFullNode(config FullNodeConfig) (*lazyFullNode, error) {
 		return nil, fmt.Errorf("NewSdk: error creating new account client using url %s: %w", config.GRPCConfig.HostPort, err)
 	}
 
-	fullNode := &lazyFullNode{
+	fullNode := &LazyFullNode{
 		sessionClient: sessionClient,
 		appClient:     appClient,
 		blockClient:   blockClient,
@@ -78,7 +78,7 @@ func NewLazyFullNode(config FullNodeConfig) (*lazyFullNode, error) {
 // GetApp:
 // - Returns the onchain application matching the supplied application address.
 // - Required to fulfill the FullNode interface.
-func (lfn *lazyFullNode) GetApp(ctx context.Context, appAddr string) (*apptypes.Application, error) {
+func (lfn *LazyFullNode) GetApp(ctx context.Context, appAddr string) (*apptypes.Application, error) {
 	app, err := lfn.appClient.GetApplication(ctx, appAddr)
 	return &app, err
 }
@@ -86,7 +86,7 @@ func (lfn *lazyFullNode) GetApp(ctx context.Context, appAddr string) (*apptypes.
 // GetSession:
 // - Uses the Shannon SDK to fetch a session for the (serviceID, appAddr) combination.
 // - Required to fulfill the FullNode interface.
-func (lfn *lazyFullNode) GetSession(
+func (lfn *LazyFullNode) GetSession(
 	ctx context.Context,
 	serviceID protocol.ServiceID,
 	appAddr string,
@@ -118,7 +118,7 @@ func (lfn *lazyFullNode) GetSession(
 // ValidateRelayResponse:
 // - Validates the raw response bytes received from an endpoint.
 // - Uses the SDK and the account client for validation.
-func (lfn *lazyFullNode) ValidateRelayResponse(supplierAddr sdk.SupplierAddress, responseBz []byte) (*servicetypes.RelayResponse, error) {
+func (lfn *LazyFullNode) ValidateRelayResponse(supplierAddr sdk.SupplierAddress, responseBz []byte) (*servicetypes.RelayResponse, error) {
 	return sdk.ValidateRelayResponse(
 		context.Background(),
 		supplierAddr,
@@ -130,14 +130,14 @@ func (lfn *lazyFullNode) ValidateRelayResponse(supplierAddr sdk.SupplierAddress,
 // IsHealthy:
 // - Always returns true for a LazyFullNode.
 // - Required to fulfill the FullNode interface.
-func (lfn *lazyFullNode) IsHealthy() bool {
+func (lfn *LazyFullNode) IsHealthy() bool {
 	return true
 }
 
 // GetAccountClient:
 // - Returns the account client created by the lazy fullnode.
 // - Used to create relay request signers.
-func (lfn *lazyFullNode) GetAccountClient() *sdk.AccountClient {
+func (lfn *LazyFullNode) GetAccountClient() *sdk.AccountClient {
 	return lfn.accountClient
 }
 

--- a/protocol/shannon/gateway_mode.go
+++ b/protocol/shannon/gateway_mode.go
@@ -7,6 +7,7 @@ import (
 	"slices"
 
 	apptypes "github.com/pokt-network/poktroll/x/application/types"
+	sessiontypes "github.com/pokt-network/poktroll/x/session/types"
 
 	"github.com/buildwithgrove/path/protocol"
 )
@@ -27,11 +28,11 @@ func (p *Protocol) SupportedGatewayModes() []protocol.GatewayMode {
 // The permitted apps are determined as follows:
 //   - Centralized mode: the gateway address and owned apps addresses are used to determine the permitted apps (specified in configs).
 //   - Delegated mode: the gateway address and app address in the HTTP headers are used to determine the permitted apps.
-func (p *Protocol) getGatewayModePermittedApps(
+func (p *Protocol) getGatewayModePermittedSessions(
 	ctx context.Context,
 	serviceID protocol.ServiceID,
 	httpReq *http.Request,
-) ([]*apptypes.Application, error) {
+) ([]sessiontypes.Session, error) {
 	p.logger.With(
 		"service_ID", serviceID,
 		"gateway_mode", p.gatewayMode,
@@ -40,10 +41,10 @@ func (p *Protocol) getGatewayModePermittedApps(
 	switch p.gatewayMode {
 
 	case protocol.GatewayModeCentralized:
-		return p.getCentralizedGatewayModeApps(ctx, serviceID)
+		return p.getCentralizedGatewayModeSessions(ctx, serviceID)
 
 	case protocol.GatewayModeDelegated:
-		return p.getDelegatedGatewayModeApps(ctx, httpReq)
+		return p.getDelegatedGatewayModeSessions(ctx, serviceID, httpReq)
 
 	// TODO_MVP(@adshmh): Uncomment the following code section once support for Permissionless Gateway mode is added to the shannon package.
 	//case protocol.GatewayModePermissionless:

--- a/protocol/shannon/mode_centralized.go
+++ b/protocol/shannon/mode_centralized.go
@@ -120,6 +120,10 @@ func (p *Protocol) getCentralizedGatewayModeSessions(
 
 	// Loop over the address of apps owned by the gateway in Centralized gateway mode.
 	for _, ownedApp := range p.ownedApps {
+		if ownedApp.StakedServiceID != serviceID {
+			continue
+		}
+
 		ownedAppAddr := ownedApp.AppAddr
 
 		logger.Info().Msgf("checking app %s owned by the gateway", ownedAppAddr)

--- a/protocol/shannon/protocol.go
+++ b/protocol/shannon/protocol.go
@@ -67,6 +67,7 @@ func NewProtocol(
 	logger polylog.Logger,
 	fullNode FullNode,
 	config GatewayConfig,
+	ownedApps []OwnedApp,
 ) (*Protocol, error) {
 	shannonLogger := logger.With("protocol", "shannon")
 
@@ -83,14 +84,10 @@ func NewProtocol(
 		gatewayMode:          config.GatewayMode,
 		// tracks sanctioned endpoints
 		sanctionedEndpointsStore: newSanctionedEndpointsStore(logger),
-	}
 
-	if config.GatewayMode == protocol.GatewayModeCentralized {
-		ownedApps, err := protocolInstance.getCentralizedModeOwnedApps(config.OwnedAppsPrivateKeysHex)
-		if err != nil {
-			return nil, fmt.Errorf("NewProtocol: error getting the owned apps for Centralized gateway mode: %w", err)
-		}
-		protocolInstance.ownedApps = ownedApps
+		// ownedApps is the list of apps owned by the gateway operator running PATH in Centralized gateway mode.
+		// If PATH is not running in Centralized mode, this field is nil.
+		ownedApps: ownedApps,
 	}
 
 	return protocolInstance, nil
@@ -115,7 +112,7 @@ type Protocol struct {
 
 	// ownedApps holds the addresses and staked service IDs of all apps owned by the gateway operator running
 	// PATH in Centralized mode. If PATH is not running in Centralized mode, this field is nil.
-	ownedApps []ownedApp
+	ownedApps []OwnedApp
 
 	// sanctionedEndpointsStore tracks sanctioned endpoints
 	sanctionedEndpointsStore *sanctionedEndpointsStore


### PR DESCRIPTION

## 🚨 TODO_IN_THIS_PR 

Do not merge until these TODOs are resolved:
- TODO_IN_THIS_PR: make this configurable in YAML with default value of 30 seconds - protocol/shannon/fullnode_cache.go

## 🌿 Summary

Refactor Shannon protocol to source apps from GetSession calls to ensure apps and sessions are always in sync, removing the need for separate app caching.

### 🌱 Primary Changes:
- Removed app caching layer and now source apps directly from session queries to prevent sync issues
- Updated centralized mode to fetch owned apps during initialization and use them for session queries
- Simplified caching strategy to only cache sessions with a shorter TTL (30s) to match protocol requirements

### 🍃 Secondary changes:
- Updated dependencies to latest poktroll and shannon-sdk versions
- Refactored lazyFullNode to LazyFullNode and improved naming conventions
- Removed unused app cache configuration and related constants


## 💡 New TODOs 

New TODOs introduced in this PR:
- TODO_MVP(@adshmh): Rename `LazyFullNode`: this struct does not perform any caching and should be named accordingly. - protocol/shannon/fullnode_lazy.go

## 🛠️ Type of change

Select one or more from the following:

- [ ] New feature, functionality or library
- [ ] Bug fix
- [ ] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## 🤯 Sanity Checklist

- [ ] I have updated the GitHub Issue 'assignees', 'reviewers', 'labels', 'project', 'iteration' and 'milestone'
- [ ] For docs, I have run 'make docusaurus_start'
- [ ] For code, I have run 'make test_all'
- [ ] For configurations, I have update the documentation
- [ ] I added TODOs where applicable
