### PR TITLE
Add emoji to misconfiguration warning

### DIFF
--- a/protocol/shannon/mode_centralized.go
+++ b/protocol/shannon/mode_centralized.go
@@ -104,7 +104,7 @@ func (p *Protocol) getCentralizedGatewayModeActiveSessions(
 	ownedAppsForService, ok := p.ownedApps[serviceID]
 	if !ok || len(ownedAppsForService) == 0 {
 		err := fmt.Errorf("%s: %s", errProtocolContextSetupCentralizedNoAppsForService, serviceID)
-		logger.Error().Err(err).Msg("MISCONFIGURATION: ZERO owned apps found for service.")
+		logger.Error().Err(err).Msg("🚨 MISCONFIGURATION: ❌ ZERO owned apps found for service.")
 		return nil, err
 	}
 


### PR DESCRIPTION
## Summary

Add an emoji to misconfiguration log entry

### Primary Changes:

- Add an emoji to misconfiguration log entry

### Secondary Changes:

## Issue

![image](https://github.com/user-attachments/assets/58151a48-0133-44ff-ad6f-f4811e349304)

- Issue or PR: #306 

https://github.com/buildwithgrove/path/pull/306/files#r2157400443

## Type of change

Select one or more from the following:

- [ ] New feature, functionality or library
- [ ] Bug fix
- [x] Code health or cleanup
- [x] Documentation
- [ ] Other (specify)

## QoS Checklist

### E2E Validation & Tests

- [ ] `make path_up`
- [ ] `make test_e2e_evm_shannon`
- [ ] `make test_e2e_evm_morse`

### Observability

- [ ] 1. `make path_up`
- [ ] 2. Run one of the following:
  - For `Shannon` with `anvil`: `make test_request__shannon_relay_util_100`
  - For `Morse` with `F00C`: `make test_request__morse_relay_util_100`
- [ ] 3. Visit [PATH Relay Grafana Dashboard](http://localhost:3003/d/relays/path-service-requests) to view results

## Sanity Checklist

- [x] I have updated the GitHub Issue `assignees`, `reviewers`, `labels`, `project`, `iteration` and `milestone`
- [ ] For docs, I have run `make docusaurus_start`
- [ ] For code, I have run `make test_all`
- [ ] For configurations, I have updated the documentation
- [ ] I added `TODO`s where applicable
