### PR TITLE
[QoS][CometBFT] Use CometBFT QoS for Pocket* services

### DIFF
--- a/config/service_qos_config.go
+++ b/config/service_qos_config.go
@@ -429,8 +429,21 @@ var shannonServices = []ServiceQoSConfig{
 	// Osmosis
 	cometbft.NewCometBFTServiceQoSConfig("osmosis", "osmosis"),
 
+	// *** Pocket Services ***
+
+	// Pocket Mainnet and Beta Testnet
+	cometbft.NewCometBFTServiceQoSConfig("pocket", "pocket"),
+
+	// Pocket Mainnet
+	cometbft.NewCometBFTServiceQoSConfig("pocket-alpha", "pocket-alpha"),
+	cometbft.NewCometBFTServiceQoSConfig("pocket-beta", "pocket-beta"),
+
 	// Pocket Beta Testnet
-	cometbft.NewCometBFTServiceQoSConfig("pocket-beta-rpc", "pocket-beta"),
+	cometbft.NewCometBFTServiceQoSConfig("pocket-beta1", "pocket-beta1"),
+	cometbft.NewCometBFTServiceQoSConfig("pocket-beta2", "pocket-beta2"),
+	cometbft.NewCometBFTServiceQoSConfig("pocket-beta3", "pocket-beta3"),
+	cometbft.NewCometBFTServiceQoSConfig("pocket-beta4", "pocket-beta4"),
+	cometbft.NewCometBFTServiceQoSConfig("pocket-beta5", "pocket-beta5"),
 
 	// Cosmos Hub
 	cometbft.NewCometBFTServiceQoSConfig("cometbft", "cosmoshub-4"),


### PR DESCRIPTION
## Summary

Use CometBFT as QoS for Pocket* services.

### Primary Changes:

- Map all Pocket services to CometBFT QoS.

## Issue

NoOp QoS was being used for Pocket services.

- Issue or PR: #{ISSUE_OR_PR_NUMBER}

## Type of change

Select one or more from the following:

- [ ] New feature, functionality or library
- [x] Bug fix
- [ ] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## QoS Checklist

### E2E Validation & Tests

- [x] `make path_up`
- [ ] `make test_e2e_evm_shannon`
- [ ] `make test_e2e_evm_morse`

### Observability

- [x] 1. `make path_up`
- [ ] 2. Run one of the following:
  - For `Shannon` with `anvil`: `make test_request__shannon_relay_util_100`
  - For `Morse` with `F00C`: `make test_request__morse_relay_util_100`
- [ ] 3. Visit [PATH Relay Grafana Dashboard](http://localhost:3003/d/relays/path-service-requests) to view results

## Sanity Checklist

- [x] I have updated the GitHub Issue `assignees`, `reviewers`, `labels`, `project`, `iteration` and `milestone`
- [ ] For docs, I have run `make docusaurus_start`
- [ ] For code, I have run `make test_all`
- [ ] For configurations, I have updated the documentation
- [ ] I added `TODO`s where applicable
