### PR TITLE
[QoS][EVM] Fix: QoS handles malformed endpoint responses for all requests

### DIFF
--- a/e2e/config_test.go
+++ b/e2e/config_test.go
@@ -132,10 +132,10 @@ func loadE2ELoadTestConfig() (*Config, error) {
 	var cfgPath string
 	// Prefer custom config if present, otherwise fall back to default
 	if _, err := os.Stat(customConfigFile); err == nil {
-		fmt.Printf("💽 Using CUSTOM config file: e2e/%s\n\n", customConfigFile)
+		fmt.Printf("💽 Using CUSTOM config file: %se2e/%s%s\n\n", CYAN, customConfigFile, RESET)
 		cfgPath = customConfigFile
 	} else {
-		fmt.Printf("💾 Using DEFAULT config file: e2e/%s\n\n", defaultConfigFile)
+		fmt.Printf("💾 Using DEFAULT config file: %se2e/%s%s\n\n", CYAN, defaultConfigFile, RESET)
 		cfgPath = defaultConfigFile
 	}
 

--- a/local/kind-config.yaml
+++ b/local/kind-config.yaml
@@ -16,9 +16,75 @@ nodes:
     - containerPort: 80
       hostPort: 3000
       protocol: TCP
+    # Configure kubelet for complete log retention and debugging
+    # This ensures all container logs (especially PATH application logs) are preserved
+    # for debugging and analysis without loss of initial log entries or periodic rotation
+    kubeadmConfigPatches:
+    - |
+      kind: InitConfiguration
+      apiVersion: kubeadm.k8s.io/v1beta3
+      nodeRegistration:
+        kubeletExtraArgs:
+          container-log-max-size: "1Gi"
+          container-log-max-files: "10"
+    - |
+      kind: JoinConfiguration
+      apiVersion: kubeadm.k8s.io/v1beta3
+      nodeRegistration:
+        kubeletExtraArgs:
+          container-log-max-size: "1Gi"
+          container-log-max-files: "10"
+    - |
+      kind: KubeletConfiguration
+      apiVersion: kubelet.config.k8s.io/v1beta1
+      containerLogMaxSize: "1Gi"
+      containerLogMaxFiles: 10
+      # Optimize log rotation for debugging - reduces monitoring frequency and concurrency
+      # to prevent aggressive log cleanup that was causing missing initial log entries
+      containerLogMaxWorkers: 1
+      containerLogMonitorInterval: "30s"
+      # Additional kubelet settings for log retention
+      imageGCHighThresholdPercent: 85
+      imageGCLowThresholdPercent: 80
+      evictionHard:
+        memory.available: "100Mi"
+        nodefs.available: "1Gi"
+        imagefs.available: "1Gi"
+      evictionSoft:
+        memory.available: "200Mi"
+        nodefs.available: "2Gi"
+        imagefs.available: "2Gi"
+      evictionSoftGracePeriod:
+        memory.available: "30s"
+        nodefs.available: "1m"
+        imagefs.available: "1m"
+    # Mount host directory to preserve logs
+    extraMounts:
+    - hostPath: /tmp/kind-logs
+      containerPath: /var/log/containers-backup
+      # This gives us a backup location for logs on the host
+
 containerdConfigPatches:
   # Ensure kind can pull images from GitHub Container Registry
   - |
     [plugins."io.containerd.grpc.v1.cri".registry.mirrors]
       [plugins."io.containerd.grpc.v1.cri".registry.mirrors."ghcr.io"]
         endpoint = ["https://ghcr.io"]
+  # Configure containerd logging to prevent aggressive cleanup
+  - |
+    [plugins."io.containerd.grpc.v1.cri"]
+      # Disable containerd's built-in log rotation
+      disable_cgroup = false
+    [plugins."io.containerd.grpc.v1.cri".containerd]
+      [plugins."io.containerd.grpc.v1.cri".containerd.runtimes]
+        [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]
+          runtime_type = "io.containerd.runc.v2"
+          [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options]
+            SystemdCgroup = true
+    # Configure garbage collection to be less aggressive
+    [plugins."io.containerd.gc.v1.scheduler"]
+      pause_threshold = 0.02
+      deletion_threshold = 0
+      mutation_threshold = 100
+      schedule_delay = "0s"
+      startup_delay = "100ms"

--- a/observation/qos/evm.pb.go
+++ b/observation/qos/evm.pb.go
@@ -852,8 +852,9 @@ func (x *EVMGetBalanceResponse) GetResponseValidationError() EVMResponseValidati
 	return EVMResponseValidationError_EVM_RESPONSE_VALIDATION_ERROR_UNSPECIFIED
 }
 
-// EVMUnrecognizedResponse handles requests with methods ignored by state update and endpoint validation
-// Example: As of PR #72, `eth_call` requests are not used for endpoint validation
+// EVMUnrecognizedResponse handles requests with unrecognized/unvalidated response methods for QoS endpoint selection.
+// - Example: eth_call response contents used for endpoint validation (as of PR #72)
+// - Sanctions still apply to endpoints returning invalid responses (e.g. unparseable JSONRPC)
 type EVMUnrecognizedResponse struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// The HTTP status code received from the endpoint

--- a/observation/qos/evm.pb.go
+++ b/observation/qos/evm.pb.go
@@ -13,12 +13,14 @@
 package qos
 
 import (
-	_ "github.com/buildwithgrove/path/observation/metadata"
-	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
-	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	reflect "reflect"
 	sync "sync"
 	unsafe "unsafe"
+
+	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
+	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
+
+	_ "github.com/buildwithgrove/path/observation/metadata"
 )
 
 const (

--- a/proto/path/qos/evm.proto
+++ b/proto/path/qos/evm.proto
@@ -235,8 +235,9 @@ message EVMGetBalanceResponse {
   optional EVMResponseValidationError response_validation_error = 5 [(metadata.semantic_meaning) = "Validity failure type"];
 }
 
-// EVMUnrecognizedResponse handles requests with methods ignored by state update and endpoint validation
-// Example: As of PR #72, `eth_call` requests are not used for endpoint validation
+// EVMUnrecognizedResponse handles requests with unrecognized/unvalidated response methods for QoS endpoint selection.
+// - Example: eth_call response contents used for endpoint validation (as of PR #72)
+// - Sanctions still apply to endpoints returning invalid responses (e.g. unparseable JSONRPC) 
 message EVMUnrecognizedResponse {
   // The HTTP status code received from the endpoint
   int32 http_status_code = 1;

--- a/proto/path/qos/evm.proto
+++ b/proto/path/qos/evm.proto
@@ -237,7 +237,7 @@ message EVMGetBalanceResponse {
 
 // EVMUnrecognizedResponse handles requests with unrecognized/unvalidated response methods for QoS endpoint selection.
 // - Example: eth_call response contents used for endpoint validation (as of PR #72)
-// - Sanctions still apply to endpoints returning invalid responses (e.g. unparseable JSONRPC) 
+// - Sanctions still apply to endpoints returning invalid responses (e.g. unparsable JSONRPC)
 message EVMUnrecognizedResponse {
   // The HTTP status code received from the endpoint
   int32 http_status_code = 1;

--- a/qos/evm/endpoint.go
+++ b/qos/evm/endpoint.go
@@ -3,14 +3,18 @@ package evm
 import "time"
 
 // endpoint captures the details required to validate an EVM endpoint.
+//
 // It contains all checks that should be run for the endpoint to validate
 // it is providing a valid response to service requests.
+//
 // TODO_IMPROVE: Rename to 'endpointValidation'
 type endpoint struct {
-	hasReturnedEmptyResponse    bool
-	hasReturnedInvalidResponse  bool
+	hasReturnedEmptyResponse   bool
+	hasReturnedInvalidResponse bool
+
 	invalidResponseLastObserved *time.Time
-	checkBlockNumber            endpointCheckBlockNumber
-	checkChainID                endpointCheckChainID
-	checkArchival               endpointCheckArchival
+
+	checkBlockNumber endpointCheckBlockNumber
+	checkChainID     endpointCheckChainID
+	checkArchival    endpointCheckArchival
 }

--- a/qos/evm/endpoint.go
+++ b/qos/evm/endpoint.go
@@ -1,12 +1,16 @@
 package evm
 
+import "time"
+
 // endpoint captures the details required to validate an EVM endpoint.
 // It contains all checks that should be run for the endpoint to validate
 // it is providing a valid response to service requests.
 // TODO_IMPROVE: Rename to 'endpointValidation'
 type endpoint struct {
-	hasReturnedEmptyResponse bool
-	checkBlockNumber         endpointCheckBlockNumber
-	checkChainID             endpointCheckChainID
-	checkArchival            endpointCheckArchival
+	hasReturnedEmptyResponse    bool
+	hasReturnedInvalidResponse  bool
+	invalidResponseLastObserved *time.Time
+	checkBlockNumber            endpointCheckBlockNumber
+	checkChainID                endpointCheckChainID
+	checkArchival               endpointCheckArchival
 }

--- a/qos/evm/endpoint_selection.go
+++ b/qos/evm/endpoint_selection.go
@@ -9,10 +9,14 @@ import (
 	"github.com/buildwithgrove/path/protocol"
 )
 
-var errEmptyResponseObs = errors.New("endpoint is invalid: history of empty responses")
-var errRecentInvalidResponseObs = errors.New("endpoint is invalid: recent invalid response")
+var (
+	errEmptyResponseObs         = errors.New("endpoint is invalid: history of empty responses")
+	errRecentInvalidResponseObs = errors.New("endpoint is invalid: recent invalid response")
+	errEmptyEndpointListObs     = errors.New("received empty list of endpoints to select from")
+)
 
 // TODO_UPNEXT(@adshmh): make the invalid response timeout duration configurable
+// It is set to 30 minutes because that is the session time as of #321.
 const invalidResponseTimeout = 30 * time.Minute
 
 /* -------------------- QoS Valid Endpoint Selector -------------------- */
@@ -61,7 +65,7 @@ func (ss *serviceState) filterValidEndpoints(availableEndpoints protocol.Endpoin
 	logger := ss.logger.With("method", "filterValidEndpoints").With("qos_instance", "evm")
 
 	if len(availableEndpoints) == 0 {
-		return nil, errors.New("received empty list of endpoints to select from")
+		return nil, errEmptyEndpointListObs
 	}
 
 	logger.Info().Msgf("About to filter through %d available endpoints", len(availableEndpoints))
@@ -104,12 +108,12 @@ func (ss *serviceState) basicEndpointValidation(endpoint endpoint) error {
 	ss.serviceStateLock.RLock()
 	defer ss.serviceStateLock.RUnlock()
 
-	// Ensure the endpoint has not returned an empty response.
+	// Check if the endpoint has returned an empty response.
 	if endpoint.hasReturnedEmptyResponse {
 		return fmt.Errorf("empty response validation failed: %w", errEmptyResponseObs)
 	}
 
-	// Ensure the endpoint has not returned an invalid response within the timeout period.
+	// Check if the endpoint has returned an invalid response within the invalid response timeout period.
 	if endpoint.hasReturnedInvalidResponse && endpoint.invalidResponseLastObserved != nil {
 		timeSinceInvalidResponse := time.Since(*endpoint.invalidResponseLastObserved)
 		if timeSinceInvalidResponse < invalidResponseTimeout {
@@ -118,17 +122,17 @@ func (ss *serviceState) basicEndpointValidation(endpoint endpoint) error {
 		}
 	}
 
-	// Ensure the endpoint's block number is not more than the sync allowance behind the perceived block number.
+	// Check if the endpoint's block number is not more than the sync allowance behind the perceived block number.
 	if err := ss.isBlockNumberValid(endpoint.checkBlockNumber); err != nil {
 		return fmt.Errorf("block number validation for %d failed: %w", endpoint.checkBlockNumber.parsedBlockNumberResponse, err)
 	}
 
-	// Ensure the endpoint's EVM chain ID matches the expected chain ID.
+	// Check if the endpoint's EVM chain ID matches the expected chain ID.
 	if err := ss.isChainIDValid(endpoint.checkChainID); err != nil {
 		return fmt.Errorf("validation for chain ID failed: %w", err)
 	}
 
-	// Ensure the endpoint has returned an archival balance for the perceived block number.
+	// Check if the endpoint has returned an archival balance for the perceived block number.
 	if err := ss.archivalState.isArchivalBalanceValid(endpoint.checkArchival); err != nil {
 		return fmt.Errorf("archival balance validation for %s failed: %w", endpoint.checkArchival.observedArchivalBalance, err)
 	}

--- a/qos/evm/endpoint_store.go
+++ b/qos/evm/endpoint_store.go
@@ -125,12 +125,21 @@ func applyObservation(
 		}
 	}
 
+	// If unrecognizedResponse is not nil, the observation is for an unrecognized response.
+	if unrecognizedResponse := observation.GetUnrecognizedResponse(); unrecognizedResponse != nil {
+		applyUnrecognizedResponseObservation(endpoint, unrecognizedResponse)
+		endpointWasMutated = true
+		return
+	}
+
 	return endpointWasMutated // endpoint was not mutated by the observation
 }
 
 // applyEmptyResponseObservation updates the empty response check if a valid observation is provided.
 func applyEmptyResponseObservation(endpoint *endpoint) {
 	endpoint.hasReturnedEmptyResponse = true
+	now := time.Now()
+	endpoint.invalidResponseLastObserved = &now
 }
 
 // applyBlockNumberObservation updates the block number check if a valid observation is provided.
@@ -168,5 +177,16 @@ func applyArchivalObservation(endpoint *endpoint, archivalResponse *qosobservati
 	endpoint.checkArchival = endpointCheckArchival{
 		observedArchivalBalance: archivalResponse.GetBalance(),
 		expiresAt:               time.Now().Add(checkArchivalInterval),
+	}
+}
+
+// applyUnrecognizedResponseObservation updates the invalid response check if a validation error is present.
+func applyUnrecognizedResponseObservation(endpoint *endpoint, unrecognizedResponse *qosobservations.EVMUnrecognizedResponse) {
+	// Check if the unrecognized response has a validation error set to something other than UNSPECIFIED
+	validationError := unrecognizedResponse.GetResponseValidationError()
+	if validationError != qosobservations.EVMResponseValidationError_EVM_RESPONSE_VALIDATION_ERROR_UNSPECIFIED {
+		endpoint.hasReturnedInvalidResponse = true
+		now := time.Now()
+		endpoint.invalidResponseLastObserved = &now
 	}
 }

--- a/qos/evm/response_generic.go
+++ b/qos/evm/response_generic.go
@@ -10,8 +10,9 @@ import (
 )
 
 const (
-	// errCodeUnmarshaling is set as the JSONRPC response's error code if the endpoint returns a malformed response
-	errCodeUnmarshaling = -32600
+	// errCodeUnmarshaling is set as the JSONRPC response's error code if the endpoint returns a malformed response.
+	// -32000 Error code will result in returning a 500 HTTP Status Code to the client.
+	errCodeUnmarshaling = -32000
 
 	// errMsgUnmarshaling is the generic message returned to the user if the endpoint returns a malformed response.
 	errMsgUnmarshaling = "the response returned by the endpoint is not a valid JSONRPC response"
@@ -45,8 +46,9 @@ type responseGeneric struct {
 	validationError *qosobservations.EVMResponseValidationError
 }
 
-// GetObservation returns an observation that is NOT used in validating endpoints.
-// This allows sharing data with other entities, e.g. a data pipeline.
+// GetObservation returns an observation that is used in validating endpoints.
+// This generates observations for unrecognized responses that can trigger endpoint
+// disqualification when validation errors are present.
 // Implements the response interface.
 func (r responseGeneric) GetObservation() qosobservations.EVMEndpointObservation {
 	return qosobservations.EVMEndpointObservation{
@@ -89,23 +91,22 @@ func (r responseGeneric) getHTTPStatusCode() int {
 	return r.jsonRPCResponse.GetRecommendedHTTPStatusCode()
 }
 
-// responseUnmarshallerGeneric processes raw response data into a responseGeneric struct.
-// It extracts and stores any data needed for generating a response payload.
-func responseUnmarshallerGeneric(logger polylog.Logger, jsonrpcReq jsonrpc.Request, data []byte) (response, error) {
-	var response jsonrpc.Response
-	err := json.Unmarshal(data, &response)
-	if err != nil {
-		errResponse := getGenericJSONRPCErrResponse(logger, jsonrpcReq.ID, data, err)
-		validationError := qosobservations.EVMResponseValidationError_EVM_RESPONSE_VALIDATION_ERROR_UNMARSHAL
-		errResponse.validationError = &validationError
-		return errResponse, err
-	}
+// responseUnmarshallerGenericFromResponse processes an already unmarshaled JSON-RPC response
+// into a responseGeneric struct. This avoids double unmarshaling when the response has
+// already been parsed.
+func responseUnmarshallerGenericFromResponse(logger polylog.Logger, jsonrpcReq jsonrpc.Request, jsonrpcResponse jsonrpc.Response) (response, error) {
+	httpStatus := jsonrpcResponse.GetRecommendedHTTPStatusCode()
+	logger.With(
+		"jsonrpc_response", jsonrpcResponse,
+		"jsonrpc_request", jsonrpcReq,
+		"http_status", httpStatus,
+	).Debug().Msg("Processing EVM generic response")
 
 	// Response successfully parsed into JSONRPC format.
 	return responseGeneric{
 		logger:          logger,
-		jsonRPCResponse: response,
-		validationError: nil, // Intentionally set to nil to indicate a valid JSONRPC error response.
+		jsonRPCResponse: jsonrpcResponse,
+		validationError: nil, // Intentionally set to nil to indicate a valid JSONRPC response.
 	}, nil
 }
 
@@ -113,14 +114,17 @@ func responseUnmarshallerGeneric(logger polylog.Logger, jsonrpcReq jsonrpc.Reque
 // - JSON-RPC error with supplied ID
 // - Error details
 // - Invalid payload in the "data" field
+// Sets validation error to UNMARSHAL to trigger endpoint disqualification.
 func getGenericJSONRPCErrResponse(_ polylog.Logger, id jsonrpc.ID, malformedResponsePayload []byte, err error) responseGeneric {
 	errData := map[string]string{
 		errDataFieldRawBytes:        string(malformedResponsePayload),
 		errDataFieldUnmarshalingErr: err.Error(),
 	}
 
+	validationError := qosobservations.EVMResponseValidationError_EVM_RESPONSE_VALIDATION_ERROR_UNMARSHAL
 	return responseGeneric{
 		jsonRPCResponse: jsonrpc.GetErrorResponse(id, errCodeUnmarshaling, errMsgUnmarshaling, errData),
+		validationError: &validationError, // Set validation error to trigger endpoint disqualification
 	}
 }
 

--- a/qos/evm/response_generic.go
+++ b/qos/evm/response_generic.go
@@ -91,9 +91,8 @@ func (r responseGeneric) getHTTPStatusCode() int {
 	return r.jsonRPCResponse.GetRecommendedHTTPStatusCode()
 }
 
-// responseUnmarshallerGenericFromResponse processes an already unmarshaled JSON-RPC response
-// into a responseGeneric struct. This avoids double unmarshaling when the response has
-// already been parsed.
+// responseUnmarshallerGenericFromResponse processes an already unmarshaled JSON-RPC response into a responseGeneric struct.
+// This avoids double unmarshaling when the response has already been parsed.
 func responseUnmarshallerGenericFromResponse(logger polylog.Logger, jsonrpcReq jsonrpc.Request, jsonrpcResponse jsonrpc.Response) (response, error) {
 	httpStatus := jsonrpcResponse.GetRecommendedHTTPStatusCode()
 	logger.With(

--- a/qos/evm/service_state.go
+++ b/qos/evm/service_state.go
@@ -14,6 +14,11 @@ import (
 	"github.com/buildwithgrove/path/qos/jsonrpc"
 )
 
+var (
+	errNilApplyObservations    = errors.New("ApplyObservations: received nil")
+	errNilApplyEVMObservations = errors.New("ApplyObservations: received nil EVM observation")
+)
+
 // The serviceState struct maintains the expected current state of the EVM blockchain
 // based on the endpoints' responses to different requests.
 //
@@ -109,12 +114,12 @@ func (ss *serviceState) shouldChainIDCheckRun(check endpointCheckChainID) bool {
 // ApplyObservations updates endpoint storage and blockchain state from observations.
 func (ss *serviceState) ApplyObservations(observations *qosobservations.Observations) error {
 	if observations == nil {
-		return errors.New("ApplyObservations: received nil")
+		return errNilApplyObservations
 	}
 
 	evmObservations := observations.GetEvm()
 	if evmObservations == nil {
-		return errors.New("ApplyObservations: received nil EVM observation")
+		return errNilApplyEVMObservations
 	}
 
 	updatedEndpoints := ss.endpointStore.updateEndpointsFromObservations(

--- a/qos/solana/response_generic.go
+++ b/qos/solana/response_generic.go
@@ -10,6 +10,7 @@ import (
 )
 
 // TODO_UPNEXT(@adshmh): Update solana and cometbft QoS to detect and sanction malformed endpoint responses to any request.
+// See evm implementation in #321 for reference.
 
 const (
 	// errCodeUnmarshaling is set as the JSON-RPC response's error code if the endpoint returns a malformed response.

--- a/qos/solana/response_generic.go
+++ b/qos/solana/response_generic.go
@@ -9,6 +9,8 @@ import (
 	"github.com/buildwithgrove/path/qos/jsonrpc"
 )
 
+// TODO_UPNEXT(@adshmh): Update solana and cometbft QoS to detect and sanction malformed endpoint responses to any request.
+
 const (
 	// errCodeUnmarshaling is set as the JSON-RPC response's error code if the endpoint returns a malformed response.
 	errCodeUnmarshaling = -32600


### PR DESCRIPTION
## Summary

Enhanced QoS endpoint validation with invalid response tracking and improved Kind cluster logging configuration

### Primary Changes:

- Add invalid response tracking to endpoint validation with 30-minute timeout for endpoint disqualification
- Implement EVMUnrecognizedResponse observation handling to trigger sanctions on endpoints returning unparseable responses
- Update generic response handling to use already-parsed JSON-RPC responses and set proper validation errors

### Secondary Changes:

- Configure comprehensive log retention in Kind cluster with 1GB max size and 10 file rotation
- Add containerd garbage collection tuning to prevent aggressive log cleanup
- Update protobuf comments to clarify EVMUnrecognizedResponse usage for QoS endpoint selection

## Issue

- 400 HTTP HTTP Status codes returned in response  to valid requests if endpoint fails.
- Endpoints returning malformed responses are not sanctioned.

- Issue or PR: #{ISSUE_OR_PR_NUMBER}

## Type of change

Select one or more from the following:

- [x] New feature, functionality or library
- [x] Bug fix
- [ ] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## QoS Checklist

### E2E Validation & Tests

- [ ] `make path_up`
- [ ] `make test_e2e_evm_shannon`
- [ ] `make test_e2e_evm_morse`

### Observability

- [x] 1. `make path_up`
- [x] 2. Run one of the following:
  - For `Shannon` with `anvil`: `make test_request__shannon_relay_util_100`
  - For `Morse` with `F00C`: `make test_request__morse_relay_util_100`
- [ ] 3. Visit [PATH Relay Grafana Dashboard](http://localhost:3003/d/relays/path-service-requests) to view results

## Sanity Checklist

- [x] I have updated the GitHub Issue `assignees`, `reviewers`, `labels`, `project`, `iteration` and `milestone`
- [ ] For docs, I have run `make docusaurus_start`
- [ ] For code, I have run `make test_all`
- [ ] For configurations, I have updated the documentation
- [x] I added `TODO`s where applicable
