### PR TITLE
[SERVICE] Revised service IDs for onchain cleanup

### DIFF
--- a/api/path_openapi.yaml
+++ b/api/path_openapi.yaml
@@ -14,12 +14,12 @@ servers:
         default: eth
         description: The service ID that determines the subdomain
         enum:
-          - arb_one
-          - arb_sep_test
+          - arb-one
+          - arb-sepolia-testnet
           - avax
           - avax-dfk
           - base
-          - base-test
+          - base-sepolia-testnet
           - bera
           - bitcoin
           - blast
@@ -27,8 +27,8 @@ servers:
           - bsc
           - celo
           - eth
-          - eth_hol_test
-          - eth_sep_test
+          - eth-holesky-testnet
+          - eth-sepolia-testnet
           - evmos
           - fantom
           - fraxtal
@@ -47,24 +47,24 @@ servers:
           - near
           - oasys
           - op
-          - op_sep_test
+          - op-sepolia-testnet
           - opbnb
           - pocket
           - poly
-          - poly_amoy_test
-          - poly_zkevm
+          - poly-amoy-testnet
+          - poly-zkevm
           - radix
           - scroll
           - sei
           - sonic
           - sui
           - taiko
-          - taiko_hek_test
+          - taiko-hekla-testnet
           - tron
-          - xrpl_evm_dev
-          - xrpl_evm_test
-          - zklink_nova
-          - zksync_era
+          - xrplevm
+          - xrplevm-testnet
+          - zklink-nova
+          - zksync-era
   - url: http://localhost:3069
     description: Local PATH instance
 components:
@@ -124,11 +124,11 @@ components:
       schema:
         type: string
   examples:
-    arb_one:
-      value: arb_one
+    arb-one:
+      value: arb-one
       summary: Arbitrum One
-    arb_sep_test:
-      value: arb_sep_test
+    arb-sepolia-testnet:
+      value: arb-sepolia-testnet
       summary: Arbitrum Sepolia Testnet
     avax:
       value: avax
@@ -139,8 +139,8 @@ components:
     base:
       value: base
       summary: Base
-    base-test:
-      value: base-test
+    base-sepolia-testnet:
+      value: base-sepolia-testnet
       summary: Base Testnet
     bera:
       value: bera
@@ -163,11 +163,11 @@ components:
     eth:
       value: eth
       summary: Ethereum
-    eth_hol_test:
-      value: eth_hol_test
+    eth-holesky-testnet:
+      value: eth-holesky-testnet
       summary: Ethereum Holesky Testnet
-    eth_sep_test:
-      value: eth_sep_test
+    eth-sepolia-testnet:
+      value: eth-sepolia-testnet
       summary: Ethereum Sepolia Testnet
     evmos:
       value: evmos
@@ -223,8 +223,8 @@ components:
     op:
       value: op
       summary: Optimism
-    op_sep_test:
-      value: op_sep_test
+    op-sepolia-testnet:
+      value: op-sepolia-testnet
       summary: Optimism Sepolia Testnet
     opbnb:
       value: opbnb
@@ -235,11 +235,11 @@ components:
     poly:
       value: poly
       summary: Polygon
-    poly_amoy_test:
-      value: poly_amoy_test
+    poly-amoy-testnet:
+      value: poly-amoy-testnet
       summary: Polygon Amoy Testnet
-    poly_zkevm:
-      value: poly_zkevm
+    poly-zkevm:
+      value: poly-zkevm
       summary: Polygon zkEVM
     radix:
       value: radix
@@ -259,23 +259,23 @@ components:
     taiko:
       value: taiko
       summary: Taiko
-    taiko_hek_test:
-      value: taiko_hek_test
+    taiko-hekla-testnet:
+      value: taiko-hekla-testnet
       summary: Taiko Hekla Testnet
     tron:
       value: tron
       summary: Tron
-    xrpl_evm_dev:
-      value: xrpl_evm_dev
-      summary: XRPL EVM Dev
-    xrpl_evm_test:
-      value: xrpl_evm_test
-      summary: XRPL EVM Testnet
-    zklink_nova:
-      value: zklink_nova
+    xrplevm:
+      value: xrplevm
+      summary: XRPLEVM
+    xrplevm-testnet:
+      value: xrplevm-testnet
+      summary: XRPLEVM Testnet
+    zklink-nova:
+      value: zklink-nova
       summary: zkLink Nova
-    zksync_era:
-      value: zksync_era
+    zksync-era:
+      value: zksync-era
       summary: zkSync Era
 security:
   - ApiKeyAuth: []

--- a/config/service_qos_config.go
+++ b/config/service_qos_config.go
@@ -60,7 +60,7 @@ var shannonServices = []ServiceQoSConfig{
 	// *** EVM Services (Archival) ***
 
 	// Arbitrum One
-	evm.NewEVMServiceQoSConfig("arb_one", "0xa4b1", evm.NewEVMArchivalCheckConfig(
+	evm.NewEVMServiceQoSConfig("arb-one", "0xa4b1", evm.NewEVMArchivalCheckConfig(
 		// https://arbiscan.io/address/0xb38e8c17e38363af6ebdcb3dae12e0243582891d
 		"0xb38e8c17e38363af6ebdcb3dae12e0243582891d",
 		// Contract start block
@@ -68,7 +68,7 @@ var shannonServices = []ServiceQoSConfig{
 	)),
 
 	// Arbitrum Sepolia Testnet
-	evm.NewEVMServiceQoSConfig("arb_sep_test", "0x66EEE", evm.NewEVMArchivalCheckConfig(
+	evm.NewEVMServiceQoSConfig("arb-sepolia-testnet", "0x66EEE", evm.NewEVMArchivalCheckConfig(
 		// https://sepolia.arbiscan.io/address/0x22b65d0b9b59af4d3ed59f18b9ad53f5f4908b54
 		"0x22b65d0b9b59af4d3ed59f18b9ad53f5f4908b54",
 		// Contract start block
@@ -100,7 +100,7 @@ var shannonServices = []ServiceQoSConfig{
 	)),
 
 	// Base Sepolia Testnet
-	evm.NewEVMServiceQoSConfig("base-test", "0x14a34", evm.NewEVMArchivalCheckConfig(
+	evm.NewEVMServiceQoSConfig("base-sepolia-testnet", "0x14a34", evm.NewEVMArchivalCheckConfig(
 		// https://sepolia.basescan.org/address/0xbab76e4365a2dff89ddb2d3fc9994103b48886c0
 		"0xbab76e4365a2dff89ddb2d3fc9994103b48886c0",
 		// Contract start block
@@ -156,7 +156,7 @@ var shannonServices = []ServiceQoSConfig{
 	)),
 
 	// Ethereum Holesky Testnet
-	evm.NewEVMServiceQoSConfig("eth_hol_test", "0x4268", evm.NewEVMArchivalCheckConfig(
+	evm.NewEVMServiceQoSConfig("eth-holesky-testnet", "0x4268", evm.NewEVMArchivalCheckConfig(
 		// https://holesky.etherscan.io/address/0xc6392ad8a14794ea57d237d12017e7295bea2363
 		"0xc6392ad8a14794ea57d237d12017e7295bea2363",
 		// Contract start block
@@ -164,7 +164,7 @@ var shannonServices = []ServiceQoSConfig{
 	)),
 
 	// Ethereum Sepolia Testnet
-	evm.NewEVMServiceQoSConfig("eth_sep_test", "0xaa36a7", evm.NewEVMArchivalCheckConfig(
+	evm.NewEVMServiceQoSConfig("eth-sepolia-testnet", "0xaa36a7", evm.NewEVMArchivalCheckConfig(
 		// https://sepolia.etherscan.io/address/0xc0f3833b7e7216eecd9f6bc2c7927a7aa36ab58b
 		"0xc0f3833b7e7216eecd9f6bc2c7927a7aa36ab58b",
 		// Contract start block
@@ -276,7 +276,7 @@ var shannonServices = []ServiceQoSConfig{
 	)),
 
 	// Optimism Sepolia Testnet
-	evm.NewEVMServiceQoSConfig("op_sep_test", "0xAA37DC", evm.NewEVMArchivalCheckConfig(
+	evm.NewEVMServiceQoSConfig("op-sepolia-testnet", "0xAA37DC", evm.NewEVMArchivalCheckConfig(
 		// https://sepolia-optimism.etherscan.io/address/0x734d539a7efee15714a2755caa4280e12ef3d7e4
 		"0x734d539a7efee15714a2755caa4280e12ef3d7e4",
 		// Contract start block
@@ -292,7 +292,7 @@ var shannonServices = []ServiceQoSConfig{
 	)),
 
 	// Polygon Amoy Testnet
-	evm.NewEVMServiceQoSConfig("poly_amoy_test", "0x13882", evm.NewEVMArchivalCheckConfig(
+	evm.NewEVMServiceQoSConfig("poly-amoy-testnet", "0x13882", evm.NewEVMArchivalCheckConfig(
 		// https://amoy.polygonscan.com/address/0x54d03ec0c462e9a01f77579c090cde0fc2617817
 		"0x54d03ec0c462e9a01f77579c090cde0fc2617817",
 		// Contract start block
@@ -300,7 +300,7 @@ var shannonServices = []ServiceQoSConfig{
 	)),
 
 	// Polygon zkEVM
-	evm.NewEVMServiceQoSConfig("poly_zkevm", "0x44d", evm.NewEVMArchivalCheckConfig(
+	evm.NewEVMServiceQoSConfig("poly-zkevm", "0x44d", evm.NewEVMArchivalCheckConfig(
 		// https://zkevm.polygonscan.com/address/0xee1727f5074e747716637e1776b7f7c7133f16b1
 		"0xee1727f5074E747716637e1776B7F7C7133f16b1",
 		// Contract start block
@@ -332,7 +332,7 @@ var shannonServices = []ServiceQoSConfig{
 	)),
 
 	// Taiko Hekla Testnet
-	evm.NewEVMServiceQoSConfig("taiko_hek_test", "0x28c61", evm.NewEVMArchivalCheckConfig(
+	evm.NewEVMServiceQoSConfig("taiko-hekla-testnet", "0x28c61", evm.NewEVMArchivalCheckConfig(
 		// https://hekla.taikoscan.io/address/0x1670090000000000000000000000000000010001
 		"0x1670090000000000000000000000000000010001",
 		// Contract start block
@@ -340,7 +340,7 @@ var shannonServices = []ServiceQoSConfig{
 	)),
 
 	// XRPL EVM Testnet
-	evm.NewEVMServiceQoSConfig("xrpl_evm_test", "0x161c28", evm.NewEVMArchivalCheckConfig(
+	evm.NewEVMServiceQoSConfig("xrplevm-testnet", "0x161c28", evm.NewEVMArchivalCheckConfig(
 		// https://explorer.testnet.xrplevm.org/address/0xc29e2583eD5C77df8792067989Baf9E4CCD4D7fc
 		"0xc29e2583eD5C77df8792067989Baf9E4CCD4D7fc",
 		// Contract start block
@@ -348,7 +348,7 @@ var shannonServices = []ServiceQoSConfig{
 	)),
 
 	// zkLink
-	evm.NewEVMServiceQoSConfig("zklink_nova", "0xc5cc4", evm.NewEVMArchivalCheckConfig(
+	evm.NewEVMServiceQoSConfig("zklink-nova", "0xc5cc4", evm.NewEVMArchivalCheckConfig(
 		// https://explorer.zklink.io/address/0xa3cb8648d12bD36e713af27D92968B370D7A9546
 		"0xa3cb8648d12bD36e713af27D92968B370D7A9546",
 		// Contract start block
@@ -356,7 +356,7 @@ var shannonServices = []ServiceQoSConfig{
 	)),
 
 	// zkSync
-	evm.NewEVMServiceQoSConfig("zksync_era", "0x144", evm.NewEVMArchivalCheckConfig(
+	evm.NewEVMServiceQoSConfig("zksync-era", "0x144", evm.NewEVMArchivalCheckConfig(
 		// https://explorer.zksync.io/address/0x03AC0b1b952C643d66A4Dc1fBc75118109cC074C
 		"0x03AC0b1b952C643d66A4Dc1fBc75118109cC074C",
 		// Contract start block

--- a/docusaurus/docs/learn/qos/1_supported_services.md
+++ b/docusaurus/docs/learn/qos/1_supported_services.md
@@ -84,7 +84,7 @@ If a Service ID is not specified in the tables below, it does not have a QoS imp
 | Taiko                                                      | taiko                    | EVM              | 167000                              | ✅                        |
 | Taiko Hekla Testnet                                        | taiko-hekla-testnet      | EVM              | 167009                              | ✅                        |
 | XRPLEVM Testnet                                            | xrplevm-testnet          | EVM              | 1449000                             | ✅                        |
-| zkLink                                                     | zklink_nova              | EVM              | 810180                              | ✅                        |
+| zkLink                                                     | zklink-nova              | EVM              | 810180                              | ✅                        |
 | zkSync                                                     | zksync_era               | EVM              | 324                                 | ✅                        |
 | Anvil - Ethereum development/testing                       | anvil                    | EVM              | 31337                               |                           |
 | Anvil WebSockets - Ethereum WebSockets development/testing | anvilws                  | EVM              | 31337                               |                           |
@@ -99,10 +99,6 @@ If a Service ID is not specified in the tables below, it does not have a QoS imp
 | XRPLEVM                                                    | xrplevm                  | EVM              | 1440000                             |                           |
 | TRON                                                       | tron                     | EVM              | 728126428                           |                           |
 | Sei                                                        | sei                      | EVM              | 1329                                |                           |
-| Celestia Archival                                          | tia_da                   | CometBFT         | celestia-archival                   |                           |
-| Celestia Consensus Archival                                | tia_cons                 | CometBFT         | celestia-consensus-archival         |                           |
-| Celestia Testnet DA Archival                               | tia_da_test              | CometBFT         | celestia-testnet-da-archival        |                           |
-| Celestia Testnet Consensus Archival                        | tia_cons_test            | CometBFT         | celestia-testnet-consensus-archival |                           |
 | Osmosis                                                    | osmosis                  | CometBFT         | osmosis                             |                           |
 | Pocket Beta Testnet                                        | pocket-beta-rpc          | CometBFT         | pocket-beta                         |                           |
 | Cosmos Hub                                                 | cometbft                 | CometBFT         | cosmoshub-4                         |                           |

--- a/docusaurus/docs/learn/qos/1_supported_services.md
+++ b/docusaurus/docs/learn/qos/1_supported_services.md
@@ -42,26 +42,26 @@ If a Service ID is not specified in the tables below, it does not have a QoS imp
 
 ## 🌿 Current PATH QoS Support
 
-**🗓️ Document Last Updated: 2025-06-03**
+**🗓️ Document Last Updated: 2025-06-23**
 
-## Shannon Protocol Services
+## Grove PATH Services
 
 | Service Name                                               | Authoritative Service ID | Service QoS Type | Chain ID (if applicable)            | Archival Check Configured |
 | ---------------------------------------------------------- | ------------------------ | ---------------- | ----------------------------------- | ------------------------- |
-| Arbitrum One                                               | arb_one                  | EVM              | 42161                               | ✅                        |
-| Arbitrum Sepolia Testnet                                   | arb_sep_test             | EVM              | 421614                              | ✅                        |
+| Arbitrum One                                               | arb-one                  | EVM              | 42161                               | ✅                        |
+| Arbitrum Sepolia Testnet                                   | arb-sepolia-testnet      | EVM              | 421614                              | ✅                        |
 | Avalanche                                                  | avax                     | EVM              | 43114                               | ✅                        |
 | Avalanche-DFK                                              | avax-dfk                 | EVM              | 53935                               | ✅                        |
 | Base                                                       | base                     | EVM              | 8453                                | ✅                        |
-| Base Sepolia Testnet                                       | base-test                | EVM              | 84532                               | ✅                        |
+| Base Sepolia Testnet                                       | base-sepolia-testnet     | EVM              | 84532                               | ✅                        |
 | Berachain                                                  | bera                     | EVM              | 80094                               | ✅                        |
 | Blast                                                      | blast                    | EVM              | 81457                               | ✅                        |
 | BNB Smart Chain                                            | bsc                      | EVM              | 56                                  | ✅                        |
 | Boba                                                       | boba                     | EVM              | 288                                 | ✅                        |
 | Celo                                                       | celo                     | EVM              | 42220                               | ✅                        |
 | Ethereum                                                   | eth                      | EVM              | 1                                   | ✅                        |
-| Ethereum Holesky Testnet                                   | eth_hol_test             | EVM              | 17000                               | ✅                        |
-| Ethereum Sepolia Testnet                                   | eth_sep_test             | EVM              | 11155111                            | ✅                        |
+| Ethereum Holesky Testnet                                   | eth-holesky-testnet      | EVM              | 17000                               | ✅                        |
+| Ethereum Sepolia Testnet                                   | eth-sepolia-testnet      | EVM              | 11155111                            | ✅                        |
 | Fantom                                                     | fantom                   | EVM              | 250                                 | ✅                        |
 | Fuse                                                       | fuse                     | EVM              | 122                                 | ✅                        |
 | Gnosis                                                     | gnosis                   | EVM              | 100                                 | ✅                        |
@@ -75,15 +75,15 @@ If a Service ID is not specified in the tables below, it does not have a QoS imp
 | Moonbeam                                                   | moonbeam                 | EVM              | 1284                                | ✅                        |
 | Oasys                                                      | oasys                    | EVM              | 248                                 | ✅                        |
 | Optimism                                                   | op                       | EVM              | 10                                  | ✅                        |
-| Optimism Sepolia Testnet                                   | op_sep_test              | EVM              | 11155420                            | ✅                        |
+| Optimism Sepolia Testnet                                   | op-sepolia-testnet       | EVM              | 11155420                            | ✅                        |
 | Polygon                                                    | poly                     | EVM              | 137                                 | ✅                        |
-| Polygon Amoy Testnet                                       | poly_amoy_test           | EVM              | 80002                               | ✅                        |
-| Polygon zkEVM                                              | poly_zkevm               | EVM              | 1101                                | ✅                        |
+| Polygon Amoy Testnet                                       | poly-amoy-testnet        | EVM              | 80002                               | ✅                        |
+| Polygon zkEVM                                              | poly-zkevm               | EVM              | 1101                                | ✅                        |
 | Scroll                                                     | scroll                   | EVM              | 534352                              | ✅                        |
 | Sonic                                                      | sonic                    | EVM              | 146                                 | ✅                        |
 | Taiko                                                      | taiko                    | EVM              | 167000                              | ✅                        |
-| Taiko Hekla Testnet                                        | taiko_hek_test           | EVM              | 167009                              | ✅                        |
-| XRPL EVM Testnet                                           | xrpl_evm_test            | EVM              | 1449000                             | ✅                        |
+| Taiko Hekla Testnet                                        | taiko-hekla-testnet      | EVM              | 167009                              | ✅                        |
+| XRPLEVM Testnet                                            | xrplevm-testnet          | EVM              | 1449000                             | ✅                        |
 | zkLink                                                     | zklink_nova              | EVM              | 810180                              | ✅                        |
 | zkSync                                                     | zksync_era               | EVM              | 324                                 | ✅                        |
 | Anvil - Ethereum development/testing                       | anvil                    | EVM              | 31337                               |                           |
@@ -96,7 +96,7 @@ If a Service ID is not specified in the tables below, it does not have a QoS imp
 | opBNB                                                      | opbnb                    | EVM              | 204                                 |                           |
 | Radix                                                      | radix                    | EVM              | 4919                                |                           |
 | Sui                                                        | sui                      | EVM              | 257                                 |                           |
-| XRPL EVM Devnet                                            | xrpl_evm_dev             | EVM              | 1440002                             |                           |
+| XRPLEVM                                                    | xrplevm                  | EVM              | 1440000                             |                           |
 | TRON                                                       | tron                     | EVM              | 728126428                           |                           |
 | Sei                                                        | sei                      | EVM              | 1329                                |                           |
 | Celestia Archival                                          | tia_da                   | CometBFT         | celestia-archival                   |                           |
@@ -108,63 +108,3 @@ If a Service ID is not specified in the tables below, it does not have a QoS imp
 | Cosmos Hub                                                 | cometbft                 | CometBFT         | cosmoshub-4                         |                           |
 | Solana                                                     | solana                   | Solana           |                                     |                           |
 
-## Morse Protocol Services
-
-| Service Name                                     | Authoritative Service ID | Service QoS Type | Chain ID (if applicable)            | Archival Check Configured |
-| ------------------------------------------------ | ------------------------ | ---------------- | ----------------------------------- | ------------------------- |
-| Arbitrum One                                     | F001                     | EVM              | 42161                               | ✅                        |
-| Arbitrum Sepolia Testnet                         | F002                     | EVM              | 421614                              | ✅                        |
-| Avalanche                                        | F003                     | EVM              | 43114                               | ✅                        |
-| Avalanche-DFK                                    | F004                     | EVM              | 53935                               | ✅                        |
-| Base                                             | F005                     | EVM              | 8453                                | ✅                        |
-| Base Sepolia Testnet                             | F006                     | EVM              | 84532                               | ✅                        |
-| Berachain                                        | F035                     | EVM              | 80094                               | ✅                        |
-| Blast                                            | F008                     | EVM              | 81457                               | ✅                        |
-| BNB Smart Chain                                  | F009                     | EVM              | 56                                  | ✅                        |
-| Boba                                             | F00A                     | EVM              | 288                                 | ✅                        |
-| Celo                                             | F00B                     | EVM              | 42220                               | ✅                        |
-| Ethereum                                         | F00C                     | EVM              | 1                                   | ✅                        |
-| Ethereum Holesky Testnet                         | F00D                     | EVM              | 17000                               | ✅                        |
-| Ethereum Sepolia Testnet                         | F00E                     | EVM              | 11155111                            | ✅                        |
-| Fuse                                             | F012                     | EVM              | 122                                 | ✅                        |
-| Gnosis                                           | F013                     | EVM              | 100                                 | ✅                        |
-| Harmony-0                                        | F014                     | EVM              | 1666600000                          | ✅                        |
-| Ink                                              | F032                     | EVM              | 57073                               | ✅                        |
-| IoTeX                                            | F015                     | EVM              | 4689                                | ✅                        |
-| Kaia                                             | F016                     | EVM              | 8217                                | ✅                        |
-| Linea                                            | F030                     | EVM              | 59144                               | ✅                        |
-| Mantle                                           | F033                     | EVM              | 5000                                | ✅                        |
-| Metis                                            | F018                     | EVM              | 1088                                | ✅                        |
-| Moonbeam                                         | F019                     | EVM              | 1284                                | ✅                        |
-| Oasys                                            | F01C                     | EVM              | 248                                 | ✅                        |
-| Optimism                                         | F01D                     | EVM              | 10                                  | ✅                        |
-| Optimism Sepolia Testnet                         | F01E                     | EVM              | 11155420                            | ✅                        |
-| opBNB                                            | F01F                     | EVM              | 204                                 | ✅                        |
-| Polygon                                          | F021                     | EVM              | 137                                 | ✅                        |
-| Polygon Amoy Testnet                             | F022                     | EVM              | 80002                               | ✅                        |
-| Polygon zkEVM                                    | F029                     | EVM              | 1101                                | ✅                        |
-| Scroll                                           | F024                     | EVM              | 534352                              | ✅                        |
-| Sonic                                            | F02D                     | EVM              | 146                                 | ✅                        |
-| Taiko                                            | F027                     | EVM              | 167000                              | ✅                        |
-| Taiko Hekla Testnet                              | F028                     | EVM              | 167009                              | ✅                        |
-| XRPL EVM Testnet                                 | F036                     | EVM              | 1449000                             | ✅                        |
-| zkLink                                           | F02A                     | EVM              | 810180                              | ✅                        |
-| zkSync                                           | F02B                     | EVM              | 324                                 | ✅                        |
-| Evmos                                            | F00F                     | EVM              | 9001                                |                           |
-| Fantom                                           | F010                     | EVM              | 250                                 |                           |
-| Fraxtal                                          | F011                     | EVM              | 252                                 |                           |
-| Kava                                             | F017                     | EVM              | 2222                                |                           |
-| Moonriver                                        | F01A                     | EVM              | 1285                                |                           |
-| Near                                             | F01B                     | EVM              | 397                                 |                           |
-| Radix                                            | F023                     | EVM              | 4919                                |                           |
-| Sui                                              | F026                     | EVM              | 257                                 |                           |
-| XRPL EVM Devnet                                  | F02C                     | EVM              | 1440002                             |                           |
-| TRON                                             | F02E                     | EVM              | 728126428                           |                           |
-| Berachain Testnet                                | F031                     | EVM              | 80084                               |                           |
-| Sei                                              | F034                     | EVM              | 1329                                |                           |
-| Celestia Archival                                | A0CA                     | CometBFT         | celestia-archival                   |                           |
-| Celestia Consensus Archival                      | A0CB                     | CometBFT         | celestia-consensus-archival         |                           |
-| Celestia Testnet DA Archival                     | A0CC                     | CometBFT         | celestia-testnet-da-archival        |                           |
-| Celestia Testnet Consensus Archival              | A0CD                     | CometBFT         | celestia-testnet-consensus-archival |                           |
-| Osmosis                                          | F020                     | CometBFT         | osmosis                             |                           |
-| TODO_MVP(@adshmh): Drop the Chain ID for Solana. | F025                     | Solana           |                                     |                           |

--- a/e2e/config/.grove.archival.e2e_load_test.config.yaml
+++ b/e2e/config/.grove.archival.e2e_load_test.config.yaml
@@ -19,9 +19,9 @@ service_config_overrides:
   "anvil":
     global_rps: 1
     requests_per_method: 3
-  "arb_one":
+  "arb-one":
     archival: true
-  "arb_sep_test":
+  "arb-sepolia-testnet":
     archival: true
   "avax":
     archival: true
@@ -29,7 +29,7 @@ service_config_overrides:
     archival: true
   "base":
     archival: true
-  "base-test":
+  "base-sepolia-testnet":
     archival: true
   "bera":
     archival: true

--- a/e2e/config/.grove.archival.e2e_load_test.config.yaml
+++ b/e2e/config/.grove.archival.e2e_load_test.config.yaml
@@ -45,9 +45,9 @@ service_config_overrides:
     archival: true
   "eth":
     archival: true
-  "eth_hol_test":
+  "eth-holesky-testnet":
     archival: true
-  "eth_sep_test":
+  "eth-sepolia-testnet":
     archival: true
   "evmos":
     archival: true
@@ -85,7 +85,7 @@ service_config_overrides:
     archival: true
   "op":
     archival: true
-  "op_sep_test":
+  "op-sepolia-testnet":
     archival: true
   "opbnb":
     archival: true
@@ -95,9 +95,9 @@ service_config_overrides:
     archival: true
   "poly":
     archival: true
-  "poly_amoy_test":
+  "poly-amoy-testnet":
     archival: true
-  "poly_zkevm":
+  "poly-zkevm":
     archival: true
   "radix":
     archival: true
@@ -113,15 +113,15 @@ service_config_overrides:
     archival: true
   "taiko":
     archival: true
-  "taiko_hek_test":
+  "taiko-hekla-testnet":
     archival: true
   "tron":
     archival: true
-  "xrpl_evm_dev":
+  "xrplevm":
     archival: true
-  "xrpl_evm_test":
+  "xrplevm-testnet":
     archival: true
-  "zklink_nova":
+  "zklink-nova":
     archival: true
   "zksync_era":
     archival: true

--- a/e2e/config/.grove.e2e_load_test.config.yaml
+++ b/e2e/config/.grove.e2e_load_test.config.yaml
@@ -19,9 +19,9 @@ service_config_overrides:
   "anvil":
     global_rps: 1
     requests_per_method: 3
-  "arb_one":
+  "arb-one":
     archival: false
-  "arb_sep_test":
+  "arb-sepolia-testnet":
     archival: false
   "avax":
     archival: false
@@ -29,7 +29,7 @@ service_config_overrides:
     archival: false
   "base":
     archival: false
-  "base-test":
+  "base-sepolia-testnet":
     archival: false
   "bera":
     archival: false

--- a/e2e/config/.grove.e2e_load_test.config.yaml
+++ b/e2e/config/.grove.e2e_load_test.config.yaml
@@ -45,9 +45,9 @@ service_config_overrides:
     archival: false
   "eth":
     archival: false
-  "eth_hol_test":
+  "eth-holesky-testnet":
     archival: false
-  "eth_sep_test":
+  "eth-sepolia-testnet":
     archival: false
   "evmos":
     archival: false
@@ -85,7 +85,7 @@ service_config_overrides:
     archival: false
   "op":
     archival: false
-  "op_sep_test":
+  "op-sepolia-testnet":
     archival: false
   "opbnb":
     archival: false
@@ -95,9 +95,9 @@ service_config_overrides:
     archival: false
   "poly":
     archival: false
-  "poly_amoy_test":
+  "poly-amoy-testnet":
     archival: false
-  "poly_zkevm":
+  "poly-zkevm":
     archival: false
   "radix":
     archival: false
@@ -113,15 +113,15 @@ service_config_overrides:
     archival: false
   "taiko":
     archival: false
-  "taiko_hek_test":
+  "taiko-hekla-testnet":
     archival: false
   "tron":
     archival: false
-  "xrpl_evm_dev":
+  "xrplevm":
     archival: false
-  "xrpl_evm_test":
+  "xrplevm-testnet":
     archival: false
-  "zklink_nova":
+  "zklink-nova":
     archival: false
   "zksync_era":
     archival: false

--- a/e2e/config/services.schema.yaml
+++ b/e2e/config/services.schema.yaml
@@ -36,7 +36,7 @@ definitions:
       service_id:
         description: "Service ID to test - identifies the specific blockchain service"
         type: string
-        examples: ["F00C", "anvil", "eth", "arb_one"]
+        examples: ["F00C", "anvil", "eth", "arb-one"]
       service_type:
         description: "Type of service to test"
         type: string

--- a/e2e/config/services_shannon.yaml
+++ b/e2e/config/services_shannon.yaml
@@ -11,7 +11,7 @@
 # - near
 # - radix
 # - xrpl_evm_dev
-# - base-testnet
+# - base-sepolia-testnetnet
 # - moonriver
 # - sei
 # - svc-poktminer
@@ -27,8 +27,8 @@ services:
   # ------------- EVM Services -------------
 
   # Shannon - Arbitrum One (Archival)
-  - name: "Shannon - arb_one (Arbitrum One) Test"
-    service_id: "arb_one"
+  - name: "Shannon - arb-one (Arbitrum One) Test"
+    service_id: "arb-one"
     service_type: "evm"
     alias: "arbitrum-one"
     archival: true
@@ -40,8 +40,8 @@ services:
       call_data: "0x18160ddd"
 
   # Shannon - Arbitrum Sepolia Testnet (Archival)
-  - name: "Shannon - arb_sep_test (Arbitrum Sepolia Testnet) Test"
-    service_id: "arb_sep_test"
+  - name: "Shannon - arb-sepolia-testnet (Arbitrum Sepolia Testnet) Test"
+    service_id: "arb-sepolia-testnet"
     service_type: "evm"
     alias: "arbitrum-sepolia-testnet"
     archival: true
@@ -90,8 +90,8 @@ services:
 
   # Shannon - Base Sepolia Testnet (Archival)
   - name: "Shannon - base (Base Sepolia Testnet) Test"
-    service_id: "base-test"
-    alias: "base-testnet"
+    service_id: "base-sepolia-testnet"
+    alias: "base-sepolia-testnetnet"
     service_type: "evm"
     archival: true
     service_params:

--- a/e2e/config/services_shannon.yaml
+++ b/e2e/config/services_shannon.yaml
@@ -174,8 +174,8 @@ services:
       call_data: "0x18160ddd"
 
   # Shannon - Ethereum Holesky Testnet (Archival)
-  - name: "Shannon - eth_hol_test (Ethereum Holesky Testnet) Test"
-    service_id: "eth_hol_test"
+  - name: "Shannon - eth-holesky-testnet (Ethereum Holesky Testnet) Test"
+    service_id: "eth-holesky-testnet"
     alias: "eth-holesky-testnet"
     service_type: "evm"
     archival: true
@@ -187,8 +187,8 @@ services:
       call_data: "0x18160ddd"
 
   # Shannon - Ethereum Sepolia Testnet (Archival)
-  - name: "Shannon - eth_sep_test (Ethereum Sepolia Testnet) Test"
-    service_id: "eth_sep_test"
+  - name: "Shannon - eth-sepolia-testnet (Ethereum Sepolia Testnet) Test"
+    service_id: "eth-sepolia-testnet"
     alias: "eth-sepolia-testnet"
     service_type: "evm"
     archival: true
@@ -369,7 +369,7 @@ services:
 
   # Shannon - Optimism Sepolia Testnet (Archival)
   - name: "Shannon - optimism_sep_test (Optimism Sepolia Testnet) Test"
-    service_id: "op_sep_test"
+    service_id: "op-sepolia-testnet"
     alias: "optimism-sepolia-testnet"
     service_type: "evm"
     archival: true
@@ -406,7 +406,7 @@ services:
 
   # Shannon - Polygon Amoy Testnet (Archival)
   - name: "Shannon - polygon_amoy_test (Polygon Amoy Testnet) Test"
-    service_id: "poly_amoy_test"
+    service_id: "poly-amoy-testnet"
     service_type: "evm"
     archival: true
     service_params:
@@ -418,7 +418,7 @@ services:
 
   # Shannon - Polygon zkEVM (Archival)
   - name: "Shannon - polygon_zkevm (Polygon zkEVM) Test"
-    service_id: "poly_zkevm"
+    service_id: "poly-zkevm"
     service_type: "evm"
     archival: true
     service_params:
@@ -466,7 +466,7 @@ services:
 
   # Shannon - Taiko Hekla Testnet (Archival)
   - name: "Shannon - taiko_hekla_test (Taiko Hekla Testnet) Test"
-    service_id: "taiko_hek_test"
+    service_id: "taiko-hekla-testnet"
     service_type: "evm"
     archival: true
     service_params:
@@ -476,9 +476,22 @@ services:
       transaction_hash: "0x26f8e0bc913775116335b2b379c19e0a044acdbf5d42f149b7ddd288e273dd6d"
       call_data: "0x18160ddd"
 
-  # Shannon - XRPL EVM Testnet (Archival)
-  - name: "Shannon - xrpl_evm_test (XRPL EVM Testnet) Test"
-    service_id: "xrpl_evm_test"
+  # TODO TECHDEBT: Implement test for xrplevm (mainnet)
+  # Shannon - XRPLEVM
+  #- name: "Shannon - xrplevm-testnet (XRPL EVM Testnet) Test"
+  #  service_id: "xrplevm-testnet"
+  #  service_type: "evm"
+  #  archival: true
+  #  service_params:
+  #    # https://explorer.testnet.xrplevm.org/address/0xc29e2583eD5C77df8792067989Baf9E4CCD4D7fc
+  #    contract_address: "0xc29e2583eD5C77df8792067989Baf9E4CCD4D7fc"
+  #    contract_start_block: 368266
+  #    transaction_hash: "0xa59fde70cac38068dfd87adb1d7eb40200421ebf7075911f83bcdde810e94058"
+  #    call_data: "0x18160ddd"
+
+  # Shannon - XRPLEVM Testnet (Archival)
+  - name: "Shannon - xrplevm-testnet (XRPLEVM Testnet) Test"
+    service_id: "xrplevm-testnet"
     service_type: "evm"
     archival: true
     service_params:
@@ -490,7 +503,7 @@ services:
 
   # Shannon - zkLink (Archival)
   - name: "Shannon - zklink (zkLink) Test"
-    service_id: "zklink_nova"
+    service_id: "zklink-nova"
     service_type: "evm"
     archival: true
     service_params:

--- a/e2e/scripts/shannon_preliminary_services_test.sh
+++ b/e2e/scripts/shannon_preliminary_services_test.sh
@@ -28,8 +28,8 @@ EVM_SERVICES=(
     "bsc"
     "celo"
     "eth"
-    "eth_hol_test"
-    "eth_sep_test"
+    "eth-holesky-testnet"
+    "eth-sepolia-testnet"
     "evmos"
     "fantom"
     "fraxtal"
@@ -48,12 +48,12 @@ EVM_SERVICES=(
     "near"
     "oasys"
     "op"
-    "op_sep_test"
+    "op-sepolia-testnet"
     "opbnb"
     "osmosis"
     "poly"
-    "poly_amoy_test"
-    "poly_zkevm"
+    "poly-amoy-testnet"
+    "poly-zkevm"
     "radix"
     "scroll"
     "sei"
@@ -61,11 +61,11 @@ EVM_SERVICES=(
     "sonic"
     "sui"
     "taiko"
-    "taiko_hek_test"
+    "taiko-hekla-testnet"
     "tron"
-    "xrpl_evm_dev"
-    "xrpl_evm_test"
-    "zklink_nova"
+    "xrplevm"
+    "xrplevm-testnet"
+    "zklink-nova"
     "zksync_era"
 )
 
@@ -319,12 +319,12 @@ get_service_identifier() {
         arb-one) echo "arbitrum-one" ;;
         arb-sepolia-testnet) echo "arbitrum-sepolia-testnet" ;;
         base-sepolia-testnet) echo "base-sepolia-testnetnet" ;;
-        eth_hol_test) echo "eth-holesky-testnet" ;;
-        eth_sep_test) echo "eth-sepolia-testnet" ;;
-        op_sep_test) echo "optimism-sepolia-testnet" ;;
+        eth-holesky-testnet) echo "eth-holesky-testnet" ;;
+        eth-sepolia-testnet) echo "eth-sepolia-testnet" ;;
+        op-sepolia-testnet) echo "optimism-sepolia-testnet" ;;
         poly) echo "poly" ;;
-        taiko_hek_test) echo "taiko-hekla-testnet" ;;
-        xrpl_evm_test) echo "xrpl-evm-test" ;;
+        taiko-hekla-testnet) echo "taiko-hekla-testnet" ;;
+        xrplevm-testnet) echo "xrpl-evm-test" ;;
         zksync_era) echo "zksync-era" ;;
         *) echo "$service_id" ;;
         esac

--- a/e2e/scripts/shannon_preliminary_services_test.sh
+++ b/e2e/scripts/shannon_preliminary_services_test.sh
@@ -15,11 +15,11 @@ source "$(dirname "$0")/shannon_preliminary_services_helpers.sh"
 
 # EVM-compatible services that use JSON-RPC eth_blockNumber for testing
 EVM_SERVICES=(
-    "arb_one"
-    "arb_sep_test"
+    "arb-one"
+    "arb-sepolia-testnet"
     "avax-dfk"
     "avax"
-    "base-test"
+    "base-sepolia-testnet"
     "base"
     "bera"
     "bitcoin"
@@ -316,9 +316,9 @@ get_service_identifier() {
     local service_id="$1"
     if [ "$ENVIRONMENT" = "production" ]; then
         case "$service_id" in
-        arb_one) echo "arbitrum-one" ;;
-        arb_sep_test) echo "arbitrum-sepolia-testnet" ;;
-        base-test) echo "base-testnet" ;;
+        arb-one) echo "arbitrum-one" ;;
+        arb-sepolia-testnet) echo "arbitrum-sepolia-testnet" ;;
+        base-sepolia-testnet) echo "base-sepolia-testnetnet" ;;
         eth_hol_test) echo "eth-holesky-testnet" ;;
         eth_sep_test) echo "eth-sepolia-testnet" ;;
         op_sep_test) echo "optimism-sepolia-testnet" ;;

--- a/makefiles/test.mk
+++ b/makefiles/test.mk
@@ -9,7 +9,7 @@
 
 .PHONY: test_all ## Run all unit tests and E2E test a subset of key services.
 test_all: test_unit
-	@$(MAKE) e2e_test eth,poly,xrpl_evm_test,oasys
+	@$(MAKE) e2e_test eth,poly,xrplevm-testnet,oasys
 	@$(MAKE) morse_e2e_test F00C,F021,F036,F01C
 
 .PHONY: test_unit

--- a/qos/evm/state_archival.go
+++ b/qos/evm/state_archival.go
@@ -135,7 +135,7 @@ func blockNumberToHex(blockNumber uint64) string {
 //
 // `archivalConsensusThreshold` endpoints must agree on the same balance for it to be set as the expected archival balance.
 func (as *archivalState) updateExpectedBalance(updatedEndpoints map[protocol.EndpointAddr]endpoint) {
-	// Parallelize balance fetching and consensus because some chains have very low block latencies (e.g. arb_one).
+	// Parallelize balance fetching and consensus because some chains have very low block latencies (e.g. arb-one).
 	balanceCh := make(chan string, len(updatedEndpoints))
 	timeout := time.After(5 * time.Second)
 	var wg sync.WaitGroup


### PR DESCRIPTION
## Summary

Bringing services back in line with the onchain service IDs that are now cleaned up.

### Primary Changes:

- Update services in accordance with https://docs.google.com/spreadsheets/d/1QWVGEuB2u5bkGfONoDNaltjny1jd9rJ_f7HZTjSGgQM/edit?gid=195862478#gid=195862478 to the new naming conventions.

### Secondary Changes:

- Add `xrplevm` preliminarily to the codebase

## Issue

- https://github.com/pokt-network/poktroll/issues/1526

## Type of change

Select one or more from the following:

- [x] New feature, functionality or library
- [ ] Bug fix
- [x] Code health or cleanup
- [x] Documentation
- [ ] Other (specify)

## QoS Checklist

### E2E Validation & Tests

- [ ] `make path_up`
- [ ] `make test_e2e_evm_shannon`
- [ ] `make test_e2e_evm_morse`

### Observability

- [ ] 1. `make path_up`
- [ ] 2. Run one of the following:
  - For `Shannon` with `anvil`: `make test_request__shannon_relay_util_100`
  - For `Morse` with `F00C`: `make test_request__morse_relay_util_100`
- [ ] 3. Visit [PATH Relay Grafana Dashboard](http://localhost:3003/d/relays/path-service-requests) to view results

## Sanity Checklist

- [ ] I have updated the GitHub Issue `assignees`, `reviewers`, `labels`, `project`, `iteration` and `milestone`
- [ ] For docs, I have run `make docusaurus_start`
- [ ] For code, I have run `make test_all`
- [ ] For configurations, I have updated the documentation
- [ ] I added `TODO`s where applicable
