### PR TITLE
[QoS][CometBFT] CometBFT QoS returns HTTP status matching the JSONRPC response

### DIFF
--- a/protocol/shannon/sanctions.go
+++ b/protocol/shannon/sanctions.go
@@ -155,7 +155,10 @@ func classifyHttpError(logger polylog.Logger, err error) (protocolobservations.S
 	}
 
 	// If we can't classify the HTTP error, it's an internal error
-	logger.Warn().Msg("Unable to classify HTTP error - defaulting to internal error")
+	logger.With(
+		"err_preview", errStr[:min(100, len(errStr))],
+	).Warn().Msg("Unable to classify HTTP error - defaulting to internal error")
+
 	return protocolobservations.ShannonEndpointErrorType_SHANNON_ENDPOINT_ERROR_INTERNAL,
 		protocolobservations.ShannonSanctionType_SHANNON_SANCTION_SESSION
 }
@@ -232,6 +235,8 @@ func classifyMalformedEndpointPayload(logger polylog.Logger, payloadContent stri
 	}
 
 	// If we can't classify the malformed payload, it's an internal error
-	logger.Warn().Msg("Unable to classify malformed endpoint payload - defaulting to internal error")
+	logger.With(
+		"endpoint_payload_preview", payloadContents[:min(100, len(payloadContents))],
+	).Warn().Msg("Unable to classify malformed endpoint payload - defaulting to internal error")
 	return protocolobservations.ShannonEndpointErrorType_SHANNON_ENDPOINT_ERROR_INTERNAL, protocolobservations.ShannonSanctionType_SHANNON_SANCTION_SESSION
 }

--- a/qos/cometbft/context.go
+++ b/qos/cometbft/context.go
@@ -118,6 +118,7 @@ func (rc requestContext) GetHTTPResponse() gateway.HTTPResponse {
 	// Default to generic response if no endpoint responses exist
 	return httpResponse{
 		responsePayload: response.GetResponsePayload(),
+		responseStatus:  response.GetResponseStatusCode(),
 	}
 }
 

--- a/qos/cometbft/response.go
+++ b/qos/cometbft/response.go
@@ -65,11 +65,27 @@ func unmarshalResponse(
 	if err := json.Unmarshal(data, &jsonrpcResponse); err != nil {
 		// The response raw payload (e.g. as received from an endpoint) could not be unmarshalled as a JSONRC response.
 		// Return a generic response to the user.
+		payloadStr := string(data)
+		logger.With(
+			"request", jsonrpcReq,
+			"unmarshal_err", err,
+			"raw_payload", payloadStr[:min(100, len(payloadStr))],
+			"endpoint_addr", endpointAddr,
+		).Debug().Msg("Failed to unmarshal response payload as JSON-RPC")
+
+		// The response raw payload (e.g. as received from an endpoint) could not be unmarshalled as a JSONRC response.
+		// Return a generic response to the user.
 		return getGenericJSONRPCErrResponse(logger, jsonrpcResponse, data, err), err
 	}
 
 	// Validate the JSON-RPC response.
 	if err := jsonrpcResponse.Validate(getExpectedResponseID(jsonrpcResponse, isJSONRPC)); err != nil {
+		logger.With(
+			"request", jsonrpcReq,
+			"validation_err", err,
+			"endpoint_addr", endpointAddr,
+		).Debug().Msg("JSON-RPC response validation failed")
+
 		return getGenericJSONRPCErrResponse(logger, jsonrpcResponse, data, err), err
 	}
 

--- a/qos/cometbft/response_generic.go
+++ b/qos/cometbft/response_generic.go
@@ -64,15 +64,11 @@ func (r responseGeneric) GetResponsePayload() []byte {
 }
 
 // CometBFT response codes:
-// - 200: Success
-// - 500: Error
-// Reference: https://docs.cometbft.com/v0.38/rpc/
+// returns an HTTP status code corresponding to the underlying JSON-RPC response code.
+// DEV_NOTE: This is an opinionated mapping following best practice but not enforced by any specifications or standards.
 // Implements the response interface.
 func (r responseGeneric) GetResponseStatusCode() int {
-	if r.jsonRPCResponse.IsError() {
-		return http.StatusInternalServerError
-	}
-	return http.StatusOK
+	return r.jsonRPCResponse.GetRecommendedHTTPStatusCode()
 }
 
 // responseUnmarshallerGeneric processes raw response data into a responseGeneric struct.

--- a/qos/cometbft/response_health.go
+++ b/qos/cometbft/response_health.go
@@ -74,14 +74,9 @@ func (r responseToHealth) GetResponsePayload() []byte {
 	return bz
 }
 
-// CometBFT response codes:
-// - 200: Success
-// - 500: Error
-// Reference: https://docs.cometbft.com/v0.38/rpc/
+// returns an HTTP status code corresponding to the underlying JSON-RPC response code.
+// DEV_NOTE: This is an opinionated mapping following best practice but not enforced by any specifications or standards.
 // Implements the response interface.
 func (r responseToHealth) GetResponseStatusCode() int {
-	if r.jsonRPCResponse.IsError() {
-		return http.StatusInternalServerError
-	}
-	return http.StatusOK
+	return r.jsonRPCResponse.GetRecommendedHTTPStatusCode()
 }

--- a/qos/cometbft/response_status.go
+++ b/qos/cometbft/response_status.go
@@ -110,14 +110,9 @@ func (r responseToStatus) GetResponsePayload() []byte {
 	return bz
 }
 
-// CometBFT response codes:
-// - 200: Success
-// - 500: Error
-// Reference: https://docs.cometbft.com/v0.38/rpc/
+// returns an HTTP status code corresponding to the underlying JSON-RPC response code.
+// DEV_NOTE: This is an opinionated mapping following best practice but not enforced by any specifications or standards.
 // Implements the response interface.
 func (r responseToStatus) GetResponseStatusCode() int {
-	if r.jsonRPCResponse.IsError() {
-		return http.StatusInternalServerError
-	}
-	return http.StatusOK
+	return r.jsonRPCResponse.GetRecommendedHTTPStatusCode()
 }


### PR DESCRIPTION
## Summary

Enhance logging with payload previews and refactor HTTP status code handling for JSON-RPC responses

### Primary Changes:

- Add payload preview logging to error classification functions in sanctions.go with truncated error and endpoint payload content
- Refactor HTTP status code logic across CometBFT response handlers to use GetRecommendedHTTPStatusCode() method instead of hardcoded 200/500 mapping
- Add debug logging for JSON-RPC response unmarshalling and validation failures with request context and error details

### Secondary Changes:

- Fix missing responseStatus field assignment in context.go HTTP response construction
- Update code comments to reflect new opinionated HTTP status code mapping approach with developer notes

## Issue

Incorrect success rate calculations for CometBFT services.

- Issue or PR: #{ISSUE_OR_PR_NUMBER}

## Type of change

Select one or more from the following:

- [ ] New feature, functionality or library
- [x] Bug fix
- [ ] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## QoS Checklist

### E2E Validation & Tests

- [ ] `make path_up`
- [ ] `make test_e2e_evm_shannon`
- [ ] `make test_e2e_evm_morse`

### Observability

- [ ] 1. `make path_up`
- [ ] 2. Run one of the following:
  - For `Shannon` with `anvil`: `make test_request__shannon_relay_util_100`
  - For `Morse` with `F00C`: `make test_request__morse_relay_util_100`
- [ ] 3. Visit [PATH Relay Grafana Dashboard](http://localhost:3003/d/relays/path-service-requests) to view results

## Sanity Checklist

- [ ] I have updated the GitHub Issue `assignees`, `reviewers`, `labels`, `project`, `iteration` and `milestone`
- [ ] For docs, I have run `make docusaurus_start`
- [ ] For code, I have run `make test_all`
- [ ] For configurations, I have updated the documentation
- [ ] I added `TODO`s where applicable
