### PR TITLE
[Protocol][Shannon] Shannon handles endpoint errors on relay response validation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/patrickmn/go-cache v2.1.0+incompatible
 	github.com/pokt-foundation/pocket-go v0.21.0
 	github.com/pokt-network/poktroll v0.1.17
-	github.com/pokt-network/shannon-sdk v0.0.0-20250603210336-969a825fddd5
+	github.com/pokt-network/shannon-sdk v0.0.0-20250615013032-bbc533b256f4
 	github.com/prometheus/client_golang v1.22.0
 	github.com/stretchr/testify v1.10.0
 	github.com/tsenart/vegeta v12.7.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -1016,6 +1016,8 @@ github.com/pokt-network/ring-go v0.1.0 h1:hF7mDR4VVCIqqDAsrloP8azM9y1mprc99YgnTj
 github.com/pokt-network/ring-go v0.1.0/go.mod h1:8NHPH7H3EwrPX3XHfpyRI6bz4gApkE3+fd0XZRbMWP0=
 github.com/pokt-network/shannon-sdk v0.0.0-20250603210336-969a825fddd5 h1:TTtN4ln+AWWPb8wbUZESAyZqUWFxV/kQNkNCEE6FgmM=
 github.com/pokt-network/shannon-sdk v0.0.0-20250603210336-969a825fddd5/go.mod h1:D7ZoOsLtOzDD7Vj9bnIIPFDbqfcUBR0Ic995vyfbdQM=
+github.com/pokt-network/shannon-sdk v0.0.0-20250615013032-bbc533b256f4 h1:5UlMGjlQE6uPBKuSFYp+c2s2FAGYa3kYcYrLUlAr3Cc=
+github.com/pokt-network/shannon-sdk v0.0.0-20250615013032-bbc533b256f4/go.mod h1:D7ZoOsLtOzDD7Vj9bnIIPFDbqfcUBR0Ic995vyfbdQM=
 github.com/pokt-network/smt v0.13.0 h1:C2F8FlJh34aU+DVeRU/Bt8BOkFXn4QjWMK+nbT9PUj4=
 github.com/pokt-network/smt v0.13.0/go.mod h1:S4Ho4OPkK2v2vUCHNtA49XDjqUC/OFYpBbynRVYmxvA=
 github.com/pokt-network/smt/kvstore/pebble v0.0.0-20240822175047-21ea8639c188 h1:QK1WmFKQ/OzNVob/br55Brh+EFbWhcdq41WGC8UMihM=

--- a/observation/protocol/shannon.pb.go
+++ b/observation/protocol/shannon.pb.go
@@ -110,9 +110,22 @@ type ShannonEndpointErrorType int32
 
 const (
 	ShannonEndpointErrorType_SHANNON_ENDPOINT_ERROR_UNSPECIFIED ShannonEndpointErrorType = 0
-	ShannonEndpointErrorType_SHANNON_ENDPOINT_ERROR_INTERNAL    ShannonEndpointErrorType = 1 // endpoint internal error: not recognized.
-	ShannonEndpointErrorType_SHANNON_ENDPOINT_ERROR_CONFIG      ShannonEndpointErrorType = 2 // endpoint config error: e.g. DNS lookup error, TLS certificate error.
-	ShannonEndpointErrorType_SHANNON_ENDPOINT_ERROR_TIMEOUT     ShannonEndpointErrorType = 3 // endpoint timeout on responding to relay request.
+	// endpoint internal error: not recognized.
+	ShannonEndpointErrorType_SHANNON_ENDPOINT_ERROR_INTERNAL ShannonEndpointErrorType = 1
+	// endpoint config error: e.g. DNS lookup error, TLS certificate error.
+	ShannonEndpointErrorType_SHANNON_ENDPOINT_ERROR_CONFIG ShannonEndpointErrorType = 2
+	// endpoint timeout on responding to relay request.
+	ShannonEndpointErrorType_SHANNON_ENDPOINT_ERROR_TIMEOUT ShannonEndpointErrorType = 3
+	// Endpoint payload failed to unmarshal into a RelayResponse struct
+	ShannonEndpointErrorType_SHANNON_ENDPOINT_ERROR_PAYLOAD_UNMARSHAL_ERR ShannonEndpointErrorType = 4
+	// Endpoint response failed basic validation
+	ShannonEndpointErrorType_SHANNON_ENDPOINT_ERROR_RESPONSE_VALIDATION_ERR ShannonEndpointErrorType = 5
+	// Could not fetch the public key for supplier address used for the relay.
+	ShannonEndpointErrorType_SHANNON_ENDPOINT_ERROR_RESPONSE_GET_PUBKEY_ERR ShannonEndpointErrorType = 6
+	// Received nil public key on supplier lookup using its address
+	ShannonEndpointErrorType_SHANNON_ENDPOINT_ERROR_NIL_SUPPLIER_PUBKEY ShannonEndpointErrorType = 7
+	// RelayResponse's signature failed validation.
+	ShannonEndpointErrorType_SHANNON_ENDPOINT_ERROR_RESPONSE_SIGNATURE_VALIDATION_ERR ShannonEndpointErrorType = 8
 )
 
 // Enum value maps for ShannonEndpointErrorType.
@@ -122,12 +135,22 @@ var (
 		1: "SHANNON_ENDPOINT_ERROR_INTERNAL",
 		2: "SHANNON_ENDPOINT_ERROR_CONFIG",
 		3: "SHANNON_ENDPOINT_ERROR_TIMEOUT",
+		4: "SHANNON_ENDPOINT_ERROR_PAYLOAD_UNMARSHAL_ERR",
+		5: "SHANNON_ENDPOINT_ERROR_RESPONSE_VALIDATION_ERR",
+		6: "SHANNON_ENDPOINT_ERROR_RESPONSE_GET_PUBKEY_ERR",
+		7: "SHANNON_ENDPOINT_ERROR_NIL_SUPPLIER_PUBKEY",
+		8: "SHANNON_ENDPOINT_ERROR_RESPONSE_SIGNATURE_VALIDATION_ERR",
 	}
 	ShannonEndpointErrorType_value = map[string]int32{
-		"SHANNON_ENDPOINT_ERROR_UNSPECIFIED": 0,
-		"SHANNON_ENDPOINT_ERROR_INTERNAL":    1,
-		"SHANNON_ENDPOINT_ERROR_CONFIG":      2,
-		"SHANNON_ENDPOINT_ERROR_TIMEOUT":     3,
+		"SHANNON_ENDPOINT_ERROR_UNSPECIFIED":                       0,
+		"SHANNON_ENDPOINT_ERROR_INTERNAL":                          1,
+		"SHANNON_ENDPOINT_ERROR_CONFIG":                            2,
+		"SHANNON_ENDPOINT_ERROR_TIMEOUT":                           3,
+		"SHANNON_ENDPOINT_ERROR_PAYLOAD_UNMARSHAL_ERR":             4,
+		"SHANNON_ENDPOINT_ERROR_RESPONSE_VALIDATION_ERR":           5,
+		"SHANNON_ENDPOINT_ERROR_RESPONSE_GET_PUBKEY_ERR":           6,
+		"SHANNON_ENDPOINT_ERROR_NIL_SUPPLIER_PUBKEY":               7,
+		"SHANNON_ENDPOINT_ERROR_RESPONSE_SIGNATURE_VALIDATION_ERR": 8,
 	}
 )
 
@@ -571,12 +594,17 @@ const file_path_protocol_shannon_proto_rawDesc = "" +
 	"5SHANNON_REQUEST_ERROR_INTERNAL_DELEGATED_GET_APP_HTTP\x10\x06\x126\n" +
 	"2SHANNON_REQUEST_ERROR_INTERNAL_DELEGATED_FETCH_APP\x10\a\x12B\n" +
 	">SHANNON_REQUEST_ERROR_INTERNAL_DELEGATED_APP_DOES_NOT_DELEGATE\x10\b\x125\n" +
-	"1SHANNON_REQUEST_ERROR_INTERNAL_SIGNER_SETUP_ERROR\x10\t*\xae\x01\n" +
+	"1SHANNON_REQUEST_ERROR_INTERNAL_SIGNER_SETUP_ERROR\x10\t*\xb6\x03\n" +
 	"\x18ShannonEndpointErrorType\x12&\n" +
 	"\"SHANNON_ENDPOINT_ERROR_UNSPECIFIED\x10\x00\x12#\n" +
 	"\x1fSHANNON_ENDPOINT_ERROR_INTERNAL\x10\x01\x12!\n" +
 	"\x1dSHANNON_ENDPOINT_ERROR_CONFIG\x10\x02\x12\"\n" +
-	"\x1eSHANNON_ENDPOINT_ERROR_TIMEOUT\x10\x03*u\n" +
+	"\x1eSHANNON_ENDPOINT_ERROR_TIMEOUT\x10\x03\x120\n" +
+	",SHANNON_ENDPOINT_ERROR_PAYLOAD_UNMARSHAL_ERR\x10\x04\x122\n" +
+	".SHANNON_ENDPOINT_ERROR_RESPONSE_VALIDATION_ERR\x10\x05\x122\n" +
+	".SHANNON_ENDPOINT_ERROR_RESPONSE_GET_PUBKEY_ERR\x10\x06\x12.\n" +
+	"*SHANNON_ENDPOINT_ERROR_NIL_SUPPLIER_PUBKEY\x10\a\x12<\n" +
+	"8SHANNON_ENDPOINT_ERROR_RESPONSE_SIGNATURE_VALIDATION_ERR\x10\b*u\n" +
 	"\x13ShannonSanctionType\x12 \n" +
 	"\x1cSHANNON_SANCTION_UNSPECIFIED\x10\x00\x12\x1c\n" +
 	"\x18SHANNON_SANCTION_SESSION\x10\x01\x12\x1e\n" +

--- a/proto/path/protocol/shannon.proto
+++ b/proto/path/protocol/shannon.proto
@@ -42,10 +42,24 @@ message ShannonRequestError {
 // ShannonEndpointErrorType enumerates possible relay errors when interacting with Shannon endpoints.
 enum ShannonEndpointErrorType {
   SHANNON_ENDPOINT_ERROR_UNSPECIFIED = 0;
-  SHANNON_ENDPOINT_ERROR_INTERNAL = 1; // endpoint internal error: not recognized.
-  SHANNON_ENDPOINT_ERROR_CONFIG = 2; // endpoint config error: e.g. DNS lookup error, TLS certificate error.
-  SHANNON_ENDPOINT_ERROR_TIMEOUT = 3; // endpoint timeout on responding to relay request.
-  // SHANNON_ENDPOINT_ERROR_MAXED_OUT = 4; // TODO_TECHDEBT: Uncomment when this is used.
+  // endpoint internal error: not recognized.
+  SHANNON_ENDPOINT_ERROR_INTERNAL = 1;
+  // endpoint config error: e.g. DNS lookup error, TLS certificate error.
+  SHANNON_ENDPOINT_ERROR_CONFIG = 2;
+  // endpoint timeout on responding to relay request.
+  SHANNON_ENDPOINT_ERROR_TIMEOUT = 3;
+  // Endpoint payload failed to unmarshal into a RelayResponse struct
+  SHANNON_ENDPOINT_ERROR_PAYLOAD_UNMARSHAL_ERR = 4;
+  // Endpoint response failed basic validation
+  SHANNON_ENDPOINT_ERROR_RESPONSE_VALIDATION_ERR = 5;
+  // Could not fetch the public key for supplier address used for the relay.
+  SHANNON_ENDPOINT_ERROR_RESPONSE_GET_PUBKEY_ERR = 6;
+  // Received nil public key on supplier lookup using its address
+  SHANNON_ENDPOINT_ERROR_NIL_SUPPLIER_PUBKEY = 7;
+  // RelayResponse's signature failed validation.
+  SHANNON_ENDPOINT_ERROR_RESPONSE_SIGNATURE_VALIDATION_ERR = 8;
+  // TODO_TECHDEBT: Uncomment when this is used.
+  // SHANNON_ENDPOINT_ERROR_MAXED_OUT = 9;
 }
 
 // ShannonSanctionType specifies the duration type for endpoint sanctions

--- a/protocol/shannon/fullnode_cache.go
+++ b/protocol/shannon/fullnode_cache.go
@@ -153,7 +153,6 @@ func NewCachingFullNode(
 // GetApp is a NoOp (apps fetched only at startup; relaying fetches sessions for app/session sync).
 func (cfn *cachingFullNode) GetApp(ctx context.Context, appAddr string) (*apptypes.Application, error) {
 	return cfn.lazyFullNode.GetApp(ctx, appAddr)
-	// return nil, fmt.Errorf("GetApp is a NoOp in the caching full node")
 }
 
 // GetSession returns (and auto-refreshes) the session for a service/app from cache.

--- a/protocol/shannon/fullnode_cache.go
+++ b/protocol/shannon/fullnode_cache.go
@@ -152,7 +152,8 @@ func NewCachingFullNode(
 
 // GetApp is a NoOp (apps fetched only at startup; relaying fetches sessions for app/session sync).
 func (cfn *cachingFullNode) GetApp(ctx context.Context, appAddr string) (*apptypes.Application, error) {
-	return nil, fmt.Errorf("GetApp is a NoOp in the caching full node")
+	return cfn.lazyFullNode.GetApp(ctx, appAddr)
+	// return nil, fmt.Errorf("GetApp is a NoOp in the caching full node")
 }
 
 // GetSession returns (and auto-refreshes) the session for a service/app from cache.

--- a/protocol/shannon/fullnode_cache.go
+++ b/protocol/shannon/fullnode_cache.go
@@ -150,7 +150,7 @@ func NewCachingFullNode(
 	}, nil
 }
 
-// GetApp is a NoOp (apps fetched only at startup; relaying fetches sessions for app/session sync).
+// GetApp is only used at startup; relaying fetches sessions for app/session sync.
 func (cfn *cachingFullNode) GetApp(ctx context.Context, appAddr string) (*apptypes.Application, error) {
 	return cfn.lazyFullNode.GetApp(ctx, appAddr)
 }


### PR DESCRIPTION
## Summary

Enhance Shannon endpoint error handling with new error types on relay response validation.

### Primary Changes:

- Upgrade shannon-sdk from v0.0.0-20250603210336-969a825fddd5 to v0.0.0-20250615013032-bbc533b256f4
- Add 5 new ShannonEndpointErrorType enum values for payload unmarshal, response validation, public key errors, and signature validation
- Implement error classification logic in sanctions.go to map specific SDK errors to appropriate endpoint error types and sanction levels
- Enable GetApp method in cachingFullNode by delegating to lazyFullNode instead of returning a NoOp error

### Secondary Changes:

- Update generated protobuf files (shannon.pb.go) to reflect new enum values

## Issue

Relay response validation errors were not used for sanctioning, keeping bad endpoints in the endpoint selection pool:

    1. PATH queries FullNode1
    2. FullNode1 sends ValidSession to PATH 
    3. PATH Prepares RelayRequest(SessionHeader)
    4. PATH Sends RReq(SH) to RelayMiner(RM)
    5. RM queries FullNode2 for session
    6. FullNode2 sends InvalidSession to RM
    7. RM cannot process RelayResponse because
        1. FullNode2.InvalidSession != FullNode1.ValidSession
    8. RM sends a EmptyRes to PATH
    9. PATH fails to deserialize EmptyRes
    10. PATH logs an entry saying RelayReq will fail


- Issue or PR: #{ISSUE_OR_PR_NUMBER}

## Type of change

Select one or more from the following:

- [x] New feature, functionality or library
- [x] Bug fix
- [ ] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## QoS Checklist

### E2E Validation & Tests

- [x] `make path_up`
- [ ] `make test_e2e_evm_shannon`
- [ ] `make test_e2e_evm_morse`

### Observability

- [ ] 1. `make path_up`
- [ ] 2. Run one of the following:
  - For `Shannon` with `anvil`: `make test_request__shannon_relay_util_100`
  - For `Morse` with `F00C`: `make test_request__morse_relay_util_100`
- [ ] 3. Visit [PATH Relay Grafana Dashboard](http://localhost:3003/d/relays/path-service-requests) to view results

## Sanity Checklist

- [x] I have updated the GitHub Issue `assignees`, `reviewers`, `labels`, `project`, `iteration` and `milestone`
- [ ] For docs, I have run `make docusaurus_start`
- [ ] For code, I have run `make test_all`
- [ ] For configurations, I have updated the documentation
- [ ] I added `TODO`s where applicable
