### PR TITLE
[QoS][Cosmos] Hydrate REST request logger with request details

### DIFF
--- a/qos/cosmos/request_validator_rest.go
+++ b/qos/cosmos/request_validator_rest.go
@@ -87,10 +87,15 @@ func (rv *requestValidator) buildRESTRequestContext(
 		servicePayload,
 	)
 
-	logger.With(
+	// Hydrate the logger with REST request details.
+	logger = logger.With(
+		"rest_backend_service", rpcType,
 		"payload_length", len(servicePayload.Data),
-		"request_path", servicePayload.Path,
-	).Debug().Msg("REST request validation successful.")
+		"rest_request_path", servicePayload.Path,
+		"rest_request_method", servicePayload.Method,
+	)
+
+	logger.Debug().Msg("REST request validation successful.")
 
 	// Create specialized REST context
 	return &requestContext{


### PR DESCRIPTION
## Summary

Hydrate REST request logger with request details

## Issue

Insufficient details in REST request processors/validators logs to track endpoint errors.

- Issue or PR: #{ISSUE_OR_PR_NUMBER}

## Type of change

Select one or more from the following:

- [x] New feature, functionality or library
- [ ] Bug fix
- [ ] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## QoS Checklist

### E2E Validation & Tests

- [ ] `make path_up`
- [ ] `make test_e2e_evm_shannon`

### Observability

- [ ] 1. `make path_up`
- [ ] 2. Run the following E2E test: `make test_request__shannon_relay_util_100`
- [ ] 3. View results in LocalNet's [PATH Relay Grafana Dashboard](http://localhost:3003/d/relays/path-service-requests)

## Sanity Checklist

- [ ] I have updated the GitHub Issue `assignees`, `reviewers`, `labels`, `project`, `iteration` and `milestone`
- [ ] For docs, I have run `make docusaurus_start`
- [ ] For code, I have run `make test_all`
- [ ] For configurations, I have updated the documentation
- [ ] I added `TODO`s where applicable
