### PR TITLE
[Shannon] Make OwnedApps a map to avoid excess looping calls to GetSession

### DIFF
--- a/cmd/shannon.go
+++ b/cmd/shannon.go
@@ -13,7 +13,7 @@ import (
 
 // getShannonFullNode builds and returns a FullNode implementation for Shannon protocol integration, using the supplied configuration.
 // It also returns the owned apps if the gateway mode is Centralized.
-func getShannonFullNode(logger polylog.Logger, config *shannonconfig.ShannonGatewayConfig) (shannon.FullNode, []shannon.OwnedApp, error) {
+func getShannonFullNode(logger polylog.Logger, config *shannonconfig.ShannonGatewayConfig) (shannon.FullNode, shannon.OwnedApps, error) {
 	fullNodeConfig := config.FullNodeConfig
 
 	// TODO_MVP(@adshmh): rename the variables here once a more accurate name is selected for `LazyFullNode`
@@ -28,7 +28,7 @@ func getShannonFullNode(logger polylog.Logger, config *shannonconfig.ShannonGate
 	}
 
 	// Initialize the owned apps for the gateway mode. This value will be nil if gateway mode is not Centralized.
-	var ownedApps []shannon.OwnedApp
+	var ownedApps shannon.OwnedApps
 	if config.GatewayConfig.GatewayMode == protocol.GatewayModeCentralized {
 		ownedApps, err = shannon.GetCentralizedModeOwnedApps(logger, config.GatewayConfig.OwnedAppsPrivateKeysHex, lazyFullNode)
 		if err != nil {

--- a/cmd/shannon.go
+++ b/cmd/shannon.go
@@ -13,7 +13,7 @@ import (
 
 // getShannonFullNode builds and returns a FullNode implementation for Shannon protocol integration, using the supplied configuration.
 // It also returns the owned apps if the gateway mode is Centralized.
-func getShannonFullNode(logger polylog.Logger, config *shannonconfig.ShannonGatewayConfig) (shannon.FullNode, shannon.OwnedApps, error) {
+func getShannonFullNode(logger polylog.Logger, config *shannonconfig.ShannonGatewayConfig) (shannon.FullNode, map[protocol.ServiceID][]string, error) {
 	fullNodeConfig := config.FullNodeConfig
 
 	// TODO_MVP(@adshmh): rename the variables here once a more accurate name is selected for `LazyFullNode`
@@ -28,7 +28,7 @@ func getShannonFullNode(logger polylog.Logger, config *shannonconfig.ShannonGate
 	}
 
 	// Initialize the owned apps for the gateway mode. This value will be nil if gateway mode is not Centralized.
-	var ownedApps shannon.OwnedApps
+	var ownedApps map[protocol.ServiceID][]string
 	if config.GatewayConfig.GatewayMode == protocol.GatewayModeCentralized {
 		ownedApps, err = shannon.GetCentralizedModeOwnedApps(logger, config.GatewayConfig.OwnedAppsPrivateKeysHex, lazyFullNode)
 		if err != nil {

--- a/protocol/shannon/fullnode_cache.go
+++ b/protocol/shannon/fullnode_cache.go
@@ -123,7 +123,7 @@ func NewCachingFullNode(
 	lazyFullNode *LazyFullNode,
 	cacheConfig CacheConfig,
 ) (*cachingFullNode, error) {
-	// Set default app and session TTLs if not set
+	// Set default session TTL if not set
 	cacheConfig.hydrateDefaults()
 
 	// Log cache configuration

--- a/protocol/shannon/fullnode_cache.go
+++ b/protocol/shannon/fullnode_cache.go
@@ -126,6 +126,11 @@ func NewCachingFullNode(
 	// Set default app and session TTLs if not set
 	cacheConfig.hydrateDefaults()
 
+	// Log cache configuration
+	logger.Debug().
+		Str("cache_config_session_ttl", cacheConfig.SessionTTL.String()).
+		Msgf("cachingFullNode - Cache Configuration")
+
 	// Configure session cache with early refreshes
 	sessionMinRefreshDelay, sessionMaxRefreshDelay := getCacheDelays(cacheConfig.SessionTTL)
 

--- a/protocol/shannon/fullnode_cache.go
+++ b/protocol/shannon/fullnode_cache.go
@@ -88,7 +88,7 @@ var _ FullNode = &cachingFullNode{}
 // Background refreshes happen before entries expire, so GetApp/GetSession never block.
 //
 // Example times (values may change):
-//   - 4min TTL, refresh at 1.2-3.6min (30-90% of TTL)
+//   - 30s TTL, refresh at 22.5-27s (75-90% of TTL)
 //
 // Benefits: Zero-latency reads for active traffic, thundering herd protection,
 // automatic load balancing, and graceful degradation.
@@ -127,7 +127,7 @@ type cachingFullNode struct {
 func NewCachingFullNode(
 	logger polylog.Logger,
 	lazyFullNode *LazyFullNode,
-	ownedAppAddrs []OwnedApp,
+	ownedApps OwnedApps,
 	cacheConfig CacheConfig,
 ) (*cachingFullNode, error) {
 	// Set default app and session TTLs if not set

--- a/protocol/shannon/mode_centralized.go
+++ b/protocol/shannon/mode_centralized.go
@@ -11,17 +11,6 @@ import (
 	"github.com/buildwithgrove/path/protocol/crypto"
 )
 
-// OwnedApps is a map of service IDs to a list of app addresses owned by the gateway operator in Centralized Gateway Mode.
-// One service ID can have multiple apps owned by the gateway operator.
-//
-// Example:
-//
-//	{
-//	  "anvil": ["pokt1...", "pokt2..."],
-//	  "eth": ["pokt3...", "pokt4..."],
-//	}
-type OwnedApps map[protocol.ServiceID][]string
-
 // Centralized Gateway Mode - Shannon Protocol Integration
 //
 // - PATH (Shannon instance) holds private keys for gateway operator's apps
@@ -36,15 +25,26 @@ type OwnedApps map[protocol.ServiceID][]string
 //   - Returns list of apps owned by the gateway, built from supplied private keys
 //   - Supplied private keys are ONLY used to build app addresses for relay signing
 //   - Populates `appAddr` and `stakedServiceID` for each app
+//
+// The owned apps map is a map of service IDs to a list of app addresses owned by
+// the gateway operator in Centralized Gateway Mode.
+// One service ID can have multiple apps owned by the gateway operator.
+//
+// Example:
+//
+//	{
+//	  "anvil": ["pokt1...", "pokt2..."],
+//	  "eth": ["pokt3...", "pokt4..."],
+//	}
 func GetCentralizedModeOwnedApps(
 	logger polylog.Logger,
 	ownedAppsPrivateKeysHex []string,
 	lazyFullNode *LazyFullNode,
-) (OwnedApps, error) {
+) (map[protocol.ServiceID][]string, error) {
 	logger = logger.With("method", "getCentralizedModeOwnedApps")
 	logger.Debug().Msg("Building the list of owned apps.")
 
-	ownedApps := make(OwnedApps)
+	ownedApps := make(map[protocol.ServiceID][]string)
 	for _, ownedAppPrivateKeyHex := range ownedAppsPrivateKeysHex {
 		// Retrieve the app's secp256k1 private key from the hex string.
 		ownedAppPrivateKey, err := crypto.GetSecp256k1PrivateKeyFromKeyHex(ownedAppPrivateKeyHex)
@@ -101,6 +101,8 @@ func (p *Protocol) getCentralizedGatewayModeSessions(
 	)
 	logger.Debug().Msg("fetching the list of owned apps.")
 
+	// TODO_TECHDEBT(@commoddity): if an owned app is changed re-staked for a
+	// different service, PATH must be restarted for changes to take effect.
 	ownedAppsForService, ok := p.ownedApps[serviceID]
 	if !ok || len(ownedAppsForService) == 0 {
 		return nil, fmt.Errorf("no owned apps for service %s", serviceID)

--- a/protocol/shannon/protocol.go
+++ b/protocol/shannon/protocol.go
@@ -69,7 +69,7 @@ func NewProtocol(
 	config GatewayConfig,
 	// ownedApps is the list of apps owned by the gateway operator running PATH in Centralized gateway mode.
 	// If PATH is not running in Centralized mode, this field is nil.
-	ownedApps OwnedApps,
+	ownedApps map[protocol.ServiceID][]string,
 ) (*Protocol, error) {
 	shannonLogger := logger.With("protocol", "shannon")
 
@@ -114,7 +114,7 @@ type Protocol struct {
 
 	// ownedApps holds the addresses and staked service IDs of all apps owned by the gateway operator running
 	// PATH in Centralized mode. If PATH is not running in Centralized mode, this field is nil.
-	ownedApps OwnedApps
+	ownedApps map[protocol.ServiceID][]string
 
 	// sanctionedEndpointsStore tracks sanctioned endpoints
 	sanctionedEndpointsStore *sanctionedEndpointsStore

--- a/protocol/shannon/protocol.go
+++ b/protocol/shannon/protocol.go
@@ -69,7 +69,7 @@ func NewProtocol(
 	config GatewayConfig,
 	// ownedApps is the list of apps owned by the gateway operator running PATH in Centralized gateway mode.
 	// If PATH is not running in Centralized mode, this field is nil.
-	ownedApps []OwnedApp,
+	ownedApps OwnedApps,
 ) (*Protocol, error) {
 	shannonLogger := logger.With("protocol", "shannon")
 
@@ -114,7 +114,7 @@ type Protocol struct {
 
 	// ownedApps holds the addresses and staked service IDs of all apps owned by the gateway operator running
 	// PATH in Centralized mode. If PATH is not running in Centralized mode, this field is nil.
-	ownedApps []OwnedApp
+	ownedApps OwnedApps
 
 	// sanctionedEndpointsStore tracks sanctioned endpoints
 	sanctionedEndpointsStore *sanctionedEndpointsStore
@@ -268,8 +268,8 @@ func (p *Protocol) ConfiguredServiceIDs() map[protocol.ServiceID]struct{} {
 	}
 
 	configuredServiceIDs := make(map[protocol.ServiceID]struct{})
-	for _, ownedApp := range p.ownedApps {
-		configuredServiceIDs[ownedApp.StakedServiceID] = struct{}{}
+	for serviceID := range p.ownedApps {
+		configuredServiceIDs[serviceID] = struct{}{}
 	}
 
 	return configuredServiceIDs


### PR DESCRIPTION
## 🌿 Summary

Optimize owned apps storage and lookup by converting from slice to map structure to avoid excessive looping.

Implements TODO:
```go
// TODO_IMPROVE(@commoddity, @adshmh): This function currently loops through all apps owned by the gateway.
// Without a caching FullNode, this results in extremely slow behaviour. We should look into improving the
// efficiency of this lookup to get the list of apps owned by the gateway.
```

### 🌱 Primary Changes:
- Convert `OwnedApp` slice to `OwnedApps` map structure for efficient service-based lookups
- Remove redundant looping through all owned apps when checking service-specific apps
- Implement direct service ID to app addresses mapping in centralized gateway mode

## 🛠️ Type of change

Select one or more from the following:

- [x] Code health or cleanup

## 🤯 Sanity Checklist

- [x] I have updated the GitHub Issue 'assignees', 'reviewers', 'labels', 'project', 'iteration' and 'milestone'
- [x] For code, I have run 'make test_all'
