### PR TITLE
[Protocol][Shannon] Sanction endpoints on nil supplier public key

### DIFF
--- a/protocol/shannon/sanctions.go
+++ b/protocol/shannon/sanctions.go
@@ -36,11 +36,15 @@ func classifyRelayError(logger polylog.Logger, err error) (protocolobservations.
 		return protocolobservations.ShannonEndpointErrorType_SHANNON_ENDPOINT_ERROR_RESPONSE_GET_PUBKEY_ERR,
 			protocolobservations.ShannonSanctionType_SHANNON_SANCTION_SESSION
 
-	// Received nil public key on supplier lookup using its address
+	// Received nil public key on supplier lookup using its address.
+	// This means the supplier account is not properly initialized:
+	//
+	// In Cosmos SDK (and thus in pocketd) accounts:
+	// - Are created when they receive tokens.
+	// - Get their public key onchain once they sign their first transaction (e.g. send, delegate, stake, etc.)
 	case errors.Is(err, sdk.ErrRelayResponseValidationNilSupplierPubKey):
 		return protocolobservations.ShannonEndpointErrorType_SHANNON_ENDPOINT_ERROR_NIL_SUPPLIER_PUBKEY,
-			// No sanctions needed: supplier address is provided by PATH.
-			protocolobservations.ShannonSanctionType_SHANNON_SANCTION_UNSPECIFIED
+			protocolobservations.ShannonSanctionType_SHANNON_SANCTION_SESSION
 
 	// RelayResponse's signature failed validation.
 	case errors.Is(err, sdk.ErrRelayResponseValidationSignatureError):


### PR DESCRIPTION
## Summary

Sanction endpoint if supplier's public key is nil.

### Primary Changes:

- Sanction endpoint if supplier's public key is nil.


## Issue

Endpoints with uninitialized supplier accounts were not sanctioned, dropping the success rate as the relay response from such endpoints cannot be verified.

- Issue or PR: #{ISSUE_OR_PR_NUMBER}

## Type of change

Select one or more from the following:

- [x] New feature, functionality or library
- [x] Bug fix
- [ ] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## QoS Checklist

### E2E Validation & Tests

- [ ] `make path_up`
- [ ] `make test_e2e_evm_shannon`
- [ ] `make test_e2e_evm_morse`

### Observability

- [ ] 1. `make path_up`
- [ ] 2. Run one of the following:
  - For `Shannon` with `anvil`: `make test_request__shannon_relay_util_100`
  - For `Morse` with `F00C`: `make test_request__morse_relay_util_100`
- [ ] 3. Visit [PATH Relay Grafana Dashboard](http://localhost:3003/d/relays/path-service-requests) to view results

## Sanity Checklist

- [x] I have updated the GitHub Issue `assignees`, `reviewers`, `labels`, `project`, `iteration` and `milestone`
- [ ] For docs, I have run `make docusaurus_start`
- [ ] For code, I have run `make test_all`
- [ ] For configurations, I have updated the documentation
- [ ] I added `TODO`s where applicable
