### PR TITLE
[QoS] add xrplevm to service_qos_config.go

### DIFF
--- a/config/service_qos_config.go
+++ b/config/service_qos_config.go
@@ -53,7 +53,7 @@ var QoSServiceConfigs = qosServiceConfigs{
 }
 
 const (
-	defaultEVMChainID      = "0x1" // ETH Mainnet (1)
+	defaultEVMChainID       = "0x1" // ETH Mainnet (1)
 	defaultCosmosSDKChainID = "cosmoshub-4"
 )
 
@@ -452,6 +452,14 @@ var shannonServices = []ServiceQoSConfig{
 		sharedtypes.RPCType_COMET_BFT: {},
 	}),
 
+	// XRPL EVM
+	cosmos.NewCosmosSDKServiceQoSConfig("xrplevm", "xrplevm_1440000-1", map[sharedtypes.RPCType]struct{}{
+		sharedtypes.RPCType_JSON_RPC:  {}, // XRPLEVM supports the EVM API over JSON-RPC.
+		sharedtypes.RPCType_REST:      {}, // CosmosSDK
+		sharedtypes.RPCType_COMET_BFT: {},
+		sharedtypes.RPCType_WEBSOCKET: {}, // XRPLEVM supports the EVM API over JSON-RPC WebSockets.
+	}),
+
 	// XRPL EVM Testnet
 	cosmos.NewCosmosSDKServiceQoSConfig("xrplevm-testnet", "xrplevm_1449000-1", map[sharedtypes.RPCType]struct{}{
 		sharedtypes.RPCType_JSON_RPC:  {}, // XRPLEVM supports the EVM API over JSON-RPC.
@@ -459,9 +467,6 @@ var shannonServices = []ServiceQoSConfig{
 		sharedtypes.RPCType_COMET_BFT: {},
 		sharedtypes.RPCType_WEBSOCKET: {}, // XRPLEVM supports the EVM API over JSON-RPC WebSockets.
 	}),
-
-	// TODO_UPNEXT(@commoddity): XRPL EVM MainNet
-	// TODO_UPNEXT(@commoddity): XRPL EVM Devnet
 
 	// *** Solana Services ***
 

--- a/config/service_qos_config.go
+++ b/config/service_qos_config.go
@@ -453,6 +453,7 @@ var shannonServices = []ServiceQoSConfig{
 	}),
 
 	// XRPL EVM
+	// Reference: https://docs.xrplevm.org/pages/developers/developing-smart-contracts/deploy-the-smart-contract#1.-set-up-your-wallet
 	cosmos.NewCosmosSDKServiceQoSConfig("xrplevm", "xrplevm_1440000-1", map[sharedtypes.RPCType]struct{}{
 		sharedtypes.RPCType_JSON_RPC:  {}, // XRPLEVM supports the EVM API over JSON-RPC.
 		sharedtypes.RPCType_REST:      {}, // CosmosSDK


### PR DESCRIPTION
## 🌿 Summary

Add support for `xrplevm` chain to the service QoS configuration.

### 🌱 Primary Changes:
- Introduced `xrplevm` chain configuration in `service_qos_config.go`
- Added support for `xrplevm_1440000-1` network identifier
- Enabled multiple RPC types for `xrplevm`, including JSON-RPC, REST, COMET_BFT, and WebSocket

### 🍃 Secondary changes:
- Removed obsolete TODOs referencing upcoming `xrplevm` MainNet and Devnet support
- Minor formatting adjustment to variable alignment for consistency

## 🛠️ Type of change

Select one or more from the following:

- [x] New feature, functionality or library
- [ ] Bug fix
- [ ] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)
