### PR TITLE
[QoS][JSONRPC] Fix: JSONRPC explicit null vs absent result field

### DIFF
--- a/e2e/service_evm_test.go
+++ b/e2e/service_evm_test.go
@@ -270,10 +270,10 @@ func getCurrentBlockHeight(client *http.Client, gatewayURL string, headers http.
 		return 0, fmt.Errorf("Error getting current block height: %w", err)
 	}
 
-	// Process hex string result
-	hexString, ok := jsonRPC.Result.(string)
-	if !ok {
-		return 0, fmt.Errorf("Error getting current block height: %T", jsonRPC.Result)
+	// Unmarshal the result into a string
+	var hexString string
+	if err := jsonRPC.UnmarshalResult(&hexString); err != nil {
+		return 0, fmt.Errorf("Error unmarshaling block number result: %w", err)
 	}
 
 	// Parse hex (remove "0x" prefix if present)

--- a/e2e/service_solana_test.go
+++ b/e2e/service_solana_test.go
@@ -241,15 +241,9 @@ func getCurrentSlotNumber(client *http.Client, gatewayURL string, headers http.H
 		return 0, err
 	}
 
-	// Marshal the result back to JSON so we can unmarshal it into our struct
-	resultBytes, err := json.Marshal(jsonRPC.Result)
-	if err != nil {
-		return 0, fmt.Errorf("failed to marshal result: %w", err)
-	}
-
-	// Unmarshal into getEpochInfoResponse
+	// Unmarshal the result into getEpochInfoResponse
 	var epochInfo getEpochInfoResponse
-	if err := json.Unmarshal(resultBytes, &epochInfo); err != nil {
+	if err := jsonRPC.UnmarshalResult(&epochInfo); err != nil {
 		return 0, fmt.Errorf("failed to unmarshal epoch info: %w", err)
 	}
 

--- a/qos/jsonrpc/response_test.go
+++ b/qos/jsonrpc/response_test.go
@@ -6,6 +6,12 @@ import (
 )
 
 func TestResponse_Validate(t *testing.T) {
+	// Helper function to create *json.RawMessage
+	rawMsg := func(s string) *json.RawMessage {
+		msg := json.RawMessage(s)
+		return &msg
+	}
+
 	tests := []struct {
 		name     string
 		reqID    ID
@@ -18,7 +24,7 @@ func TestResponse_Validate(t *testing.T) {
 			response: Response{
 				ID:      IDFromStr("1"),
 				Version: Version2,
-				Result:  &json.RawMessage(`"success"`),
+				Result:  rawMsg(`"success"`),
 			},
 			wantErr: false,
 		},
@@ -28,7 +34,7 @@ func TestResponse_Validate(t *testing.T) {
 			response: Response{
 				ID:      IDFromStr("1"),
 				Version: Version2,
-				Result:  &json.RawMessage(`null`),
+				Result:  rawMsg(`null`),
 			},
 			wantErr: false,
 		},
@@ -38,7 +44,7 @@ func TestResponse_Validate(t *testing.T) {
 			response: Response{
 				ID:      IDFromStr("1"),
 				Version: Version2,
-				Result:  &json.RawMessage(`{"blockHash":"0x1234","status":"0x1"}`),
+				Result:  rawMsg(`{"blockHash":"0x1234","status":"0x1"}`),
 			},
 			wantErr: false,
 		},
@@ -48,7 +54,7 @@ func TestResponse_Validate(t *testing.T) {
 			response: Response{
 				ID:      IDFromStr("1"),
 				Version: "1.0",
-				Result:  &json.RawMessage(`"success"`),
+				Result:  rawMsg(`"success"`),
 			},
 			wantErr: true,
 		},
@@ -58,7 +64,7 @@ func TestResponse_Validate(t *testing.T) {
 			response: Response{
 				ID:      IDFromStr("1"),
 				Version: Version2,
-				Result:  &json.RawMessage(`"success"`),
+				Result:  rawMsg(`"success"`),
 				Error:   &ResponseError{Code: 1, Message: "error"},
 			},
 			wantErr: true,
@@ -69,7 +75,7 @@ func TestResponse_Validate(t *testing.T) {
 			response: Response{
 				ID:      IDFromStr("1"),
 				Version: Version2,
-				Result:  &json.RawMessage(`null`),
+				Result:  rawMsg(`null`),
 				Error:   &ResponseError{Code: 1, Message: "error"},
 			},
 			wantErr: true,
@@ -91,7 +97,7 @@ func TestResponse_Validate(t *testing.T) {
 			response: Response{
 				ID:      IDFromStr("1"),
 				Version: Version2,
-				Result:  &json.RawMessage(`"success"`),
+				Result:  rawMsg(`"success"`),
 			},
 			wantErr: true,
 		},
@@ -101,7 +107,7 @@ func TestResponse_Validate(t *testing.T) {
 			response: Response{
 				ID:      ID{}, // empty ID (will serialize as null)
 				Version: Version2,
-				Result:  &json.RawMessage(`"success"`),
+				Result:  rawMsg(`"success"`),
 			},
 			wantErr: false,
 		},
@@ -111,7 +117,7 @@ func TestResponse_Validate(t *testing.T) {
 			response: Response{
 				ID:      IDFromInt(42),
 				Version: Version2,
-				Result:  &json.RawMessage(`"success"`),
+				Result:  rawMsg(`"success"`),
 			},
 			wantErr: false,
 		},
@@ -121,7 +127,7 @@ func TestResponse_Validate(t *testing.T) {
 			response: Response{
 				ID:      IDFromInt(0),
 				Version: Version2,
-				Result:  &json.RawMessage(`"success"`),
+				Result:  rawMsg(`"success"`),
 			},
 			wantErr: false,
 		},
@@ -131,7 +137,7 @@ func TestResponse_Validate(t *testing.T) {
 			response: Response{
 				ID:      IDFromStr("1"),
 				Version: Version2,
-				Result:  &json.RawMessage(`"success"`),
+				Result:  rawMsg(`"success"`),
 			},
 			wantErr: true,
 		},
@@ -141,7 +147,7 @@ func TestResponse_Validate(t *testing.T) {
 			response: Response{
 				ID:      ID{}, // empty ID (null)
 				Version: Version2,
-				Result:  &json.RawMessage(`"success"`),
+				Result:  rawMsg(`"success"`),
 			},
 			wantErr: true,
 		},
@@ -169,6 +175,12 @@ func TestResponse_Validate(t *testing.T) {
 }
 
 func TestResponse_MarshalJSON(t *testing.T) {
+	// Helper function to create *json.RawMessage
+	rawMsg := func(s string) *json.RawMessage {
+		msg := json.RawMessage(s)
+		return &msg
+	}
+
 	tests := []struct {
 		name     string
 		response Response
@@ -179,7 +191,7 @@ func TestResponse_MarshalJSON(t *testing.T) {
 			response: Response{
 				ID:      IDFromStr("1"),
 				Version: Version2,
-				Result:  &json.RawMessage(`"success"`),
+				Result:  rawMsg(`"success"`),
 			},
 			expected: `{"id":"1","jsonrpc":"2.0","result":"success"}`,
 		},
@@ -188,7 +200,7 @@ func TestResponse_MarshalJSON(t *testing.T) {
 			response: Response{
 				ID:      IDFromStr("1"),
 				Version: Version2,
-				Result:  &json.RawMessage(`null`),
+				Result:  rawMsg(`null`),
 			},
 			expected: `{"id":"1","jsonrpc":"2.0","result":null}`,
 		},
@@ -197,7 +209,7 @@ func TestResponse_MarshalJSON(t *testing.T) {
 			response: Response{
 				ID:      IDFromInt(42),
 				Version: Version2,
-				Result:  &json.RawMessage(`123`),
+				Result:  rawMsg(`123`),
 			},
 			expected: `{"id":42,"jsonrpc":"2.0","result":123}`,
 		},
@@ -216,7 +228,7 @@ func TestResponse_MarshalJSON(t *testing.T) {
 			response: Response{
 				ID:      IDFromStr("1"),
 				Version: Version2,
-				Result:  &json.RawMessage(`{"blockHash":"0x1234","status":"0x1"}`),
+				Result:  rawMsg(`{"blockHash":"0x1234","status":"0x1"}`),
 			},
 			expected: `{"id":"1","jsonrpc":"2.0","result":{"blockHash":"0x1234","status":"0x1"}}`,
 		},
@@ -225,7 +237,7 @@ func TestResponse_MarshalJSON(t *testing.T) {
 			response: Response{
 				ID:      IDFromStr("1"),
 				Version: Version2,
-				Result:  &json.RawMessage(`["item1","item2"]`),
+				Result:  rawMsg(`["item1","item2"]`),
 			},
 			expected: `{"id":"1","jsonrpc":"2.0","result":["item1","item2"]}`,
 		},
@@ -234,7 +246,7 @@ func TestResponse_MarshalJSON(t *testing.T) {
 			response: Response{
 				ID:      IDFromStr("1"),
 				Version: Version2,
-				Result:  &json.RawMessage(`true`),
+				Result:  rawMsg(`true`),
 			},
 			expected: `{"id":"1","jsonrpc":"2.0","result":true}`,
 		},
@@ -378,6 +390,12 @@ func TestResponse_UnmarshalJSON(t *testing.T) {
 }
 
 func TestResponse_GetResultAsBytes(t *testing.T) {
+	// Helper function to create *json.RawMessage
+	rawMsg := func(s string) *json.RawMessage {
+		msg := json.RawMessage(s)
+		return &msg
+	}
+
 	tests := []struct {
 		name     string
 		response Response
@@ -387,7 +405,7 @@ func TestResponse_GetResultAsBytes(t *testing.T) {
 		{
 			name: "should return result bytes for valid result",
 			response: Response{
-				Result: &json.RawMessage(`{"status":"0x1"}`),
+				Result: rawMsg(`{"status":"0x1"}`),
 			},
 			expected: []byte(`{"status":"0x1"}`),
 			wantErr:  false,
@@ -395,7 +413,7 @@ func TestResponse_GetResultAsBytes(t *testing.T) {
 		{
 			name: "should return null bytes for null result",
 			response: Response{
-				Result: &json.RawMessage(`null`),
+				Result: rawMsg(`null`),
 			},
 			expected: []byte(`null`),
 			wantErr:  false,
@@ -425,6 +443,12 @@ func TestResponse_GetResultAsBytes(t *testing.T) {
 }
 
 func TestResponse_UnmarshalResult(t *testing.T) {
+	// Helper function to create *json.RawMessage
+	rawMsg := func(s string) *json.RawMessage {
+		msg := json.RawMessage(s)
+		return &msg
+	}
+
 	tests := []struct {
 		name     string
 		response Response
@@ -435,7 +459,7 @@ func TestResponse_UnmarshalResult(t *testing.T) {
 		{
 			name: "should unmarshal string result",
 			response: Response{
-				Result: &json.RawMessage(`"hello"`),
+				Result: rawMsg(`"hello"`),
 			},
 			target:   new(string),
 			expected: "hello",
@@ -444,7 +468,7 @@ func TestResponse_UnmarshalResult(t *testing.T) {
 		{
 			name: "should unmarshal object result",
 			response: Response{
-				Result: &json.RawMessage(`{"status":"0x1","blockHash":"0x1234"}`),
+				Result: rawMsg(`{"status":"0x1","blockHash":"0x1234"}`),
 			},
 			target: new(map[string]string),
 			expected: map[string]string{
@@ -456,7 +480,7 @@ func TestResponse_UnmarshalResult(t *testing.T) {
 		{
 			name: "should unmarshal null result",
 			response: Response{
-				Result: &json.RawMessage(`null`),
+				Result: rawMsg(`null`),
 			},
 			target:   new(*string),
 			expected: (*string)(nil),

--- a/qos/jsonrpc/response_test.go
+++ b/qos/jsonrpc/response_test.go
@@ -1,6 +1,7 @@
 package jsonrpc
 
 import (
+	"encoding/json"
 	"testing"
 )
 
@@ -17,7 +18,27 @@ func TestResponse_Validate(t *testing.T) {
 			response: Response{
 				ID:      IDFromStr("1"),
 				Version: Version2,
-				Result:  "success",
+				Result:  &json.RawMessage(`"success"`),
+			},
+			wantErr: false,
+		},
+		{
+			name:  "should validate successfully with null result",
+			reqID: IDFromStr("1"),
+			response: Response{
+				ID:      IDFromStr("1"),
+				Version: Version2,
+				Result:  &json.RawMessage(`null`),
+			},
+			wantErr: false,
+		},
+		{
+			name:  "should validate successfully with complex result",
+			reqID: IDFromStr("1"),
+			response: Response{
+				ID:      IDFromStr("1"),
+				Version: Version2,
+				Result:  &json.RawMessage(`{"blockHash":"0x1234","status":"0x1"}`),
 			},
 			wantErr: false,
 		},
@@ -27,7 +48,7 @@ func TestResponse_Validate(t *testing.T) {
 			response: Response{
 				ID:      IDFromStr("1"),
 				Version: "1.0",
-				Result:  "success",
+				Result:  &json.RawMessage(`"success"`),
 			},
 			wantErr: true,
 		},
@@ -37,7 +58,18 @@ func TestResponse_Validate(t *testing.T) {
 			response: Response{
 				ID:      IDFromStr("1"),
 				Version: Version2,
-				Result:  "success",
+				Result:  &json.RawMessage(`"success"`),
+				Error:   &ResponseError{Code: 1, Message: "error"},
+			},
+			wantErr: true,
+		},
+		{
+			name:  "should fail validation with both null result and error",
+			reqID: IDFromStr("1"),
+			response: Response{
+				ID:      IDFromStr("1"),
+				Version: Version2,
+				Result:  &json.RawMessage(`null`),
 				Error:   &ResponseError{Code: 1, Message: "error"},
 			},
 			wantErr: true,
@@ -48,6 +80,8 @@ func TestResponse_Validate(t *testing.T) {
 			response: Response{
 				ID:      IDFromStr("1"),
 				Version: Version2,
+				Result:  nil, // no result field
+				Error:   nil, // no error field
 			},
 			wantErr: true,
 		},
@@ -57,7 +91,7 @@ func TestResponse_Validate(t *testing.T) {
 			response: Response{
 				ID:      IDFromStr("1"),
 				Version: Version2,
-				Result:  "success",
+				Result:  &json.RawMessage(`"success"`),
 			},
 			wantErr: true,
 		},
@@ -67,7 +101,7 @@ func TestResponse_Validate(t *testing.T) {
 			response: Response{
 				ID:      ID{}, // empty ID (will serialize as null)
 				Version: Version2,
-				Result:  "success",
+				Result:  &json.RawMessage(`"success"`),
 			},
 			wantErr: false,
 		},
@@ -77,7 +111,7 @@ func TestResponse_Validate(t *testing.T) {
 			response: Response{
 				ID:      IDFromInt(42),
 				Version: Version2,
-				Result:  "success",
+				Result:  &json.RawMessage(`"success"`),
 			},
 			wantErr: false,
 		},
@@ -87,7 +121,7 @@ func TestResponse_Validate(t *testing.T) {
 			response: Response{
 				ID:      IDFromInt(0),
 				Version: Version2,
-				Result:  "success",
+				Result:  &json.RawMessage(`"success"`),
 			},
 			wantErr: false,
 		},
@@ -97,7 +131,7 @@ func TestResponse_Validate(t *testing.T) {
 			response: Response{
 				ID:      IDFromStr("1"),
 				Version: Version2,
-				Result:  "success",
+				Result:  &json.RawMessage(`"success"`),
 			},
 			wantErr: true,
 		},
@@ -107,9 +141,20 @@ func TestResponse_Validate(t *testing.T) {
 			response: Response{
 				ID:      ID{}, // empty ID (null)
 				Version: Version2,
-				Result:  "success",
+				Result:  &json.RawMessage(`"success"`),
 			},
 			wantErr: true,
+		},
+		{
+			name:  "should validate successfully with error response (no result field)",
+			reqID: IDFromStr("1"),
+			response: Response{
+				ID:      IDFromStr("1"),
+				Version: Version2,
+				Result:  nil, // no result field for error responses
+				Error:   &ResponseError{Code: -32000, Message: "Server error"},
+			},
+			wantErr: false,
 		},
 	}
 
@@ -121,4 +166,435 @@ func TestResponse_Validate(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestResponse_MarshalJSON(t *testing.T) {
+	tests := []struct {
+		name     string
+		response Response
+		expected string
+	}{
+		{
+			name: "should marshal response with string result",
+			response: Response{
+				ID:      IDFromStr("1"),
+				Version: Version2,
+				Result:  &json.RawMessage(`"success"`),
+			},
+			expected: `{"id":"1","jsonrpc":"2.0","result":"success"}`,
+		},
+		{
+			name: "should marshal response with null result",
+			response: Response{
+				ID:      IDFromStr("1"),
+				Version: Version2,
+				Result:  &json.RawMessage(`null`),
+			},
+			expected: `{"id":"1","jsonrpc":"2.0","result":null}`,
+		},
+		{
+			name: "should marshal response with numeric result",
+			response: Response{
+				ID:      IDFromInt(42),
+				Version: Version2,
+				Result:  &json.RawMessage(`123`),
+			},
+			expected: `{"id":42,"jsonrpc":"2.0","result":123}`,
+		},
+		{
+			name: "should marshal error response without result field",
+			response: Response{
+				ID:      IDFromStr("1"),
+				Version: Version2,
+				Result:  nil, // omitted due to omitempty
+				Error:   &ResponseError{Code: -32000, Message: "Server error"},
+			},
+			expected: `{"id":"1","jsonrpc":"2.0","error":{"code":-32000,"message":"Server error"}}`,
+		},
+		{
+			name: "should marshal response with complex result",
+			response: Response{
+				ID:      IDFromStr("1"),
+				Version: Version2,
+				Result:  &json.RawMessage(`{"blockHash":"0x1234","status":"0x1"}`),
+			},
+			expected: `{"id":"1","jsonrpc":"2.0","result":{"blockHash":"0x1234","status":"0x1"}}`,
+		},
+		{
+			name: "should marshal response with array result",
+			response: Response{
+				ID:      IDFromStr("1"),
+				Version: Version2,
+				Result:  &json.RawMessage(`["item1","item2"]`),
+			},
+			expected: `{"id":"1","jsonrpc":"2.0","result":["item1","item2"]}`,
+		},
+		{
+			name: "should marshal response with boolean result",
+			response: Response{
+				ID:      IDFromStr("1"),
+				Version: Version2,
+				Result:  &json.RawMessage(`true`),
+			},
+			expected: `{"id":"1","jsonrpc":"2.0","result":true}`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			data, err := json.Marshal(test.response)
+			if err != nil {
+				t.Errorf("Marshal() error = %v", err)
+				return
+			}
+			if string(data) != test.expected {
+				t.Errorf("Marshal() = %s, expected %s", string(data), test.expected)
+			}
+		})
+	}
+}
+
+func TestResponse_UnmarshalJSON(t *testing.T) {
+	tests := []struct {
+		name     string
+		jsonData string
+		validate func(t *testing.T, response Response)
+		wantErr  bool
+	}{
+		{
+			name:     "should unmarshal response with string result",
+			jsonData: `{"id":"1","jsonrpc":"2.0","result":"success"}`,
+			validate: func(t *testing.T, response Response) {
+				if response.ID.String() != "1" {
+					t.Errorf("ID = %v, expected '1'", response.ID)
+				}
+				if response.Version != Version2 {
+					t.Errorf("Version = %v, expected %v", response.Version, Version2)
+				}
+				if response.Result == nil {
+					t.Error("Result should not be nil")
+					return
+				}
+				if string(*response.Result) != `"success"` {
+					t.Errorf("Result = %s, expected '\"success\"'", string(*response.Result))
+				}
+			},
+			wantErr: false,
+		},
+		{
+			name:     "should unmarshal response with null result",
+			jsonData: `{"id":"1","jsonrpc":"2.0","result":null}`,
+			validate: func(t *testing.T, response Response) {
+				if response.Result == nil {
+					t.Error("Result pointer should not be nil for explicit null")
+					return
+				}
+				if string(*response.Result) != "null" {
+					t.Errorf("Result = %s, expected 'null'", string(*response.Result))
+				}
+			},
+			wantErr: false,
+		},
+		{
+			name:     "should unmarshal response with missing result field",
+			jsonData: `{"id":"1","jsonrpc":"2.0"}`,
+			validate: func(t *testing.T, response Response) {
+				if response.Result != nil {
+					t.Error("Result should be nil when field is absent")
+				}
+			},
+			wantErr: false,
+		},
+		{
+			name:     "should unmarshal response with numeric result",
+			jsonData: `{"id":42,"jsonrpc":"2.0","result":123}`,
+			validate: func(t *testing.T, response Response) {
+				if response.ID.String() != "42" {
+					t.Errorf("ID = %v, expected '42'", response.ID)
+				}
+				if string(*response.Result) != "123" {
+					t.Errorf("Result = %s, expected '123'", string(*response.Result))
+				}
+			},
+			wantErr: false,
+		},
+		{
+			name:     "should unmarshal error response",
+			jsonData: `{"id":"1","jsonrpc":"2.0","error":{"code":-32000,"message":"Server error"}}`,
+			validate: func(t *testing.T, response Response) {
+				if response.Result != nil {
+					t.Error("Result should be nil for error responses")
+				}
+				if response.Error == nil {
+					t.Error("Error should not be nil")
+					return
+				}
+				if response.Error.Code != -32000 {
+					t.Errorf("Error.Code = %d, expected -32000", response.Error.Code)
+				}
+				if response.Error.Message != "Server error" {
+					t.Errorf("Error.Message = %s, expected 'Server error'", response.Error.Message)
+				}
+			},
+			wantErr: false,
+		},
+		{
+			name:     "should unmarshal response with complex result",
+			jsonData: `{"id":"1","jsonrpc":"2.0","result":{"blockHash":"0x1234","status":"0x1"}}`,
+			validate: func(t *testing.T, response Response) {
+				expected := `{"blockHash":"0x1234","status":"0x1"}`
+				if string(*response.Result) != expected {
+					t.Errorf("Result = %s, expected %s", string(*response.Result), expected)
+				}
+			},
+			wantErr: false,
+		},
+		{
+			name:     "should unmarshal response with array result",
+			jsonData: `{"id":"1","jsonrpc":"2.0","result":["item1","item2"]}`,
+			validate: func(t *testing.T, response Response) {
+				expected := `["item1","item2"]`
+				if string(*response.Result) != expected {
+					t.Errorf("Result = %s, expected %s", string(*response.Result), expected)
+				}
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var response Response
+			err := json.Unmarshal([]byte(test.jsonData), &response)
+			if (err != nil) != test.wantErr {
+				t.Errorf("Unmarshal() error = %v, wantErr %v", err, test.wantErr)
+				return
+			}
+			if err == nil && test.validate != nil {
+				test.validate(t, response)
+			}
+		})
+	}
+}
+
+func TestResponse_GetResultAsBytes(t *testing.T) {
+	tests := []struct {
+		name     string
+		response Response
+		expected []byte
+		wantErr  bool
+	}{
+		{
+			name: "should return result bytes for valid result",
+			response: Response{
+				Result: &json.RawMessage(`{"status":"0x1"}`),
+			},
+			expected: []byte(`{"status":"0x1"}`),
+			wantErr:  false,
+		},
+		{
+			name: "should return null bytes for null result",
+			response: Response{
+				Result: &json.RawMessage(`null`),
+			},
+			expected: []byte(`null`),
+			wantErr:  false,
+		},
+		{
+			name: "should return error for missing result",
+			response: Response{
+				Result: nil,
+			},
+			expected: nil,
+			wantErr:  true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result, err := test.response.GetResultAsBytes()
+			if (err != nil) != test.wantErr {
+				t.Errorf("GetResultAsBytes() error = %v, wantErr %v", err, test.wantErr)
+				return
+			}
+			if string(result) != string(test.expected) {
+				t.Errorf("GetResultAsBytes() = %s, expected %s", string(result), string(test.expected))
+			}
+		})
+	}
+}
+
+func TestResponse_UnmarshalResult(t *testing.T) {
+	tests := []struct {
+		name     string
+		response Response
+		target   interface{}
+		expected interface{}
+		wantErr  bool
+	}{
+		{
+			name: "should unmarshal string result",
+			response: Response{
+				Result: &json.RawMessage(`"hello"`),
+			},
+			target:   new(string),
+			expected: "hello",
+			wantErr:  false,
+		},
+		{
+			name: "should unmarshal object result",
+			response: Response{
+				Result: &json.RawMessage(`{"status":"0x1","blockHash":"0x1234"}`),
+			},
+			target: new(map[string]string),
+			expected: map[string]string{
+				"status":    "0x1",
+				"blockHash": "0x1234",
+			},
+			wantErr: false,
+		},
+		{
+			name: "should unmarshal null result",
+			response: Response{
+				Result: &json.RawMessage(`null`),
+			},
+			target:   new(*string),
+			expected: (*string)(nil),
+			wantErr:  false,
+		},
+		{
+			name: "should return error for missing result",
+			response: Response{
+				Result: nil,
+			},
+			target:  new(string),
+			wantErr: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := test.response.UnmarshalResult(test.target)
+			if (err != nil) != test.wantErr {
+				t.Errorf("UnmarshalResult() error = %v, wantErr %v", err, test.wantErr)
+				return
+			}
+			if !test.wantErr {
+				// Dereference pointer to get actual value
+				switch v := test.target.(type) {
+				case *string:
+					if *v != test.expected.(string) {
+						t.Errorf("UnmarshalResult() = %v, expected %v", *v, test.expected)
+					}
+				case *map[string]string:
+					expected := test.expected.(map[string]string)
+					for k, expectedV := range expected {
+						if (*v)[k] != expectedV {
+							t.Errorf("UnmarshalResult() key %s = %v, expected %v", k, (*v)[k], expectedV)
+						}
+					}
+				case **string:
+					if *v != test.expected.(*string) {
+						t.Errorf("UnmarshalResult() = %v, expected %v", *v, test.expected)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestResponse_HelperFunctions(t *testing.T) {
+	t.Run("GetErrorResponse", func(t *testing.T) {
+		response := GetErrorResponse(IDFromStr("1"), -32000, "Server error", nil)
+
+		if response.Result != nil {
+			t.Error("Result should be nil for error response")
+		}
+		if response.Error == nil {
+			t.Error("Error should not be nil")
+		}
+		if response.Error.Code != -32000 {
+			t.Errorf("Error.Code = %d, expected -32000", response.Error.Code)
+		}
+	})
+}
+
+func TestResponse_RealWorldEthereumExample(t *testing.T) {
+	// Test the exact case from the original issue
+	jsonData := `{"jsonrpc":"2.0","id":1,"result":null}`
+
+	var response Response
+	err := json.Unmarshal([]byte(jsonData), &response)
+	if err != nil {
+		t.Errorf("Failed to unmarshal real-world Ethereum response: %v", err)
+		return
+	}
+
+	// Validate against the request ID
+	reqID := IDFromInt(1)
+	err = response.Validate(reqID)
+	if err != nil {
+		t.Errorf("Real-world Ethereum response should be valid: %v", err)
+	}
+
+	// Ensure result field is present but contains null
+	if response.Result == nil {
+		t.Error("Result field should be present for explicit null")
+		return
+	}
+	if string(*response.Result) != "null" {
+		t.Errorf("Result = %s, expected 'null'", string(*response.Result))
+	}
+
+	// Ensure it marshals back correctly
+	data, err := json.Marshal(response)
+	if err != nil {
+		t.Errorf("Failed to marshal response: %v", err)
+		return
+	}
+
+	expected := `{"id":1,"jsonrpc":"2.0","result":null}`
+	if string(data) != expected {
+		t.Errorf("Marshal() = %s, expected %s", string(data), expected)
+	}
+}
+
+func TestResponse_FieldPresenceDistinction(t *testing.T) {
+	t.Run("missing result field vs explicit null", func(t *testing.T) {
+		// Case 1: Missing result field - should be invalid
+		missingJSON := `{"jsonrpc":"2.0","id":1}`
+		var missingResponse Response
+		err := json.Unmarshal([]byte(missingJSON), &missingResponse)
+		if err != nil {
+			t.Errorf("Unmarshal failed: %v", err)
+			return
+		}
+
+		if missingResponse.Result != nil {
+			t.Error("Result should be nil when field is absent")
+		}
+
+		err = missingResponse.Validate(IDFromInt(1))
+		if err == nil {
+			t.Error("Validation should fail for missing result field")
+		}
+
+		// Case 2: Explicit null result - should be valid
+		nullJSON := `{"jsonrpc":"2.0","id":1,"result":null}`
+		var nullResponse Response
+		err = json.Unmarshal([]byte(nullJSON), &nullResponse)
+		if err != nil {
+			t.Errorf("Unmarshal failed: %v", err)
+			return
+		}
+
+		if nullResponse.Result == nil {
+			t.Error("Result should not be nil for explicit null field")
+		}
+
+		err = nullResponse.Validate(IDFromInt(1))
+		if err != nil {
+			t.Errorf("Validation should pass for explicit null result: %v", err)
+		}
+	})
 }


### PR DESCRIPTION
## Summary

Refactor JSONRPC Response.Result field to use *json.RawMessage for better null handling and field presence distinction

### Primary Changes:

- Changed Result field from any to *json.RawMessage to distinguish between absent field vs explicit null values
- Updated Validate() method to properly check field presence using pointer nil vs non-nil distinction
- Modified GetResultAsBytes() to return raw bytes directly without re-marshaling< Change 1 >

### Secondary Changes:

- Added UnmarshalResult() helper method for type-safe result unmarshaling
- Added comprehensive test coverage for JSON marshaling/unmarshaling scenarios
- Updated all existing tests to use json.RawMessage format for result values

## Issue

There are valid JSONRPC responses with `"result": null`, which fail our JSONRPC validation:

Example:

```bash
curl https://rpc.xrplevm.org -d '{"jsonrpc": "2.0", "method": "eth_getTransactionReceipt", "params": ["0xa59fde70cac38068dfd87adb1d7eb40200421ebf7075911f83bcdde810e94058"], "id": 1 }' -H 'content-type: Application/JSON'
{"jsonrpc":"2.0","id":1,"result":null}
```

- Issue or PR: #{ISSUE_OR_PR_NUMBER}

## Type of change

Select one or more from the following:

- [ ] New feature, functionality or library
- [x] Bug fix
- [ ] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## QoS Checklist

### E2E Validation & Tests

- [x] `make path_up`
- [ ] `make test_e2e_evm_shannon`

### Observability

- [x] 1. `make path_up`
- [ ] 2. Run the following E2E test: `make test_request__shannon_relay_util_100`
- [ ] 3. View results in LocalNet's [PATH Relay Grafana Dashboard](http://localhost:3003/d/relays/path-service-requests)

## Sanity Checklist

- [x] I have updated the GitHub Issue `assignees`, `reviewers`, `labels`, `project`, `iteration` and `milestone`
- [ ] For docs, I have run `make docusaurus_start`
- [ ] For code, I have run `make test_all`
- [ ] For configurations, I have updated the documentation
- [ ] I added `TODO`s where applicable
