### PR TITLE
Minor error improvements in logging

### DIFF
--- a/cmd/data.go
+++ b/cmd/data.go
@@ -23,7 +23,7 @@ func setupHTTPDataReporter(
 
 	// Error parsing the specified target URL.
 	if _, err := url.Parse(config.TargetURL); err != nil {
-		return nil, fmt.Errorf("Error processing the HTTP Data Reporter's target URL: %v", err)
+		return nil, fmt.Errorf("Error processing the HTTP Data Reporter's target URL: %w", err)
 	}
 
 	return &data.DataReporterHTTP{

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -183,7 +183,7 @@ func getConfigPath(defaultConfigPath string) (string, error) {
 	// Get executable directory for default path
 	exeDir, err := os.Executable()
 	if err != nil {
-		return "", fmt.Errorf("failed to get executable path: %v", err)
+		return "", fmt.Errorf("failed to get executable path: %w", err)
 	}
 
 	configPath = filepath.Join(filepath.Dir(exeDir), defaultConfigPath)

--- a/cmd/morse.go
+++ b/cmd/morse.go
@@ -19,7 +19,7 @@ func getMorseProtocol(
 
 	fullNode, err := morse.NewFullNode(config.FullNodeConfig)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create morse full node: %v", err)
+		return nil, fmt.Errorf("failed to create morse full node: %w", err)
 	}
 
 	protocol := morse.NewProtocol(logger, fullNode, config)

--- a/cmd/shannon.go
+++ b/cmd/shannon.go
@@ -19,7 +19,7 @@ func getShannonFullNode(logger polylog.Logger, config *shannonconfig.ShannonGate
 	// LazyFullNode skips all caching and queries the onchain data for serving each relay request.
 	lazyFullNode, err := shannon.NewLazyFullNode(fullNodeConfig)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create Shannon lazy full node: %v", err)
+		return nil, fmt.Errorf("failed to create Shannon lazy full node: %w", err)
 	}
 
 	// Bypass caching if the configuration is "lazy".
@@ -29,7 +29,7 @@ func getShannonFullNode(logger polylog.Logger, config *shannonconfig.ShannonGate
 
 	fullNode, err := shannon.NewCachingFullNode(logger, lazyFullNode, fullNodeConfig.CacheConfig)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create a Shannon caching full node instance: %v", err)
+		return nil, fmt.Errorf("failed to create a Shannon caching full node instance: %w", err)
 	}
 
 	return fullNode, nil
@@ -41,12 +41,12 @@ func getShannonProtocol(logger polylog.Logger, config *shannonconfig.ShannonGate
 
 	fullNode, err := getShannonFullNode(logger, config)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create a Shannon full node instance: %v", err)
+		return nil, fmt.Errorf("failed to create a Shannon full node instance: %w", err)
 	}
 
 	protocol, err := shannon.NewProtocol(logger, config.GatewayConfig, fullNode)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create a Shannon protocol instance: %v", err)
+		return nil, fmt.Errorf("failed to create a Shannon protocol instance: %w", err)
 	}
 
 	return protocol, nil

--- a/e2e/docker_test.go
+++ b/e2e/docker_test.go
@@ -267,7 +267,7 @@ func setupPathDocker(
 	retryConnectFn := func() error {
 		resp, err := http.Get(healthCheckURL)
 		if err != nil {
-			return fmt.Errorf("unable to connect to health check endpoint: %v", err)
+			return fmt.Errorf("unable to connect to health check endpoint: %w", err)
 		}
 		defer resp.Body.Close()
 

--- a/e2e/service_evm_test.go
+++ b/e2e/service_evm_test.go
@@ -171,7 +171,7 @@ func getEVMBlockNumber(testService *TestService, headers http.Header, gatewayURL
 			testService.ServiceParams.ContractStartBlock,
 		)
 		if err != nil {
-			return "", fmt.Errorf("Could not get archival block number: %v", err)
+			return "", fmt.Errorf("Could not get archival block number: %w", err)
 		}
 		return blockNumber, nil
 	}
@@ -187,7 +187,7 @@ func setTestBlockNumber(
 	// Get current block height - fail test if this doesn't work
 	currentBlock, err := getCurrentBlockNumber(gatewayURL, headers)
 	if err != nil {
-		return "", fmt.Errorf("Could not get current block height: %v", err)
+		return "", fmt.Errorf("Could not get current block height: %w", err)
 	}
 
 	// Get random historical block number

--- a/e2e/service_solana_test.go
+++ b/e2e/service_solana_test.go
@@ -170,7 +170,7 @@ func getSolanaBlockNumber(_ *TestService, headers http.Header, gatewayURL string
 	// Get the current slot number
 	slotNumber, err := getCurrentSlotNumber(gatewayURL, headers)
 	if err != nil {
-		return "", fmt.Errorf("Could not get current slot number: %v", err)
+		return "", fmt.Errorf("Could not get current slot number: %w", err)
 	}
 	return strconv.FormatUint(slotNumber, 10), nil
 }
@@ -228,13 +228,13 @@ func fetchSlotNumber(client *http.Client, gatewayURL string, headers http.Header
 	// Marshal the result back to JSON so we can unmarshal it into our struct
 	resultBytes, err := json.Marshal(jsonRPC.Result)
 	if err != nil {
-		return 0, fmt.Errorf("failed to marshal result: %v", err)
+		return 0, fmt.Errorf("failed to marshal result: %w", err)
 	}
 
 	// Unmarshal into getEpochInfoResponse
 	var epochInfo getEpochInfoResponse
 	if err := json.Unmarshal(resultBytes, &epochInfo); err != nil {
-		return 0, fmt.Errorf("failed to unmarshal epoch info: %v", err)
+		return 0, fmt.Errorf("failed to unmarshal epoch info: %w", err)
 	}
 
 	return epochInfo.AbsoluteSlot, nil

--- a/protocol/morse/context.go
+++ b/protocol/morse/context.go
@@ -56,7 +56,7 @@ func (rc *requestContext) HandleServiceRequest(payload protocol.Payload) (protoc
 	// record request error due to internal error.
 	// no endpoint to sanction.
 	if err != nil {
-		return rc.handleInternalError(fmt.Errorf("error matching endpoint against session's nodes: %v", err))
+		return rc.handleInternalError(fmt.Errorf("error matching endpoint against session's nodes: %w", err))
 	}
 
 	// record the endpoint query time.

--- a/protocol/morse/errors.go
+++ b/protocol/morse/errors.go
@@ -72,7 +72,7 @@ func NewNoEndpointsError(serviceID string) error {
 // NewEndpointSelectionError creates a formatted error for endpoint selection issues
 // that includes the service ID and underlying error
 func NewEndpointSelectionError(serviceID string, err error) error {
-	return fmt.Errorf("SelectEndpoint: %w for service %s: %v", ErrEndpointSelectionFailed, serviceID, err)
+	return fmt.Errorf("SelectEndpoint: %w for service %s: %w", ErrEndpointSelectionFailed, serviceID, err)
 }
 
 // NewEndpointNotFoundError creates a formatted error for when a selected endpoint is not found

--- a/protocol/shannon/protocol.go
+++ b/protocol/shannon/protocol.go
@@ -75,7 +75,7 @@ func NewProtocol(
 	if config.GatewayMode == protocol.GatewayModeCentralized {
 		var err error
 		if ownedApps, err = getCentralizedModeOwnedApps(logger, config.OwnedAppsPrivateKeysHex, fullNode); err != nil {
-			return nil, fmt.Errorf("failed to get app addresses from config: %v", err)
+			return nil, fmt.Errorf("failed to get app addresses from config: %w, err)
 		}
 	}
 

--- a/protocol/shannon/protocol.go
+++ b/protocol/shannon/protocol.go
@@ -75,7 +75,7 @@ func NewProtocol(
 	if config.GatewayMode == protocol.GatewayModeCentralized {
 		var err error
 		if ownedApps, err = getCentralizedModeOwnedApps(logger, config.OwnedAppsPrivateKeysHex, fullNode); err != nil {
-			return nil, fmt.Errorf("failed to get app addresses from config: %w, err)
+			return nil, fmt.Errorf("failed to get app addresses from config: %w", err)
 		}
 	}
 

--- a/qos/cometbft/observe.go
+++ b/qos/cometbft/observe.go
@@ -3,8 +3,6 @@
 package cometbft
 
 import (
-	"fmt"
-
 	qosobservations "github.com/buildwithgrove/path/observation/qos"
 	"github.com/buildwithgrove/path/protocol"
 )
@@ -27,7 +25,7 @@ func (es *EndpointStore) UpdateEndpointsFromObservations(
 		"qos_instance", "cometbft",
 		"method", "UpdateEndpointsFromObservations",
 	)
-	logger.Info().Msg(fmt.Sprintf("About to update endpoints from %d observations.", len(endpointObservations)))
+	logger.Info().Msgf("About to update endpoints from %d observations.", len(endpointObservations))
 
 	updatedEndpoints := make(map[protocol.EndpointAddr]endpoint)
 	for _, observation := range endpointObservations {

--- a/qos/cometbft/store.go
+++ b/qos/cometbft/store.go
@@ -2,7 +2,6 @@ package cometbft
 
 import (
 	"errors"
-	"fmt"
 	"math/rand"
 	"sync"
 
@@ -70,7 +69,7 @@ func (es *EndpointStore) filterValidEndpoints(allAvailableEndpoints protocol.End
 		return nil, errors.New("received empty list of endpoints to select from")
 	}
 
-	logger.Info().Msg(fmt.Sprintf("About to filter for valid endpoints through %d available endpoints", len(allAvailableEndpoints)))
+	logger.Info().Msgf("About to filter for valid endpoints through %d available endpoints", len(allAvailableEndpoints))
 
 	// TODO_FUTURE: use service-specific metrics to add an endpoint ranking method
 	// which can be used to assign a rank/score to a valid endpoint to guide endpoint selection.
@@ -82,17 +81,17 @@ func (es *EndpointStore) filterValidEndpoints(allAvailableEndpoints protocol.End
 
 		endpoint, found := es.endpoints[availableEndpointAddr]
 		if !found {
-			logger.Info().Msg(fmt.Sprintf("endpoint %s not found in the store. Skipping...", availableEndpointAddr))
+			logger.Info().Msgf("endpoint %s not found in the store. Skipping...", availableEndpointAddr)
 			continue
 		}
 
 		if err := es.serviceState.ValidateEndpoint(endpoint); err != nil {
-			logger.Info().Err(err).Msg(fmt.Sprintf("skipping endpoint that failed validation: %v", endpoint))
+			logger.Info().Err(err).Msgf("skipping endpoint that failed validation: %v", endpoint)
 			continue
 		}
 
 		filteredValidEndpointsAddr = append(filteredValidEndpointsAddr, availableEndpointAddr)
-		logger.Info().Msg(fmt.Sprintf("endpoint %s passed validation", availableEndpointAddr))
+		logger.Info().Msgf("endpoint %s passed validation", availableEndpointAddr)
 	}
 
 	return filteredValidEndpointsAddr, nil

--- a/qos/evm/endpoint_selection.go
+++ b/qos/evm/endpoint_selection.go
@@ -105,7 +105,7 @@ func (ss *serviceState) basicEndpointValidation(endpoint endpoint) error {
 
 	// Ensure the endpoint's block number is not more than the sync allowance behind the perceived block number.
 	if err := ss.isBlockNumberValid(endpoint.checkBlockNumber); err != nil {
-		return fmt.Errorf("block number validation for %s failed: %w", endpoint.checkBlockNumber, err)
+		return fmt.Errorf("block number validation for %d failed: %w", endpoint.checkBlockNumber.parsedBlockNumberResponse, err)
 	}
 
 	// Ensure the endpoint's EVM chain ID matches the expected chain ID.

--- a/qos/evm/endpoint_selection.go
+++ b/qos/evm/endpoint_selection.go
@@ -59,7 +59,7 @@ func (ss *serviceState) filterValidEndpoints(availableEndpoints protocol.Endpoin
 		return nil, errors.New("received empty list of endpoints to select from")
 	}
 
-	logger.Info().Msg(fmt.Sprintf("About to filter through %d available endpoints", len(availableEndpoints)))
+	logger.Info().Msgf("About to filter through %d available endpoints", len(availableEndpoints))
 
 	// TODO_FUTURE: use service-specific metrics to add an endpoint ranking method
 	// which can be used to assign a rank/score to a valid endpoint to guide endpoint selection.
@@ -70,23 +70,23 @@ func (ss *serviceState) filterValidEndpoints(availableEndpoints protocol.Endpoin
 
 		endpoint, found := ss.endpointStore.endpoints[availableEndpointAddr]
 		if !found {
-			logger.Info().Msg(fmt.Sprintf("endpoint %s not found in the store. Skipping...", availableEndpointAddr))
+			logger.Info().Msgf("❓ SKIPPING endpoint %s because it was not found in PATH's endpoint store.", availableEndpointAddr)
 			continue
 		}
 
-		if err := ss.validateEndpoint(endpoint); err != nil {
-			logger.Info().Err(err).Msg(fmt.Sprintf("skipping endpoint that failed validation: %v", endpoint))
+		if err := ss.basicEndpointValidation(endpoint); err != nil {
+			logger.Info().Err(err).Msgf("❌ SKIPPING %s endpoint because it failed basic validation: %v", availableEndpointAddr, err)
 			continue
 		}
 
 		filteredEndpointsAddr = append(filteredEndpointsAddr, availableEndpointAddr)
-		logger.Info().Msg(fmt.Sprintf("endpoint %s passed validation", availableEndpointAddr))
+		logger.Info().Msgf("✅ endpoint %s passed validation", availableEndpointAddr)
 	}
 
 	return filteredEndpointsAddr, nil
 }
 
-// validateEndpoint returns an error if the supplied endpoint is not
+// basicEndpointValidation returns an error if the supplied endpoint is not
 // valid based on the perceived state of the EVM blockchain.
 //
 // It returns an error if:
@@ -94,28 +94,28 @@ func (ss *serviceState) filterValidEndpoints(availableEndpoints protocol.Endpoin
 // - The endpoint's response to an `eth_chainId` request is not the expected chain ID.
 // - The endpoint's response to an `eth_blockNumber` request is greater than the perceived block number.
 // - The endpoint's archival check is invalid, if enabled.
-func (ss *serviceState) validateEndpoint(endpoint endpoint) error {
+func (ss *serviceState) basicEndpointValidation(endpoint endpoint) error {
 	ss.serviceStateLock.RLock()
 	defer ss.serviceStateLock.RUnlock()
 
 	// Ensure the endpoint has not returned an empty response.
 	if endpoint.hasReturnedEmptyResponse {
-		return errEmptyResponseObs
+		return fmt.Errorf("empty response validation failed: %w", errEmptyResponseObs)
 	}
 
 	// Ensure the endpoint's block number is not more than the sync allowance behind the perceived block number.
 	if err := ss.isBlockNumberValid(endpoint.checkBlockNumber); err != nil {
-		return err
+		return fmt.Errorf("block number validation for %s failed: %w", endpoint.checkBlockNumber, err)
 	}
 
 	// Ensure the endpoint's EVM chain ID matches the expected chain ID.
 	if err := ss.isChainIDValid(endpoint.checkChainID); err != nil {
-		return err
+		return fmt.Errorf("validation for chain ID %s failed: %w", *endpoint.checkChainID.chainID, err)
 	}
 
 	// Ensure the endpoint has returned an archival balance for the perceived block number.
 	if err := ss.archivalState.isArchivalBalanceValid(endpoint.checkArchival); err != nil {
-		return err
+		return fmt.Errorf("archival balance validation for %s failed: %w", endpoint.checkArchival.observedArchivalBalance, err)
 	}
 
 	return nil

--- a/qos/evm/endpoint_store.go
+++ b/qos/evm/endpoint_store.go
@@ -1,7 +1,6 @@
 package evm
 
 import (
-	"fmt"
 	"strconv"
 	"sync"
 	"time"
@@ -41,7 +40,7 @@ func (es *endpointStore) updateEndpointsFromObservations(
 		"method", "UpdateEndpointsFromObservations",
 	)
 
-	logger.Info().Msg(fmt.Sprintf("About to update endpoints from %d observations.", len(endpointObservations)))
+	logger.Info().Msgf("About to update endpoints from %d observations.", len(endpointObservations))
 
 	updatedEndpoints := make(map[protocol.EndpointAddr]endpoint)
 	for _, observation := range endpointObservations {

--- a/qos/evm/service_state.go
+++ b/qos/evm/service_state.go
@@ -174,7 +174,7 @@ func (ss *serviceState) getDisqualifiedEndpointsResponse(serviceID protocol.Serv
 
 	// Populate the data response object using the endpoints in the endpoint store.
 	for endpointAddr, endpoint := range ss.endpointStore.endpoints {
-		if err := ss.validateEndpoint(endpoint); err != nil {
+		if err := ss.basicEndpointValidation(endpoint); err != nil {
 			qosLevelDataResponse.DisqualifiedEndpoints[endpointAddr] = devtools.QoSDisqualifiedEndpoint{
 				EndpointAddr: endpointAddr,
 				Reason:       err.Error(),

--- a/qos/jsonrpc/params.go
+++ b/qos/jsonrpc/params.go
@@ -38,7 +38,7 @@ func (p *Params) UnmarshalJSON(data []byte) error {
 	// First validate the input is valid JSON.
 	var rawMessage json.RawMessage
 	if err := json.Unmarshal(data, &rawMessage); err != nil {
-		return fmt.Errorf("failed to unmarshal params field: %v", err)
+		return fmt.Errorf("failed to unmarshal params field: %w", err)
 	}
 
 	// Validate that params follows JSON-RPC 2.0 spec: must be array or object.

--- a/qos/solana/observe.go
+++ b/qos/solana/observe.go
@@ -3,8 +3,6 @@
 package solana
 
 import (
-	"fmt"
-
 	qosobservations "github.com/buildwithgrove/path/observation/qos"
 	"github.com/buildwithgrove/path/protocol"
 )
@@ -27,7 +25,7 @@ func (es *EndpointStore) UpdateEndpointsFromObservations(
 		"qos_instance", "solana",
 		"method", "UpdateEndpointsFromObservations",
 	)
-	logger.Info().Msg(fmt.Sprintf("About to update endpoints from %d observations.", len(endpointObservations)))
+	logger.Info().Msgf("About to update endpoints from %d observations.", len(endpointObservations))
 
 	updatedEndpoints := make(map[protocol.EndpointAddr]endpoint)
 	for _, observation := range endpointObservations {


### PR DESCRIPTION
> [!NOTE]
> Key changes are in `qos/evm/endpoint_selection.go`

In an attempt to answer this question:

![Screenshot 2025-06-19 at 1 32 07 PM](https://github.com/user-attachments/assets/acba97ab-7ffe-4d9b-9fd7-66216cd93666)

I found this log line in [the dashboard](https://grafana.tooling.grove.city/goto/uTj5sSPHg?orgId=1) and improved it.

```bash
// map[app_kubernetes_io_instance:path-shannon-mainnet app_kubernetes_io_managed_by:Helm app_kubernetes_io_name:path-shannon-mainnet app_kubernetes_io_version:0.0.16 cluster:portal-prd-europe-west3 container:path-shannon-mainnet deploymentname:path-shannon-mainnet endpoint_addr:pokt14jk2s5lrgxjw9yd5kwzj0jxgr2727vxa72g6r6-https://fra.spacebelt.cloud error:endpoint has not returned an archival balance response to a "eth_getBalance" request evm_chain_id:0x89 filename:/var/log/pods/middleware_path-shannon-mainnet-b9fdd766c-qf8nf_6330216e-4549-4749-b296-43fafa65f375/path-shannon-mainnet/0.log helm_sh_chart:path-0.1.25 job:middleware/path-shannon-mainnet-b9fdd766c-qf8nf level:info message:skipping endpoint that failed validation: {false {0xc00733da38} {0xc00604ced0 {13982896860259012849 4509967325073 0x6afb480}} { {0 0 <nil>}}} method:filterValidEndpoints module:qos namespace:middleware pod:path-shannon-mainnet-b9fdd766c-qf8nf pod_template_hash:b9fdd766c qos_instance:evm service_id:poly stream:stderr]
```

Also making some code health changes.