### PR TITLE
[Cosmos][QoS] Add Cosmos SDK health check to qos/cosmos package

### DIFF
--- a/proto/path/qos/cosmos.proto
+++ b/proto/path/qos/cosmos.proto
@@ -58,33 +58,36 @@ message CosmosSDKEndpointObservation {
     // Details of the response received from the endpoint
     oneof response_observation {
         // Response to `/health` request
-        CosmosSDKHealthResponse health_response = 2;
+        CometBFTHealthResponse cometbft_health_response = 2;
 
         // Response to `/status` request
-        CosmosSDKStatusResponse status_response = 3;
+        CometBFTStatusResponse cometbft_status_response = 3;
+
+        // Response to `/cosmos/base/node/v1beta1/status` request
+        CosmosSDKStatusResponse cosmos_status_response = 4;
 
         // Responses not used in endpoint validation
-        CosmosSDKUnrecognizedResponse unrecognized_response = 4;
+        CosmosSDKUnrecognizedResponse unrecognized_response = 5;
 
         // CosmosSDKEmptyResponse indicates an endpoint returned no data.
         // Used to:
         //   - Disqualify endpoints that return empty responses
         //   - Track metrics for empty response patterns
-        CosmosSDKEmptyResponse empty_response = 5;
+        CosmosSDKEmptyResponse empty_response = 6;
     }
 
     // TODO_IMPROVE(@adshmh, @commoddity): Add other observations (archival, more endpoints, etc)
 }
 
-// CosmosSDKHealthResponse stores the response to a `health` request
+// CometBFTHealthResponse stores the response to a `health` request
 // Reference: https://docs.cometbft.com/v1.0/spec/rpc/#health
-message CosmosSDKHealthResponse {
+message CometBFTHealthResponse {
     bool health_status_response = 1;
 }
 
-// CosmosSDKStatusResponse stores the latest block number from a `/status` request
+// CometBFTStatusResponse stores the latest block number from a `/status` request
 // Reference: https://docs.cometbft.com/v1.0/spec/rpc/#status
-message CosmosSDKStatusResponse {
+message CometBFTStatusResponse {
     // Chain ID of the endpoint. Comes from the `NodeInfo.Network` field in the `/status` response.
     // Reference: https://docs.cometbft.com/v1.0/spec/rpc/#status
     string chain_id_response = 1;
@@ -98,6 +101,15 @@ message CosmosSDKStatusResponse {
     // Comes from the `SyncInfo.LatestBlockHeight` field in the `/status` response.
     // Reference: https://docs.cometbft.com/v1.0/spec/rpc/#status
     string latest_block_height_response = 3;
+}
+
+// CosmosSDKStatusResponse stores the latest block number from a `/cosmos/base/node/v1beta1/status` request
+// Reference: https://docs.cosmos.network/api#tag/Service/operation/Status
+message CosmosSDKStatusResponse {
+    // Latest block height of the endpoint.
+    // Comes from the `Height` field in the `/cosmos/base/node/v1beta1/status` response.
+    // Reference: https://docs.cosmos.network/api#tag/Service/operation/Status
+    uint64 latest_block_height_response = 1;
 }
 
 // CosmosSDKUnrecognizedResponse handles requests with methods ignored by state update

--- a/qos/cosmos/check_cometbft_health.go
+++ b/qos/cosmos/check_cometbft_health.go
@@ -3,7 +3,11 @@ package cosmos
 import (
 	"fmt"
 	"net/http"
+	"strconv"
 	"time"
+
+	"github.com/pokt-network/poktroll/pkg/relayer/proxy"
+	sharedtypes "github.com/pokt-network/poktroll/x/shared/types"
 )
 
 // Get node health. Returns empty result (200 OK) on success, no response - in case of an error.
@@ -36,6 +40,7 @@ type endpointCheckHealth struct {
 // e.g. GET /health
 func (e *endpointCheckHealth) GetRequest() *http.Request {
 	req, _ := http.NewRequest(http.MethodGet, apiPathHealthCheck, nil)
+	req.Header.Set(proxy.RPCTypeHeader, strconv.Itoa(int(sharedtypes.RPCType_COMET_BFT)))
 	return req
 }
 

--- a/qos/cosmos/check_cometbft_status.go
+++ b/qos/cosmos/check_cometbft_status.go
@@ -3,7 +3,11 @@ package cosmos
 import (
 	"fmt"
 	"net/http"
+	"strconv"
 	"time"
+
+	"github.com/pokt-network/poktroll/pkg/relayer/proxy"
+	sharedtypes "github.com/pokt-network/poktroll/x/shared/types"
 )
 
 // GET CometBFT status including node info, pubkey, latest block hash, app hash, block height and time.
@@ -43,6 +47,7 @@ type endpointCheckStatus struct {
 // e.g. GET /status
 func (e *endpointCheckStatus) GetRequest() *http.Request {
 	req, _ := http.NewRequest(http.MethodGet, apiPathStatus, nil)
+	req.Header.Set(proxy.RPCTypeHeader, strconv.Itoa(int(sharedtypes.RPCType_COMET_BFT)))
 	return req
 }
 

--- a/qos/cosmos/check_cosmos_status.go
+++ b/qos/cosmos/check_cosmos_status.go
@@ -1,0 +1,58 @@
+package cosmos
+
+import (
+	"fmt"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/pokt-network/poktroll/pkg/relayer/proxy"
+	sharedtypes "github.com/pokt-network/poktroll/x/shared/types"
+)
+
+// GET Cosmos SDK status including node info and block height.
+// Reference: https://docs.cosmos.network/main/core/grpc_rest.html#status
+const apiPathCosmosStatus = "/cosmos/base/node/v1beta1/status"
+
+// TODO_IMPROVE(@commoddity): determine an appropriate interval for checking the status and/or make it configurable.
+const checkCosmosStatusInterval = 10 * time.Second
+
+var (
+	errNoCosmosStatusObs      = fmt.Errorf("endpoint has not had an observation of its response to a %q request", apiPathCosmosStatus)
+	errInvalidCosmosStatusObs = fmt.Errorf("endpoint returned an invalid response to a %q request", apiPathCosmosStatus)
+)
+
+// endpointCheckCosmosStatus is a check that ensures the endpoint's Cosmos SDK status information is valid.
+// It is used to verify the endpoint's current block height.
+type endpointCheckCosmosStatus struct {
+	// height stores the latest block height from the endpoint's response to a `/cosmos/base/node/v1beta1/status` request.
+	// It is nil if there has NOT been an observation of the endpoint's response to a `/cosmos/base/node/v1beta1/status` request.
+	latestBlockHeight *uint64
+
+	// expiresAt stores the time at which the last check expires.
+	expiresAt time.Time
+}
+
+// GetRequest returns an HTTP request to check the Cosmos SDK status.
+// e.g. GET /cosmos/base/node/v1beta1/status
+func (e *endpointCheckCosmosStatus) GetRequest() *http.Request {
+	req, _ := http.NewRequest(http.MethodGet, apiPathCosmosStatus, nil)
+	req.Header.Set(proxy.RPCTypeHeader, strconv.Itoa(int(sharedtypes.RPCType_REST)))
+	return req
+}
+
+// GetHeight returns the parsed height value for the endpoint.
+func (e *endpointCheckCosmosStatus) GetHeight() (uint64, error) {
+	if e.latestBlockHeight == nil {
+		return 0, errNoCosmosStatusObs
+	}
+	if *e.latestBlockHeight == 0 {
+		return 0, errInvalidCosmosStatusObs
+	}
+	return *e.latestBlockHeight, nil
+}
+
+// IsExpired returns true if the check has expired and needs to be refreshed.
+func (e *endpointCheckCosmosStatus) IsExpired() bool {
+	return time.Now().After(e.expiresAt)
+}

--- a/qos/cosmos/endpoint.go
+++ b/qos/cosmos/endpoint.go
@@ -12,6 +12,7 @@ type endpoint struct {
 	invalidResponseLastObserved *time.Time
 
 	// CosmosSDK-specific checks
-	checkStatus endpointCheckStatus // Checks chain ID, catching up status, and latest block height via /status
-	checkHealth endpointCheckHealth // Checks node health via /health
+	checkCometbftStatus endpointCheckStatus       // Checks chain ID, catching up status, and latest block height via /status
+	checkCometbftHealth endpointCheckHealth       // Checks node health via /health
+	checkCosmosStatus   endpointCheckCosmosStatus // Checks latest block height via /cosmos/base/node/v1beta1/status
 }

--- a/qos/cosmos/endpoint_selection.go
+++ b/qos/cosmos/endpoint_selection.go
@@ -151,23 +151,23 @@ func (ss *serviceState) basicEndpointValidation(endpoint endpoint) error {
 		}
 	}
 
-	// Check if the endpoint's health status is valid.
-	if err := ss.isHealthValid(endpoint.checkHealth); err != nil {
+	// Check if the endpoint's CometBFT health status is valid.
+	if err := ss.isCometbftHealthValid(endpoint.checkCometbftHealth); err != nil {
 		return fmt.Errorf("health validation failed: %w", err)
 	}
 
-	// Check if the endpoint's status information is valid.
-	if err := ss.isStatusValid(endpoint.checkStatus); err != nil {
+	// Check if the endpoint's CometBFT status information is valid.
+	if err := ss.isCometbftStatusValid(endpoint.checkCometbftStatus); err != nil {
 		return fmt.Errorf("status validation failed: %w", err)
 	}
 
 	return nil
 }
 
-// isHealthValid returns an error if:
+// isCometbftHealthValid returns an error if:
 //   - The endpoint has not had an observation of its response to a `/health` request.
 //   - The endpoint's health check indicates it's unhealthy.
-func (ss *serviceState) isHealthValid(check endpointCheckHealth) error {
+func (ss *serviceState) isCometbftHealthValid(check endpointCheckHealth) error {
 	healthy, err := check.GetHealthy()
 	if err != nil {
 		return fmt.Errorf("%w: %v", errNoHealthObs, err)
@@ -180,12 +180,12 @@ func (ss *serviceState) isHealthValid(check endpointCheckHealth) error {
 	return nil
 }
 
-// isStatusValid returns an error if:
+// isCometbftStatusValid returns an error if:
 //   - The endpoint has not had an observation of its response to a `/status` request.
 //   - The endpoint's chain ID does not match the expected chain ID.
 //   - The endpoint is catching up to the network.
 //   - The endpoint's block height is outside the sync allowance.
-func (ss *serviceState) isStatusValid(check endpointCheckStatus) error {
+func (ss *serviceState) isCometbftStatusValid(check endpointCheckStatus) error {
 	// Check chain ID
 	chainID, err := check.GetChainID()
 	if err != nil {

--- a/qos/cosmos/response.go
+++ b/qos/cosmos/response.go
@@ -24,18 +24,21 @@ var (
 type responseUnmarshaller func(
 	logger polylog.Logger,
 	jsonrpcResp jsonrpc.Response,
+	restResponse []byte,
 ) (response, error)
 
 var (
 	// All response types must implement the response interface.
-	_ response = &responseToHealth{}
-	_ response = &responseToStatus{}
+	_ response = &responseToCometbftHealth{}
+	_ response = &responseToCometbftStatus{}
+	_ response = &responseToCosmosStatus{}
 	_ response = &responseGeneric{}
 
 	// Maps API paths to their corresponding response unmarshallers
 	apiPathResponseMappings = map[string]responseUnmarshaller{
-		apiPathHealthCheck: responseUnmarshallerHealth,
-		apiPathStatus:      responseUnmarshallerStatus,
+		apiPathHealthCheck:  responseUnmarshallerCometbftHealth,
+		apiPathStatus:       responseUnmarshallerCometbftStatus,
+		apiPathCosmosStatus: responseUnmarshallerCosmosStatus,
 	}
 )
 
@@ -64,7 +67,7 @@ func unmarshalResponse(
 	// Unmarshal the JSON-RPC response into a method-specific response.
 	unmarshaller, found := apiPathResponseMappings[apiPath]
 	if found {
-		return unmarshaller(logger, jsonrpcResponse)
+		return unmarshaller(logger, jsonrpcResponse, data)
 	}
 
 	// Default to a generic response if no method-specific response is found.

--- a/qos/cosmos/response_cosmos_status.go
+++ b/qos/cosmos/response_cosmos_status.go
@@ -1,0 +1,89 @@
+package cosmos
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/cosmos/cosmos-sdk/client/grpc/node"
+	"github.com/pokt-network/poktroll/pkg/polylog"
+
+	qosobservations "github.com/buildwithgrove/path/observation/qos"
+	"github.com/buildwithgrove/path/qos/jsonrpc"
+)
+
+// responseToCosmosStatus provides the functionality required from a response by a requestContext instance.
+var _ response = responseToCosmosStatus{}
+
+// responseUnmarshallerCosmosStatus deserializes the provided payload
+// into a responseToCosmosStatus struct, adding any encountered errors
+// to the returned struct.
+func responseUnmarshallerCosmosStatus(
+	logger polylog.Logger,
+	_ jsonrpc.Response,
+	restResponse []byte,
+) (response, error) {
+	// Then unmarshal the JSON bytes into the node.StatusResponse struct
+	var result node.StatusResponse
+	if err := json.Unmarshal(restResponse, &result); err != nil {
+		return responseToCosmosStatus{
+			logger:       logger,
+			restResponse: restResponse,
+		}, fmt.Errorf("failed to unmarshal result: %w", err)
+	}
+
+	return responseToCosmosStatus{
+		logger:       logger,
+		restResponse: restResponse,
+		height:       result.Height,
+	}, nil
+}
+
+// responseToCosmosStatus captures the fields expected in a
+// response to a Cosmos SDK status request.
+type responseToCosmosStatus struct {
+	logger polylog.Logger
+
+	// jsonRPCResponse stores the JSON-RPC response parsed from an endpoint's response bytes.
+	restResponse []byte
+
+	// height stores the latest block height of a
+	// response to a Cosmos SDK status request as a string.
+	// Comes from the `height` field in the `/cosmos/base/node/v1beta1/status` response.
+	// Reference: https://docs.cosmos.network/main/core/grpc_rest.html#status
+	height uint64
+}
+
+// GetObservation returns an observation using a Cosmos SDK status request's response.
+// Implements the response interface.
+func (r responseToCosmosStatus) GetObservation() qosobservations.CosmosSDKEndpointObservation {
+	return qosobservations.CosmosSDKEndpointObservation{
+		ResponseObservation: &qosobservations.CosmosSDKEndpointObservation_CosmosStatusResponse{
+			CosmosStatusResponse: &qosobservations.CosmosSDKStatusResponse{
+				LatestBlockHeightResponse: r.height,
+			},
+		},
+	}
+}
+
+// GetResponsePayload returns the payload for the response to a `/cosmos/base/node/v1beta1/status` request.
+// Implements the response interface.
+func (r responseToCosmosStatus) GetResponsePayload() []byte {
+	return r.restResponse
+}
+
+// returns an HTTP status code corresponding to the underlying JSON-RPC response code.
+// DEV_NOTE: This is an opinionated mapping following best practice but not enforced by any specifications or standards.
+// Implements the response interface.
+func (r responseToCosmosStatus) GetResponseStatusCode() int {
+	return http.StatusOK
+}
+
+// GetHTTPResponse builds and returns the httpResponse matching the responseToCosmosStatus instance.
+// Implements the response interface.
+func (r responseToCosmosStatus) GetHTTPResponse() httpResponse {
+	return httpResponse{
+		responsePayload: r.GetResponsePayload(),
+		httpStatusCode:  r.GetResponseStatusCode(),
+	}
+}


### PR DESCRIPTION
## 🌿 Summary

Adds support for health and status checking of Cosmos SDK endpoints in the QoS `cosmos` package, enabling compatibility with both CometBFT and Cosmos REST APIs.

### 🌱 Primary Changes:
- Introduced new check implementation for the Cosmos SDK REST endpoint `/cosmos/base/node/v1beta1/status`
- Created new message types: `CometBFTHealthResponse`, `CometBFTStatusResponse`, and `CosmosSDKStatusResponse` to distinguish among different endpoint responses
- Renamed and refactored health and status check files, functions, and types to align with CometBFT-specific semantics
- Implemented Cosmos SDK-specific check logic via `check_cosmos_status.go` and response parsing in `response_cosmos_status.go`

### 🍃 Secondary changes:
- Updated protobuf definitions and Go-generated code to reflect the new message structures and oneof fields
- Enhanced endpoint state tracking to store and process Cosmos SDK status observations
- Improved logging, comments, and error handling throughout status and health check implementations
- Removed outdated TODO documentation that’s no longer applicable after restructuring


## 💡 New TODOs 

New TODOs introduced in this PR:
- TODO_IMPROVE(@commoddity): determine an appropriate interval for checking the status and/or make it configurable. - qos/cosmos/check_cosmos_status.go

## 🛠️ Type of change

Select one or more from the following:

- [ ] New feature, functionality or library
- [ ] Bug fix
- [ ] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## 🤯 Sanity Checklist

- [ ] I have updated the GitHub Issue 'assignees', 'reviewers', 'labels', 'project', 'iteration' and 'milestone'
- [ ] For docs, I have run 'make docusaurus_start'
- [ ] For code, I have run 'make test_all'
- [ ] For configurations, I have update the documentation
- [ ] I added TODOs where applicable
