### PR TITLE
build multiarch quickly

### DIFF
--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -19,6 +19,14 @@ jobs:
       - name: Checkout project
         uses: actions/checkout@v4
 
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: "1.24"
+
+      - name: Build binaries for multiple architectures
+        run: make release_build_cross
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
 
@@ -50,10 +58,9 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           build-args: IMAGE_TAG=${{ steps.meta.outputs.version }}
-          # TODO_TECHDEBT: speed up arm64 builds.
-          # Need for LocalNet developers
+          # Multi-arch support with pre-built binaries
           platforms: linux/amd64,linux/arm64
-          file: Dockerfile
+          file: Dockerfile.release
           cache-from: type=gha
           cache-to: type=gha,mode=max
           context: .

--- a/.serena/project.yml
+++ b/.serena/project.yml
@@ -1,0 +1,66 @@
+# language of the project (csharp, python, rust, java, typescript (also for js projects), go, cpp, or ruby)
+# Special requirements:
+#  * csharp: Requires the presence of a .sln file in the project folder.
+language: go
+
+# whether to use the project's gitignore file to ignore files
+# Added on 2025-04-07
+ignore_all_files_in_gitignore: true
+# list of additional paths to ignore
+# same syntax as gitignore, so you can use * and **
+# Was previously called `ignored_dirs`, please update your config if you are using that.
+# Added (renamed)on 2025-04-07
+ignored_paths: []
+
+# whether the project is in read-only mode
+# If set to true, all editing tools will be disabled and attempts to use them will result in an error
+# Added on 2025-04-18
+read_only: false
+
+
+# list of tool names to exclude. We recommend not excluding any tools, see the readme for more details.
+# Below is the complete list of tools for convenience.
+# To make sure you have the latest list of tools, and to view their descriptions, 
+# execute `uv run scripts/print_tool_overview.py`.
+#
+#  * `activate_project`: Activates a project by name.
+#  * `check_onboarding_performed`: Checks whether project onboarding was already performed.
+#  * `create_text_file`: Creates/overwrites a file in the project directory.
+#  * `delete_lines`: Deletes a range of lines within a file.
+#  * `delete_memory`: Deletes a memory from Serena's project-specific memory store.
+#  * `execute_shell_command`: Executes a shell command.
+#  * `find_referencing_code_snippets`: Finds code snippets in which the symbol at the given location is referenced.
+#  * `find_referencing_symbols`: Finds symbols that reference the symbol at the given location (optionally filtered by type).
+#  * `find_symbol`: Performs a global (or local) search for symbols with/containing a given name/substring (optionally filtered by type).
+#  * `get_current_config`: Prints the current configuration of the agent, including the active and available projects, tools, contexts, and modes.
+#  * `get_symbols_overview`: Gets an overview of the top-level symbols defined in a given file or directory.
+#  * `initial_instructions`: Gets the initial instructions for the current project.
+#     Should only be used in settings where the system prompt cannot be set,
+#     e.g. in clients you have no control over, like Claude Desktop.
+#  * `insert_after_symbol`: Inserts content after the end of the definition of a given symbol.
+#  * `insert_at_line`: Inserts content at a given line in a file.
+#  * `insert_before_symbol`: Inserts content before the beginning of the definition of a given symbol.
+#  * `list_dir`: Lists files and directories in the given directory (optionally with recursion).
+#  * `list_memories`: Lists memories in Serena's project-specific memory store.
+#  * `onboarding`: Performs onboarding (identifying the project structure and essential tasks, e.g. for testing or building).
+#  * `prepare_for_new_conversation`: Provides instructions for preparing for a new conversation (in order to continue with the necessary context).
+#  * `read_file`: Reads a file within the project directory.
+#  * `read_memory`: Reads the memory with the given name from Serena's project-specific memory store.
+#  * `remove_project`: Removes a project from the Serena configuration.
+#  * `replace_lines`: Replaces a range of lines within a file with new content.
+#  * `replace_symbol_body`: Replaces the full definition of a symbol.
+#  * `restart_language_server`: Restarts the language server, may be necessary when edits not through Serena happen.
+#  * `search_for_pattern`: Performs a search for a pattern in the project.
+#  * `summarize_changes`: Provides instructions for summarizing the changes made to the codebase.
+#  * `switch_modes`: Activates modes by providing a list of their names
+#  * `think_about_collected_information`: Thinking tool for pondering the completeness of collected information.
+#  * `think_about_task_adherence`: Thinking tool for determining whether the agent is still on track with the current task.
+#  * `think_about_whether_you_are_done`: Thinking tool for determining whether the task is truly completed.
+#  * `write_memory`: Writes a named memory (for future reference) to Serena's project-specific memory store.
+excluded_tools: []
+
+# initial prompt for the project. It will always be given to the LLM upon activating the project
+# (contrary to the memories, which are loaded on demand).
+initial_prompt: ""
+
+project_name: "path"

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -1,0 +1,32 @@
+# Multi-architecture Dockerfile that uses pre-built binaries
+# This Dockerfile expects binaries to be built beforehand using:
+# make release_build_cross
+
+FROM alpine:3.19 AS final
+
+# Create non-root user
+RUN addgroup -S appgroup && adduser -S appuser -G appgroup
+
+# Set working directory
+WORKDIR /app
+
+# Add runtime dependencies and prepare directories
+RUN apk add --no-cache ca-certificates tzdata && \
+    mkdir -p /app/config && \
+    chown -R appuser:appgroup /app
+
+ARG IMAGE_TAG
+ENV IMAGE_TAG=${IMAGE_TAG}
+
+# Determine the architecture and copy the appropriate binary
+ARG TARGETARCH
+COPY release/path-linux-${TARGETARCH} /app/path
+
+# Set the binary as executable
+RUN chmod +x /app/path
+
+# Use non-root user
+USER appuser
+
+# Command to run
+CMD ["./path"]

--- a/makefiles/release.mk
+++ b/makefiles/release.mk
@@ -108,3 +108,55 @@ release_tag_minor_release: ## Tag a new minor release (e.g. v1.0.0 -> v1.1.0)
 	echo "  git push origin --delete $$NEW_TAG"; \
 	echo ""; \
 	echo "########";
+
+#############################
+### Binary Build Targets  ###
+#############################
+
+# Define the release directory
+RELEASE_DIR ?= ./release
+
+# Define the architectures we want to build for
+RELEASE_PLATFORMS := linux/amd64 linux/arm64
+
+# Version information (can be overridden)
+VERSION ?= $(shell git describe --tags --always --dirty)
+COMMIT ?= $(shell git rev-parse HEAD)
+BUILD_DATE ?= $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+# Go build flags
+LDFLAGS := -s -w \
+	-X main.Version=$(VERSION) \
+	-X main.Commit=$(COMMIT) \
+	-X main.BuildDate=$(BUILD_DATE)
+
+.PHONY: release_build_cross
+release_build_cross: ## Build binaries for multiple platforms
+	@echo "Building binaries for multiple platforms..."
+	@mkdir -p $(RELEASE_DIR)
+	@for platform in $(RELEASE_PLATFORMS); do \
+		GOOS=$$(echo $$platform | cut -d/ -f1); \
+		GOARCH=$$(echo $$platform | cut -d/ -f2); \
+		output=$(RELEASE_DIR)/path-$$GOOS-$$GOARCH; \
+		echo "Building for $$GOOS/$$GOARCH..."; \
+		CGO_ENABLED=0 GOOS=$$GOOS GOARCH=$$GOARCH go build -ldflags="$(LDFLAGS)" -o $$output ./cmd; \
+		if [ $$? -eq 0 ]; then \
+			echo "✓ Built $$output"; \
+		else \
+			echo "✗ Failed to build for $$GOOS/$$GOARCH"; \
+			exit 1; \
+		fi; \
+	done
+	@echo "All binaries built successfully!"
+
+.PHONY: release_clean
+release_clean: ## Clean up release artifacts
+	@echo "Cleaning release directory..."
+	@rm -rf $(RELEASE_DIR)
+
+.PHONY: release_build_local
+release_build_local: ## Build binary for current platform only
+	@echo "Building binary for current platform..."
+	@mkdir -p $(RELEASE_DIR)
+	@CGO_ENABLED=0 go build -ldflags="$(LDFLAGS)" -o $(RELEASE_DIR)/path-local ./cmd
+	@echo "✓ Built $(RELEASE_DIR)/path-local"


### PR DESCRIPTION
## Summary

Add multi-architecture Dockerfile and cross-platform release build targets

### Primary Changes:

- Added `Dockerfile.release` to support building multi-architecture Docker images using pre-built binaries
- Introduced `release_build_cross`, `release_clean`, and `release_build_local` Makefile targets for cross-platform binary builds

### Secondary Changes:

- Included architecture-specific binary copying logic in the Dockerfile using `TARGETARCH` argument
- Configured non-root container user setup and binary execution environment

## Type of change

Select one or more from the following:

* [x] New feature, functionality or library
* [ ] Bug fix
* [x] Code health or cleanup
* [ ] Documentation
* [ ] Other (specify)

## QoS Checklist

### E2E Validation & Tests

* [ ] `make path_up`
* [ ] `make test_e2e_evm_shannon`
* [ ] `make test_e2e_evm_morse`

### Observability

* [ ] 1\. `make path_up`
* [ ] 2\. Run one of the following:

  * For `Shannon` with `anvil`: `make test_request__shannon_relay_util_100`
  * For `Morse` with `F00C`: `make test_request__morse_relay_util_100`
* [ ] 3\. Visit [[PATH Relay Grafana Dashboard](http://localhost:3003/d/relays/path-service-requests)](http://localhost:3003/d/relays/path-service-requests) to view results

## Sanity Checklist

* [ ] I have updated the GitHub Issue `assignees`, `reviewers`, `labels`, `project`, `iteration` and `milestone`
* [ ] For docs, I have run `make docusaurus_start`
* [ ] For code, I have run `make test_all`
* [ ] For configurations, I have updated the documentation
* [ ] I added `TODO`s where applicable
