### PR TITLE
[Load Test] Add pocket-beta1-5 services to load tests

### DIFF
--- a/e2e/config/services_shannon.yaml
+++ b/e2e/config/services_shannon.yaml
@@ -505,23 +505,23 @@ services:
     service_type: "cometbft"
 
   # pocket-beta1
-  - name: "Shannon - pcket-beta1"
+  - name: "Shannon - pocket-beta1"
     service_id: "pocket-beta1"
     service_type: "cometbft"
   # pocket-beta2
-  - name: "Shannon - pcket-beta2"
+  - name: "Shannon - pocket-beta2"
     service_id: "pocket-beta2"
     service_type: "cometbft"
   # pocket-beta3
-  - name: "Shannon - pcket-beta3"
+  - name: "Shannon - pocket-beta3"
     service_id: "pocket-beta3"
     service_type: "cometbft"
   # pocket-beta4
-  - name: "Shannon - pcket-beta4"
+  - name: "Shannon - pocket-beta4"
     service_id: "pocket-beta4"
     service_type: "cometbft"
   # pocket-beta5
-  - name: "Shannon - pcket-beta5"
+  - name: "Shannon - pocket-beta5"
     service_id: "pocket-beta5"
     service_type: "cometbft"
 

--- a/e2e/config/services_shannon.yaml
+++ b/e2e/config/services_shannon.yaml
@@ -504,6 +504,27 @@ services:
     service_id: "osmosis"
     service_type: "cometbft"
 
+  # pocket-beta1
+  - name: "Shannon - pcket-beta1"
+    service_id: "pocket-beta1"
+    service_type: "cometbft"
+  # pocket-beta2
+  - name: "Shannon - pcket-beta2"
+    service_id: "pocket-beta2"
+    service_type: "cometbft"
+  # pocket-beta3
+  - name: "Shannon - pcket-beta3"
+    service_id: "pocket-beta3"
+    service_type: "cometbft"
+  # pocket-beta4
+  - name: "Shannon - pcket-beta4"
+    service_id: "pocket-beta4"
+    service_type: "cometbft"
+  # pocket-beta5
+  - name: "Shannon - pcket-beta5"
+    service_id: "pocket-beta5"
+    service_type: "cometbft"
+
   # TODO_NEXT(@commoddity): Add `service_params` for the below services
 
   # # Shannon - Berachain Testnet


### PR DESCRIPTION
## Summary

Load tests can now be run against pocket-beta1, pocket-beta2, pocket-beta3, pocket-beta4, and pocket-beta5 services.

### Primary Changes:

- Updated the services_shannon.yaml with new services on beta testnet.

### Secondary Changes:

## Issue

Need to load test pocket services on beta testnet.

- Issue or PR: #{ISSUE_OR_PR_NUMBER}

## Type of change

Select one or more from the following:

- [x] New feature, functionality or library
- [ ] Bug fix
- [ ] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## QoS Checklist

### E2E Validation & Tests

- [ ] `make path_up`
- [ ] `make test_e2e_evm_shannon`
- [ ] `make test_e2e_evm_morse`

### Observability

- [ ] 1. `make path_up`
- [ ] 2. Run one of the following:
  - For `Shannon` with `anvil`: `make test_request__shannon_relay_util_100`
  - For `Morse` with `F00C`: `make test_request__morse_relay_util_100`
- [ ] 3. Visit [PATH Relay Grafana Dashboard](http://localhost:3003/d/relays/path-service-requests) to view results

## Sanity Checklist

- [x] I have updated the GitHub Issue `assignees`, `reviewers`, `labels`, `project`, `iteration` and `milestone`
- [ ] For docs, I have run `make docusaurus_start`
- [ ] For code, I have run `make test_all`
- [ ] For configurations, I have updated the documentation
- [ ] I added `TODO`s where applicable
