### PR TITLE
[QoS] Include endpoint payload preview if response validation fails

### DIFF
--- a/log/preview.go
+++ b/log/preview.go
@@ -1,0 +1,16 @@
+package log
+
+// TODO_TECHDEBT(@adshmh): Refactor as follows:
+// 1. Make this value configurable.
+// 2. Consider moving this functionality to "github.com/pokt-network/poktroll/pkg/polylog"
+//
+// maxLoggedStrLen limits preview string length to prevent log spam.
+const maxLoggedStrLen = 100
+
+// Preview truncates str to maxLoggedStrLen for logging.
+// Returns:
+//   - Original string if len <= maxLoggedStrLen
+//   - Truncated string if len > maxLoggedStrLen
+func Preview(str string) string {
+	return str[:min(maxLoggedStrLen, len(str))]
+}

--- a/metrics/qos/qos.go
+++ b/metrics/qos/qos.go
@@ -4,6 +4,7 @@ package qos
 import (
 	"github.com/pokt-network/poktroll/pkg/polylog"
 
+	"github.com/buildwithgrove/path/metrics/qos/cometbft"
 	"github.com/buildwithgrove/path/metrics/qos/evm"
 	"github.com/buildwithgrove/path/metrics/qos/solana"
 	"github.com/buildwithgrove/path/observation/qos"
@@ -25,6 +26,13 @@ func PublishQoSMetrics(
 	if evmObservations := qosObservations.GetEvm(); evmObservations != nil {
 		evm.PublishMetrics(hydratedLogger, evmObservations)
 		hydratedLogger.Debug().Msg("published EVM metrics.")
+		return
+	}
+
+	// Publish CometBFT metrics.
+	if cometbftObservations := qosObservations.GetCometbft(); cometbftObservations != nil {
+		cometbft.PublishMetrics(hydratedLogger, cometbftObservations)
+		hydratedLogger.Debug().Msg("published CometBFT metrics.")
 		return
 	}
 

--- a/qos/cometbft/response.go
+++ b/qos/cometbft/response.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/pokt-network/poktroll/pkg/polylog"
 
+	"github.com/buildwithgrove/path/log"
 	"github.com/buildwithgrove/path/protocol"
 	"github.com/buildwithgrove/path/qos/jsonrpc"
 )
@@ -69,8 +70,9 @@ func unmarshalResponse(
 		// Return a generic response to the user.
 		payloadStr := string(data)
 		logger.With(
+			"api_path", apiPath,
 			"unmarshal_err", err,
-			"raw_payload", payloadStr[:min(100, len(payloadStr))],
+			"raw_payload", log.Preview(payloadStr),
 			"endpoint_addr", endpointAddr,
 		).Debug().Msg("Failed to unmarshal response payload as JSON-RPC")
 
@@ -81,8 +83,11 @@ func unmarshalResponse(
 
 	// Validate the JSON-RPC response.
 	if err := jsonrpcResponse.Validate(getExpectedResponseID(jsonrpcResponse, isJSONRPC)); err != nil {
+		payloadStr := string(data)
 		logger.With(
+			"api_path", apiPath,
 			"validation_err", err,
+			"raw_payload", log.Preview(payloadStr),
 			"endpoint_addr", endpointAddr,
 		).Debug().Msg("JSON-RPC response validation failed")
 

--- a/qos/evm/response.go
+++ b/qos/evm/response.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/pokt-network/poktroll/pkg/polylog"
 
+	"github.com/buildwithgrove/path/log"
 	"github.com/buildwithgrove/path/protocol"
 	"github.com/buildwithgrove/path/qos/jsonrpc"
 )
@@ -65,7 +66,7 @@ func unmarshalResponse(
 		logger.With(
 			"request", jsonrpcReq,
 			"unmarshal_err", err,
-			"raw_payload", payloadStr[:min(1000, len(payloadStr))],
+			"raw_payload", log.Preview(payloadStr),
 			"endpoint_addr", endpointAddr,
 		).Debug().Msg("Failed to unmarshal response payload as JSON-RPC")
 
@@ -74,9 +75,11 @@ func unmarshalResponse(
 
 	// Validate the JSONRPC response.
 	if err := jsonrpcResponse.Validate(jsonrpcReq.ID); err != nil {
+		payloadStr := string(data)
 		logger.With(
 			"request", jsonrpcReq,
 			"validation_err", err,
+			"raw_payload", log.Preview(payloadStr),
 			"endpoint_addr", endpointAddr,
 		).Debug().Msg("JSON-RPC response validation failed")
 		return getGenericJSONRPCErrResponse(logger, jsonrpcReq.ID, data, err), err

--- a/qos/solana/context.go
+++ b/qos/solana/context.go
@@ -106,7 +106,7 @@ func (rc *requestContext) UpdateWithResponse(endpointAddr protocol.EndpointAddr,
 	// This would be an extra safety measure, as the caller should have checked the returned value
 	// indicating the validity of the request when calling on QoS instance's ParseHTTPRequest
 
-	response := unmarshalResponse(rc.logger, rc.JSONRPCReq, responseBz)
+	response := unmarshalResponse(rc.logger, rc.JSONRPCReq, responseBz, endpointAddr)
 
 	// TODO_MVP(@adshmh): Drop the unmarshaling error: the returned response interface should provide methods to allow the caller to:
 	// 1. Check if the response from the endpoint was valid or malformed. This is needed to support retrying with a different endpoint if

--- a/qos/solana/response_generic.go
+++ b/qos/solana/response_generic.go
@@ -14,7 +14,8 @@ import (
 
 const (
 	// errCodeUnmarshaling is set as the JSON-RPC response's error code if the endpoint returns a malformed response.
-	errCodeUnmarshaling = -32600
+	// -32000 Error code will result in returning a 500 HTTP Status Code to the client.
+	errCodeUnmarshaling = -32000
 
 	// errMsgUnmarshaling is the generic message returned to the user if the endpoint returns a malformed response.
 	errMsgUnmarshaling = "the response returned by the endpoint is not a valid JSON-RPC response"


### PR DESCRIPTION
## Summary

Include endpoint payload in log entries if response validation fails

### Primary Changes:
- New log package to reuse logging functionality: string preview.
- EVM QoS: Include endpoint payload in log entries if response validation fails
- Solana QoS: Include endpoint payload in log entries if response validation fails
- CometBFT QoS: Include endpoint payload in log entries if response validation fails


## Issue

No details on the payload that failed JSONRPC response validation.

- Issue or PR: #{ISSUE_OR_PR_NUMBER}

## Type of change

Select one or more from the following:

- [x] New feature, functionality or library
- [ ] Bug fix
- [ ] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## QoS Checklist

### E2E Validation & Tests

- [ ] `make path_up`
- [ ] `make test_e2e_evm_shannon`
- [ ] `make test_e2e_evm_morse`

### Observability

- [ ] 1. `make path_up`
- [ ] 2. Run one of the following:
  - For `Shannon` with `anvil`: `make test_request__shannon_relay_util_100`
  - For `Morse` with `F00C`: `make test_request__morse_relay_util_100`
- [ ] 3. Visit [PATH Relay Grafana Dashboard](http://localhost:3003/d/relays/path-service-requests) to view results

## Sanity Checklist

- [ ] I have updated the GitHub Issue `assignees`, `reviewers`, `labels`, `project`, `iteration` and `milestone`
- [ ] For docs, I have run `make docusaurus_start`
- [ ] For code, I have run `make test_all`
- [ ] For configurations, I have updated the documentation
- [ ] I added `TODO`s where applicable
