### PR TITLE
Set service_id on CometBFT log entries

### DIFF
--- a/qos/cometbft/qos.go
+++ b/qos/cometbft/qos.go
@@ -7,9 +7,11 @@ import (
 // NewQoSInstance builds and returns an instance of the CometBFT QoS service.
 func NewQoSInstance(logger polylog.Logger, config CometBFTServiceQoSConfig) *QoS {
 	cometBFTChainID := config.GetCometBFTChainID()
+	serviceId := config.GetServiceID()
 
 	logger = logger.With(
 		"qos_instance", "cometbft",
+		"service_id", serviceId,
 		"cometbft_chain_id", cometBFTChainID,
 	)
 


### PR DESCRIPTION
## Summary

Add service_id label to CometBFT QoS log entries.

## Issue

Missing service_id from CometBFT log entries.

- Issue or PR: #{ISSUE_OR_PR_NUMBER}

## Type of change

Select one or more from the following:

- [ ] New feature, functionality or library
- [ ] Bug fix
- [ ] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## QoS Checklist

### E2E Validation & Tests

- [ ] `make path_up`
- [ ] `make test_e2e_evm_shannon`
- [ ] `make test_e2e_evm_morse`

### Observability

- [ ] 1. `make path_up`
- [ ] 2. Run one of the following:
  - For `Shannon` with `anvil`: `make test_request__shannon_relay_util_100`
  - For `Morse` with `F00C`: `make test_request__morse_relay_util_100`
- [ ] 3. Visit [PATH Relay Grafana Dashboard](http://localhost:3003/d/relays/path-service-requests) to view results

## Sanity Checklist

- [ ] I have updated the GitHub Issue `assignees`, `reviewers`, `labels`, `project`, `iteration` and `milestone`
- [ ] For docs, I have run `make docusaurus_start`
- [ ] For code, I have run `make test_all`
- [ ] For configurations, I have updated the documentation
- [ ] I added `TODO`s where applicable
