### PR TITLE
feat: add Prometheus metric to expose PATH version information

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@
 
 # Don't commit binaries
 bin
+release
 
 # Do not allow a multi-moduled projected
 go.work.sum
@@ -67,9 +68,10 @@ install.log
 # exclude values.tmpl.yaml files
 !values.tmpl.yaml
 
-# Claudesync
+# Claudesync, Claude code and MCP servers
 .claudesync/
 .claudeignore
+.serena/cache
 
 # Config Backup files
 *.backup

--- a/.serena/memories/code_style_conventions.md
+++ b/.serena/memories/code_style_conventions.md
@@ -1,0 +1,33 @@
+# PATH Code Style and Conventions
+
+## Go Style
+- Standard Go formatting (gofmt)
+- Uses golangci-lint for code quality (`make go_lint`)
+- Package-level documentation with purpose and usage
+- Structured logging with polylog
+- Error handling follows Go conventions
+
+## Naming Conventions
+- Package names: lowercase, short, descriptive
+- Constants: camelCase for unexported, PascalCase for exported
+- Variables: camelCase
+- Functions: PascalCase for exported, camelCase for unexported
+- Interfaces: Usually end with -er suffix
+
+## Metrics Conventions
+- All metrics use `pathProcess = "path"` as subsystem
+- Metric names defined as constants (e.g., `requestsTotal = "requests_total"`)
+- Package-level metric variables using prometheus constructors
+- Registration in `init()` functions using `prometheus.MustRegister()`
+- Publishing through dedicated `PublishMetrics()` functions
+
+## Documentation
+- Comprehensive comments for exported functions and types
+- TODO comments with assignee format: `TODO_MVP(@username): description`
+- Usage examples in complex function comments
+
+## Testing
+- Unit tests with `-short` flag for quick testing
+- E2E tests for integration scenarios
+- Table-driven tests for multiple test cases
+- Separate test files with `_test.go` suffix

--- a/.serena/memories/metrics_patterns.md
+++ b/.serena/memories/metrics_patterns.md
@@ -1,0 +1,50 @@
+# PATH Metrics Patterns
+
+## Current Prometheus Metrics Setup
+
+### Structure
+- **Central metrics files**:
+  - `metrics/gateway.go` - Gateway-level metrics (requests, duration, response size)
+  - `metrics/server.go` - Prometheus metrics server setup
+  - `metrics/prometheus_reporter.go` - Metrics reporter interface
+  - `cmd/metrics.go` - Metrics server initialization
+
+### Protocol-specific metrics
+- `metrics/protocol/shannon/metrics.go` - Shannon protocol metrics
+- `metrics/protocol/morse/metrics.go` - Morse protocol metrics
+
+### QoS-specific metrics
+- `metrics/qos/evm/metrics.go` - EVM QoS metrics
+- `metrics/qos/solana/metrics.go` - Solana QoS metrics
+
+## Pattern Analysis
+
+### Common Constants
+- All metrics files use `pathProcess = "path"` as the subsystem name
+- Each file defines specific metric name constants (e.g., `requestsTotal`, `relaysTotalMetric`)
+
+### Registration Pattern
+- Each metrics file has an `init()` function that calls `prometheus.MustRegister()` for its metrics
+- Metrics are defined as package-level variables using `prometheus.NewCounterVec`, `prometheus.NewHistogramVec`
+
+### Metric Definition Structure
+```go
+var myMetric = prometheus.NewCounterVec(
+    prometheus.CounterOpts{
+        Subsystem: pathProcess,  // Always "path"
+        Name:      metricName,   // Defined as constant
+        Help:      "Description...",
+    },
+    []string{"label1", "label2"},  // Labels
+)
+```
+
+### Publishing Pattern
+- Each metrics file has a `PublishMetrics()` function
+- Uses `prometheus.Labels{}` to set label values
+- Calls `.With(labels).Inc()` or `.Observe(value)` on metrics
+
+## Version Handling
+- Project uses git-based versioning: `git describe --tags --always --dirty`
+- No existing version metric found in current setup
+- Build process uses ldflags in `makefiles/release.mk`

--- a/.serena/memories/project_overview.md
+++ b/.serena/memories/project_overview.md
@@ -1,0 +1,28 @@
+# PATH Project Overview
+
+## Purpose
+PATH (Path API & Toolkit Harness) is an open-source Go framework for enabling access to a decentralized supply network. It serves as a gateway that handles service requests and relays them through different protocols (Shannon and Morse) to blockchain endpoints.
+
+## Tech Stack
+- **Language**: Go
+- **Protocols**: Shannon (main), Morse (legacy, being phased out)
+- **Metrics**: Prometheus with custom metrics collection
+- **Development**: Kubernetes/Tilt for local development
+- **Configuration**: YAML-based configuration files
+- **Logging**: polylog with structured logging
+- **Testing**: Standard Go testing with E2E test suites
+
+## Architecture
+- **Gateway** (`gateway/`) - Main entry point for HTTP requests
+- **Protocol** (`protocol/`) - Protocol implementations (Shannon/Morse)
+- **QoS** (`qos/`) - Quality of Service for different blockchain services
+- **Router** (`router/`) - HTTP routing and API endpoint management
+- **Config** (`config/`) - Configuration management
+- **Metrics** (`metrics/`) - Prometheus metrics collection and reporting
+
+## Key Features
+- Multi-protocol support (Shannon and Morse)
+- QoS implementations for EVM, Solana, CometBFT
+- Comprehensive metrics and observability
+- Load balancing and endpoint management
+- Rate limiting and authentication

--- a/.serena/memories/project_overview.md
+++ b/.serena/memories/project_overview.md
@@ -1,11 +1,11 @@
 # PATH Project Overview
 
 ## Purpose
-PATH (Path API & Toolkit Harness) is an open-source Go framework for enabling access to a decentralized supply network. It serves as a gateway that handles service requests and relays them through different protocols (Shannon and Morse) to blockchain endpoints.
+PATH (Path API & Toolkit Harness) is an open-source Go framework for enabling access to a decentralized supply network. It serves as a gateway that handles service requests and relays them through the Shannon protocol to blockchain endpoints.
 
 ## Tech Stack
 - **Language**: Go
-- **Protocols**: Shannon (main), Morse (legacy, being phased out)
+- **Protocol**: Shannon (gRPC-based communication protocol)
 - **Metrics**: Prometheus with custom metrics collection
 - **Development**: Kubernetes/Tilt for local development
 - **Configuration**: YAML-based configuration files
@@ -14,15 +14,18 @@ PATH (Path API & Toolkit Harness) is an open-source Go framework for enabling ac
 
 ## Architecture
 - **Gateway** (`gateway/`) - Main entry point for HTTP requests
-- **Protocol** (`protocol/`) - Protocol implementations (Shannon/Morse)
+- **Protocol** (`protocol/`) - Shannon protocol implementation
 - **QoS** (`qos/`) - Quality of Service for different blockchain services
 - **Router** (`router/`) - HTTP routing and API endpoint management
 - **Config** (`config/`) - Configuration management
 - **Metrics** (`metrics/`) - Prometheus metrics collection and reporting
 
 ## Key Features
-- Multi-protocol support (Shannon and Morse)
+- Shannon protocol for decentralized network communication
 - QoS implementations for EVM, Solana, CometBFT
 - Comprehensive metrics and observability
 - Load balancing and endpoint management
 - Rate limiting and authentication
+
+## Note on Morse
+While the codebase contains references to Morse protocol for backward compatibility, it is no longer actively used. Shannon is the primary protocol for all operations.

--- a/.serena/memories/suggested_commands.md
+++ b/.serena/memories/suggested_commands.md
@@ -10,13 +10,18 @@
 - `make test_unit` - Run all unit tests (`go test ./... -short -count=1`)
 - `make test_all` - Run unit tests plus E2E tests for key services
 - `make e2e_test SERVICE_IDS` - Run E2E tests for specific Shannon service IDs (e.g., `make e2e_test eth,poly`)
-- `make morse_e2e_test SERVICE_IDS` - Run E2E tests for specific Morse service IDs (e.g., `make morse_e2e_test F00C,F021`)
 - `make load_test SERVICE_IDS` - Run Shannon load tests
 - `make go_lint` - Run Go linters (`golangci-lint run --timeout 5m --build-tags test`)
 
 ## Configuration
 - `make shannon_prepare_e2e_config` - Prepare Shannon E2E configuration
-- `make morse_prepare_e2e_config` - Prepare Morse E2E configuration
+
+## Release and Versioning
+- `make release_build_cross` - Build binaries for multiple platforms with version info
+- `make release_build_local` - Build binary for current platform only
+- `make release_tag_dev` - Tag a new dev release
+- `make release_tag_bug_fix` - Tag a new bug fix release
+- `make release_tag_minor_release` - Tag a new minor release
 
 ## System Commands (Darwin)
 - `git` for version control

--- a/.serena/memories/suggested_commands.md
+++ b/.serena/memories/suggested_commands.md
@@ -1,0 +1,26 @@
+# PATH Development Commands
+
+## Building and Running
+- `make path_build` - Build the PATH binary locally
+- `make path_run` - Run PATH as a standalone binary (requires CONFIG_PATH)
+- `make path_up` - Start local Tilt development environment with dependencies
+- `make path_down` - Tear down local Tilt development environment
+
+## Testing
+- `make test_unit` - Run all unit tests (`go test ./... -short -count=1`)
+- `make test_all` - Run unit tests plus E2E tests for key services
+- `make e2e_test SERVICE_IDS` - Run E2E tests for specific Shannon service IDs (e.g., `make e2e_test eth,poly`)
+- `make morse_e2e_test SERVICE_IDS` - Run E2E tests for specific Morse service IDs (e.g., `make morse_e2e_test F00C,F021`)
+- `make load_test SERVICE_IDS` - Run Shannon load tests
+- `make go_lint` - Run Go linters (`golangci-lint run --timeout 5m --build-tags test`)
+
+## Configuration
+- `make shannon_prepare_e2e_config` - Prepare Shannon E2E configuration
+- `make morse_prepare_e2e_config` - Prepare Morse E2E configuration
+
+## System Commands (Darwin)
+- `git` for version control
+- `grep` for text search (use `rg` ripgrep if available)
+- `find` for file searching
+- `ls` for directory listing
+- `cd` for directory navigation

--- a/.serena/memories/task_completion_checklist.md
+++ b/.serena/memories/task_completion_checklist.md
@@ -1,0 +1,24 @@
+# Task Completion Checklist
+
+## Code Quality
+- [ ] Run linting: `make go_lint`
+- [ ] Ensure code follows established patterns and conventions
+- [ ] Add appropriate documentation and comments
+- [ ] Follow the existing metrics patterns if adding metrics
+
+## Testing
+- [ ] Run unit tests: `make test_unit`
+- [ ] If changes affect core functionality, run: `make test_all`
+- [ ] For protocol changes, run specific E2E tests:
+  - Shannon: `make e2e_test SERVICE_IDS`
+  - Morse: `make morse_e2e_test SERVICE_IDS`
+
+## Build Verification
+- [ ] Ensure code builds successfully: `make path_build`
+- [ ] If making significant changes, test in local environment: `make path_up`
+
+## Final Checks
+- [ ] Verify changes don't break existing functionality
+- [ ] Check that metrics are properly registered if adding new ones
+- [ ] Ensure error handling follows Go conventions
+- [ ] Confirm logging uses structured logging with polylog

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -15,10 +15,18 @@ import (
 	configpkg "github.com/buildwithgrove/path/config"
 	"github.com/buildwithgrove/path/gateway"
 	"github.com/buildwithgrove/path/health"
+	"github.com/buildwithgrove/path/metrics"
 	"github.com/buildwithgrove/path/metrics/devtools"
 	protocolPkg "github.com/buildwithgrove/path/protocol"
 	"github.com/buildwithgrove/path/request"
 	"github.com/buildwithgrove/path/router"
+)
+
+// Version information injected at build time via ldflags
+var (
+	Version   string
+	Commit    string
+	BuildDate string
 )
 
 // defaultConfigPath will be appended to the location of
@@ -27,6 +35,9 @@ const defaultConfigPath = "config/.config.yaml"
 
 func main() {
 	log.Printf("🌿 PATH gateway starting...")
+
+	// Initialize version metrics for Prometheus monitoring
+	metrics.SetVersionInfo(Version, Commit, BuildDate)
 
 	configPath, err := getConfigPath(defaultConfigPath)
 	if err != nil {


### PR DESCRIPTION
## Summary

Add version metrics to PATH gateway for deployment tracking and monitoring

### Primary Changes:

- Add Version, Commit, and BuildDate variables to main package for ldflags injection
- Add `path_version_info` gauge metric with version, commit, and build_date labels to Prometheus metrics
- Initialize version metric during application startup with `SetVersionInfo()` function

### Secondary Changes:

- Update .gitignore to include release directory and .serena/cache for MCP servers
- Import metrics package in main.go to access SetVersionInfo function
- Register versionInfo metric in Prometheus during metrics initialization

## Type of change

Select one or more from the following:

- [x] New feature, functionality or library
- [ ] Bug fix
- [ ] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## QoS Checklist

### E2E Validation & Tests

- [ ] `make path_up`
- [ ] `make test_e2e_evm_shannon`
- [ ] `make test_e2e_evm_morse`

### Observability

- [ ] 1. `make path_up`
- [ ] 2. Run one of the following:
  - For `Shannon` with `anvil`: `make test_request__shannon_relay_util_100`
  - For `Morse` with `F00C`: `make test_request__morse_relay_util_100`
- [ ] 3. Visit [PATH Relay Grafana Dashboard](http://localhost:3003/d/relays/path-service-requests) to view results

## Sanity Checklist

- [ ] I have updated the GitHub Issue `assignees`, `reviewers`, `labels`, `project`, `iteration` and `milestone`
- [ ] For docs, I have run `make docusaurus_start`
- [ ] For code, I have run `make test_all`
- [ ] For configurations, I have updated the documentation
- [ ] I added `TODO`s where applicable