### PR TITLE
[Bug][Shannon][Caching] Use the caching account client in the caching full node's ValidateRelayResponse method

### DIFF
--- a/protocol/shannon/fullnode_cache.go
+++ b/protocol/shannon/fullnode_cache.go
@@ -179,12 +179,20 @@ func getSessionCacheKey(serviceID protocol.ServiceID, appAddr string) string {
 	return fmt.Sprintf("%s:%s:%s", sessionCacheKeyPrefix, serviceID, appAddr)
 }
 
-// ValidateRelayResponse: passthrough to underlying node.
+// ValidateRelayResponse:
+//   - Validates the raw response bytes received from an endpoint.
+//   - Uses the SDK and the caching full node's account client for validation.
+//   - Will use the caching account client to fetch the account pub key.
 func (cfn *cachingFullNode) ValidateRelayResponse(
 	supplierAddr sdk.SupplierAddress,
 	responseBz []byte,
 ) (*servicetypes.RelayResponse, error) {
-	return cfn.lazyFullNode.ValidateRelayResponse(supplierAddr, responseBz)
+	return sdk.ValidateRelayResponse(
+		context.Background(),
+		supplierAddr,
+		responseBz,
+		cfn.cachingAccountClient,
+	)
 }
 
 // GetAccountClient: passthrough to underlying node (returns caching client).

--- a/protocol/shannon/fullnode_lazy.go
+++ b/protocol/shannon/fullnode_lazy.go
@@ -116,8 +116,9 @@ func (lfn *LazyFullNode) GetSession(
 }
 
 // ValidateRelayResponse:
-// - Validates the raw response bytes received from an endpoint.
-// - Uses the SDK and the account client for validation.
+//   - Validates the raw response bytes received from an endpoint.
+//   - Uses the SDK and the lazy full node's account client for validation.
+//   - Will make a call to the remote full node to fetch the account public key.
 func (lfn *LazyFullNode) ValidateRelayResponse(supplierAddr sdk.SupplierAddress, responseBz []byte) (*servicetypes.RelayResponse, error) {
 	return sdk.ValidateRelayResponse(
 		context.Background(),


### PR DESCRIPTION
## 🌿 Summary

Fix caching full node's relay response validation to use the caching account client instead of the lazy full node's client.

### 🌱 Primary Changes:
- Updated `ValidateRelayResponse` in `fullnode_cache.go` to use the caching account client for validation
- Modified validation logic to properly fetch account pub key from cache
- Aligned method behavior with caching node's purpose by avoiding unnecessary remote calls

### 🍃 Secondary changes:
- Improved documentation comments in both caching and lazy full node implementations
- Standardized comment formatting across related files

## 🛠️ Type of change

Select one or more from the following:

- [ ] New feature, functionality or library
- [ ] Bug fix
- [ ] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## 🤯 Sanity Checklist

- [ ] I have updated the GitHub Issue 'assignees', 'reviewers', 'labels', 'project', 'iteration' and 'milestone'
- [ ] For docs, I have run 'make docusaurus_start'
- [ ] For code, I have run 'make test_all'
- [ ] For configurations, I have update the documentation
- [ ] I added TODOs where applicable
