### PR TITLE
[QoS] Fix & improve perceived block number updates and validation

### DIFF
--- a/qos/evm/check_blocknumber.go
+++ b/qos/evm/check_blocknumber.go
@@ -13,8 +13,9 @@ const idBlockNumberCheck = 1002
 const methodBlockNumber = jsonrpc.Method("eth_blockNumber")
 
 var (
-	errNoBlockNumberObs      = fmt.Errorf("endpoint has not had an observation of its response to a %q request", methodBlockNumber)
-	errInvalidBlockNumberObs = fmt.Errorf("endpoint returned an invalid response to a %q request", methodBlockNumber)
+	errNoBlockNumberObs                   = fmt.Errorf("endpoint has not had an observation of its response to a %q request", methodBlockNumber)
+	errInvalidBlockNumberObs              = fmt.Errorf("endpoint returned an invalid response to a %q request", methodBlockNumber)
+	errOutsideSyncAllowanceBlockNumberObs = fmt.Errorf("endpoint's block height is outside the sync allowance in response to a %q request", methodBlockNumber)
 )
 
 // endpointCheckBlockNumber is a check that ensures the endpoint's block height within the sync allowance.

--- a/qos/evm/endpoint_selection.go
+++ b/qos/evm/endpoint_selection.go
@@ -105,7 +105,7 @@ func (ss *serviceState) basicEndpointValidation(endpoint endpoint) error {
 
 	// Ensure the endpoint's block number is not more than the sync allowance behind the perceived block number.
 	if err := ss.isBlockNumberValid(endpoint.checkBlockNumber); err != nil {
-		// Fix: Dereference pointer to show actual block number instead of memory address in error logs
+		// Dereference pointer to show actual block number instead of memory address in error logs
 		var blockNumber uint64
 		if endpoint.checkBlockNumber.parsedBlockNumberResponse != nil {
 			blockNumber = *endpoint.checkBlockNumber.parsedBlockNumberResponse

--- a/qos/evm/endpoint_selection.go
+++ b/qos/evm/endpoint_selection.go
@@ -105,29 +105,25 @@ func (ss *serviceState) basicEndpointValidation(endpoint endpoint) error {
 
 	// Ensure the endpoint's block number is not more than the sync allowance behind the perceived block number.
 	if err := ss.isBlockNumberValid(endpoint.checkBlockNumber); err != nil {
-		// Dereference pointer to show actual block number instead of memory address in error logs
-		var blockNumber uint64
-		if endpoint.checkBlockNumber.parsedBlockNumberResponse != nil {
-			blockNumber = *endpoint.checkBlockNumber.parsedBlockNumberResponse
-		}
-		return fmt.Errorf("block number validation for %d failed: %w", blockNumber, err)
+		return fmt.Errorf("block number validation failed: %w", err)
 	}
 
 	// Ensure the endpoint's EVM chain ID matches the expected chain ID.
 	if err := ss.isChainIDValid(endpoint.checkChainID); err != nil {
-		return fmt.Errorf("validation for chain ID failed: %w", err)
+		return fmt.Errorf("chain ID validation failed: %w", err)
 	}
 
 	// Ensure the endpoint has returned an archival balance for the perceived block number.
 	if err := ss.archivalState.isArchivalBalanceValid(endpoint.checkArchival); err != nil {
-		return fmt.Errorf("archival balance validation for %s failed: %w", endpoint.checkArchival.observedArchivalBalance, err)
+		return fmt.Errorf("archival balance validation failed: %w", err)
 	}
 
 	return nil
 }
 
-// isValid returns an error if the endpoint's block height is less
-// than the perceived block height minus the sync allowance.
+// isBlockNumberValid returns an error if:
+//   - The endpoint has not had an observation of its response to a `eth_blockNumber` request.
+//   - The endpoint's block height is less than the perceived block height minus the sync allowance.
 func (ss *serviceState) isBlockNumberValid(check endpointCheckBlockNumber) error {
 	if ss.perceivedBlockNumber == 0 {
 		return errNoBlockNumberObs
@@ -137,25 +133,36 @@ func (ss *serviceState) isBlockNumberValid(check endpointCheckBlockNumber) error
 		return errNoBlockNumberObs
 	}
 
+	// Dereference pointer to show actual block number instead of memory address in error logs
+	parsedBlockNumber := *check.parsedBlockNumberResponse
+
 	// If the endpoint's block height is less than the perceived block height minus the sync allowance,
 	// then the endpoint is behind the chain and should be filtered out.
-	minAllowedBlockNumber := ss.perceivedBlockNumber - ss.serviceConfig.getSyncAllowance()
-
-	if *check.parsedBlockNumberResponse < minAllowedBlockNumber {
-		return errInvalidBlockNumberObs
+	syncAllowance := ss.serviceConfig.getSyncAllowance()
+	minAllowedBlockNumber := ss.perceivedBlockNumber - syncAllowance
+	if parsedBlockNumber < minAllowedBlockNumber {
+		return fmt.Errorf("%w: block number %d is outside the sync allowance relative to min allowed block number %d and sync allowance %d",
+			errOutsideSyncAllowanceBlockNumberObs, parsedBlockNumber, minAllowedBlockNumber, syncAllowance)
 	}
 
 	return nil
 }
 
-// isChainIDValid returns an error if the endpoint's chain ID does not
-// match the expected chain ID in the service state.
+// isChainIDValid returns an error if:
+//   - The endpoint has not had an observation of its response to a `eth_chainId` request.
+//   - The endpoint's chain ID does not match the expected chain ID in the service state.
 func (ss *serviceState) isChainIDValid(check endpointCheckChainID) error {
 	if check.chainID == nil {
 		return errNoChainIDObs
 	}
-	if *check.chainID != ss.serviceConfig.getEVMChainID() {
-		return errInvalidChainIDObs
+
+	// Dereference pointer to show actual chain ID instead of memory address in error logs
+	chainID := *check.chainID
+
+	expectedChainID := ss.serviceConfig.getEVMChainID()
+	if chainID != expectedChainID {
+		return fmt.Errorf("%w: chain ID %s does not match expected chain ID %s",
+			errInvalidChainIDObs, chainID, expectedChainID)
 	}
 	return nil
 }

--- a/qos/evm/endpoint_selection.go
+++ b/qos/evm/endpoint_selection.go
@@ -105,7 +105,11 @@ func (ss *serviceState) basicEndpointValidation(endpoint endpoint) error {
 
 	// Ensure the endpoint's block number is not more than the sync allowance behind the perceived block number.
 	if err := ss.isBlockNumberValid(endpoint.checkBlockNumber); err != nil {
-		return fmt.Errorf("block number validation for %d failed: %w", endpoint.checkBlockNumber.parsedBlockNumberResponse, err)
+		var blockNumber uint64
+		if endpoint.checkBlockNumber.parsedBlockNumberResponse != nil {
+			blockNumber = *endpoint.checkBlockNumber.parsedBlockNumberResponse
+		}
+		return fmt.Errorf("block number validation for %d failed: %w", blockNumber, err)
 	}
 
 	// Ensure the endpoint's EVM chain ID matches the expected chain ID.

--- a/qos/evm/endpoint_selection.go
+++ b/qos/evm/endpoint_selection.go
@@ -105,6 +105,7 @@ func (ss *serviceState) basicEndpointValidation(endpoint endpoint) error {
 
 	// Ensure the endpoint's block number is not more than the sync allowance behind the perceived block number.
 	if err := ss.isBlockNumberValid(endpoint.checkBlockNumber); err != nil {
+		// Fix: Dereference pointer to show actual block number instead of memory address in error logs
 		var blockNumber uint64
 		if endpoint.checkBlockNumber.parsedBlockNumberResponse != nil {
 			blockNumber = *endpoint.checkBlockNumber.parsedBlockNumberResponse

--- a/qos/evm/service_state.go
+++ b/qos/evm/service_state.go
@@ -139,7 +139,11 @@ func (ss *serviceState) updateFromEndpoints(updatedEndpoints map[protocol.Endpoi
 
 		// Do not update the perceived block number if the chain ID is invalid.
 		if err := ss.isChainIDValid(endpoint.checkChainID); err != nil {
-			logger.Error().Err(err).Msgf("❌ Skipping endpoint '%s' with invalid chain id '%s'", endpointAddr, endpoint.checkChainID.chainID)
+			chainIDStr := "<nil>"
+			if endpoint.checkChainID.chainID != nil {
+				chainIDStr = *endpoint.checkChainID.chainID
+			}
+			logger.Error().Err(err).Msgf("❌ Skipping endpoint '%s' with invalid chain id '%s'", endpointAddr, chainIDStr)
 			continue
 		}
 

--- a/qos/evm/service_state.go
+++ b/qos/evm/service_state.go
@@ -139,7 +139,7 @@ func (ss *serviceState) updateFromEndpoints(updatedEndpoints map[protocol.Endpoi
 
 		// Do not update the perceived block number if the chain ID is invalid.
 		if err := ss.isChainIDValid(endpoint.checkChainID); err != nil {
-			// Fix: Dereference pointer to show actual chain ID instead of memory address in error logs
+			// Dereference pointer to show actual chain ID instead of memory address in error logs
 			chainIDStr := "<nil>"
 			if endpoint.checkChainID.chainID != nil {
 				chainIDStr = *endpoint.checkChainID.chainID
@@ -155,8 +155,8 @@ func (ss *serviceState) updateFromEndpoints(updatedEndpoints map[protocol.Endpoi
 			continue
 		}
 
-		// Fix: Update perceived block number to maximum instead of overwriting with last endpoint.
-		// Per documentation, perceivedBlockNumber should be "the maximum of block height reported by any endpoint"
+		// Update perceived block number to maximum instead of overwriting with last endpoint.
+		// Per struct field documentation (lines 34-37), perceivedBlockNumber should be "the maximum of block height reported by any endpoint"
 		// but code was incorrectly overwriting with each endpoint, causing validation failures.
 		if blockNumber > ss.perceivedBlockNumber {
 			ss.perceivedBlockNumber = blockNumber

--- a/qos/evm/service_state.go
+++ b/qos/evm/service_state.go
@@ -156,7 +156,7 @@ func (ss *serviceState) updateFromEndpoints(updatedEndpoints map[protocol.Endpoi
 		}
 
 		// Update perceived block number to maximum instead of overwriting with last endpoint.
-		// Per struct field documentation (lines 34-37), perceivedBlockNumber should be "the maximum of block height reported by any endpoint"
+		// Per perceivedBlockNumber field documentation, it should be "the maximum of block height reported by any endpoint"
 		// but code was incorrectly overwriting with each endpoint, causing validation failures.
 		if blockNumber > ss.perceivedBlockNumber {
 			ss.perceivedBlockNumber = blockNumber

--- a/qos/evm/service_state.go
+++ b/qos/evm/service_state.go
@@ -125,8 +125,9 @@ func (ss *serviceState) ApplyObservations(observations *qosobservations.Observat
 	return ss.updateFromEndpoints(updatedEndpoints)
 }
 
-// updateFromEndpoints updates the service state using estimation(s) derived from the set of updated
-// endpoints. This only includes the set of endpoints for which an observation was received.
+// updateFromEndpoints updates the service state based on new observations from endpoints.
+// - Only endpoints with received observations are considered.
+// - Estimations are derived from these updated endpoints.
 func (ss *serviceState) updateFromEndpoints(updatedEndpoints map[protocol.EndpointAddr]endpoint) error {
 	ss.serviceStateLock.Lock()
 	defer ss.serviceStateLock.Unlock()
@@ -139,12 +140,7 @@ func (ss *serviceState) updateFromEndpoints(updatedEndpoints map[protocol.Endpoi
 
 		// Do not update the perceived block number if the chain ID is invalid.
 		if err := ss.isChainIDValid(endpoint.checkChainID); err != nil {
-			// Dereference pointer to show actual chain ID instead of memory address in error logs
-			chainIDStr := "<nil>"
-			if endpoint.checkChainID.chainID != nil {
-				chainIDStr = *endpoint.checkChainID.chainID
-			}
-			logger.Error().Err(err).Msgf("❌ Skipping endpoint '%s' with invalid chain id '%s'", endpointAddr, chainIDStr)
+			logger.Error().Err(err).Msgf("❌ Skipping endpoint '%s' with invalid chain id", endpointAddr)
 			continue
 		}
 
@@ -159,6 +155,7 @@ func (ss *serviceState) updateFromEndpoints(updatedEndpoints map[protocol.Endpoi
 		// Per perceivedBlockNumber field documentation, it should be "the maximum of block height reported by any endpoint"
 		// but code was incorrectly overwriting with each endpoint, causing validation failures.
 		if blockNumber > ss.perceivedBlockNumber {
+			logger.Debug().Msgf("Updating perceived block number from %d to %d", ss.perceivedBlockNumber, blockNumber)
 			ss.perceivedBlockNumber = blockNumber
 		}
 	}

--- a/qos/evm/service_state.go
+++ b/qos/evm/service_state.go
@@ -154,8 +154,10 @@ func (ss *serviceState) updateFromEndpoints(updatedEndpoints map[protocol.Endpoi
 			continue
 		}
 
-		// Update the perceived block number.
-		ss.perceivedBlockNumber = blockNumber
+		// Update the perceived block number to the maximum of current and observed block numbers.
+		if blockNumber > ss.perceivedBlockNumber {
+			ss.perceivedBlockNumber = blockNumber
+		}
 	}
 
 	// If archival checks are enabled for the service, update the archival state.

--- a/qos/evm/service_state.go
+++ b/qos/evm/service_state.go
@@ -139,6 +139,7 @@ func (ss *serviceState) updateFromEndpoints(updatedEndpoints map[protocol.Endpoi
 
 		// Do not update the perceived block number if the chain ID is invalid.
 		if err := ss.isChainIDValid(endpoint.checkChainID); err != nil {
+			// Fix: Dereference pointer to show actual chain ID instead of memory address in error logs
 			chainIDStr := "<nil>"
 			if endpoint.checkChainID.chainID != nil {
 				chainIDStr = *endpoint.checkChainID.chainID
@@ -154,7 +155,9 @@ func (ss *serviceState) updateFromEndpoints(updatedEndpoints map[protocol.Endpoi
 			continue
 		}
 
-		// Update the perceived block number to the maximum of current and observed block numbers.
+		// Fix: Update perceived block number to maximum instead of overwriting with last endpoint.
+		// Per documentation, perceivedBlockNumber should be "the maximum of block height reported by any endpoint"
+		// but code was incorrectly overwriting with each endpoint, causing validation failures.
 		if blockNumber > ss.perceivedBlockNumber {
 			ss.perceivedBlockNumber = blockNumber
 		}


### PR DESCRIPTION
## Summary

Fix EVM QoS validation failures caused by incorrect perceived block number calculation and pointer dereferencing in error messages

### Primary Changes:

- Fix perceived block number calculation to use maximum across endpoints instead of overwriting with last endpoint
- Fix pointer dereferencing in block number and chain ID error messages to show actual values instead of memory addresses

### Secondary Changes:

- Add explanatory comments for validation logic fixes with references to field documentation
- Improve error message clarity for debugging QoS validation issues

## Type of change

Select one or more from the following:

- [x] Bug fix
- [x] Code health or cleanup

## QoS Checklist

### E2E Validation & Tests

- [ ] `make path_up`
- [ ] `make test_e2e_evm_shannon`
- [ ] `make test_e2e_evm_morse`

### Observability

- [ ] 1. `make path_up`
- [ ] 2. Run one of the following:
  - For `Shannon` with `anvil`: `make test_request__shannon_relay_util_100`
  - For `Morse` with `F00C`: `make test_request__morse_relay_util_100`
- [ ] 3. Visit [PATH Relay Grafana Dashboard](http://localhost:3003/d/relays/path-service-requests) to view results

## Sanity Checklist

- [ ] I have updated the GitHub Issue `assignees`, `reviewers`, `labels`, `project`, `iteration` and `milestone`
- [ ] For docs, I have run `make docusaurus_start`
- [ ] For code, I have run `make test_all`
- [ ] For configurations, I have updated the documentation
- [ ] I added `TODO`s where applicable