### PR TITLE
[Cosmos][QoS] add EVM chain ID check for Cosmos SDK QoS

### DIFF
--- a/config/service_qos_config.go
+++ b/config/service_qos_config.go
@@ -408,53 +408,53 @@ var shannonServices = []ServiceQoSConfig{
 	// the correct chain ID is being used for each service in the CosmosSDK config.
 
 	// Osmosis
-	cosmos.NewCosmosSDKServiceQoSConfig("osmosis", "osmosis", map[sharedtypes.RPCType]struct{}{
+	cosmos.NewCosmosSDKServiceQoSConfig("osmosis", "osmosis", "", map[sharedtypes.RPCType]struct{}{
 		sharedtypes.RPCType_REST:      {}, // CosmosSDK
 		sharedtypes.RPCType_COMET_BFT: {},
 	}),
 
 	// Pocket Mainnet and Beta Testnet
-	cosmos.NewCosmosSDKServiceQoSConfig("pocket", "pocket", map[sharedtypes.RPCType]struct{}{
+	cosmos.NewCosmosSDKServiceQoSConfig("pocket", "pocket", "", map[sharedtypes.RPCType]struct{}{
 		sharedtypes.RPCType_REST:      {}, // CosmosSDK
 		sharedtypes.RPCType_COMET_BFT: {},
 	}),
 
 	// Pocket Mainnet
-	cosmos.NewCosmosSDKServiceQoSConfig("pocket-alpha", "pocket-alpha", map[sharedtypes.RPCType]struct{}{
+	cosmos.NewCosmosSDKServiceQoSConfig("pocket-alpha", "pocket-alpha", "", map[sharedtypes.RPCType]struct{}{
 		sharedtypes.RPCType_REST:      {}, // CosmosSDK
 		sharedtypes.RPCType_COMET_BFT: {},
 	}),
-	cosmos.NewCosmosSDKServiceQoSConfig("pocket-beta", "pocket-beta", map[sharedtypes.RPCType]struct{}{
+	cosmos.NewCosmosSDKServiceQoSConfig("pocket-beta", "pocket-beta", "", map[sharedtypes.RPCType]struct{}{
 		sharedtypes.RPCType_REST:      {}, // CosmosSDK
 		sharedtypes.RPCType_COMET_BFT: {},
 	}),
 
 	// Pocket Beta Testnet
-	cosmos.NewCosmosSDKServiceQoSConfig("pocket-beta1", "pocket-beta1", map[sharedtypes.RPCType]struct{}{
+	cosmos.NewCosmosSDKServiceQoSConfig("pocket-beta1", "pocket-beta1", "", map[sharedtypes.RPCType]struct{}{
 		sharedtypes.RPCType_REST:      {}, // CosmosSDK
 		sharedtypes.RPCType_COMET_BFT: {},
 	}),
-	cosmos.NewCosmosSDKServiceQoSConfig("pocket-beta2", "pocket-beta2", map[sharedtypes.RPCType]struct{}{
+	cosmos.NewCosmosSDKServiceQoSConfig("pocket-beta2", "pocket-beta2", "", map[sharedtypes.RPCType]struct{}{
 		sharedtypes.RPCType_REST:      {}, // CosmosSDK
 		sharedtypes.RPCType_COMET_BFT: {},
 	}),
-	cosmos.NewCosmosSDKServiceQoSConfig("pocket-beta3", "pocket-beta3", map[sharedtypes.RPCType]struct{}{
+	cosmos.NewCosmosSDKServiceQoSConfig("pocket-beta3", "pocket-beta3", "", map[sharedtypes.RPCType]struct{}{
 		sharedtypes.RPCType_REST:      {}, // CosmosSDK
 		sharedtypes.RPCType_COMET_BFT: {},
 	}),
-	cosmos.NewCosmosSDKServiceQoSConfig("pocket-beta4", "pocket-beta4", map[sharedtypes.RPCType]struct{}{
+	cosmos.NewCosmosSDKServiceQoSConfig("pocket-beta4", "pocket-beta4", "", map[sharedtypes.RPCType]struct{}{
 		sharedtypes.RPCType_REST:      {}, // CosmosSDK
 		sharedtypes.RPCType_COMET_BFT: {},
 	}),
 
 	// Cosmos Hub
-	cosmos.NewCosmosSDKServiceQoSConfig("cometbft", "cosmoshub-4", map[sharedtypes.RPCType]struct{}{
+	cosmos.NewCosmosSDKServiceQoSConfig("cometbft", "cosmoshub-4", "", map[sharedtypes.RPCType]struct{}{
 		sharedtypes.RPCType_COMET_BFT: {},
 	}),
 
 	// XRPL EVM
 	// Reference: https://docs.xrplevm.org/pages/developers/developing-smart-contracts/deploy-the-smart-contract#1.-set-up-your-wallet
-	cosmos.NewCosmosSDKServiceQoSConfig("xrplevm", "xrplevm_1440000-1", map[sharedtypes.RPCType]struct{}{
+	cosmos.NewCosmosSDKServiceQoSConfig("xrplevm", "xrplevm_1440000-1", "0x15f900", map[sharedtypes.RPCType]struct{}{
 		sharedtypes.RPCType_JSON_RPC:  {}, // XRPLEVM supports the EVM API over JSON-RPC.
 		sharedtypes.RPCType_REST:      {}, // CosmosSDK
 		sharedtypes.RPCType_COMET_BFT: {},
@@ -462,7 +462,7 @@ var shannonServices = []ServiceQoSConfig{
 	}),
 
 	// XRPL EVM Testnet
-	cosmos.NewCosmosSDKServiceQoSConfig("xrplevm-testnet", "xrplevm_1449000-1", map[sharedtypes.RPCType]struct{}{
+	cosmos.NewCosmosSDKServiceQoSConfig("xrplevm-testnet", "xrplevm_1449000-1", "0x161c28", map[sharedtypes.RPCType]struct{}{
 		sharedtypes.RPCType_JSON_RPC:  {}, // XRPLEVM supports the EVM API over JSON-RPC.
 		sharedtypes.RPCType_REST:      {}, // CosmosSDK
 		sharedtypes.RPCType_COMET_BFT: {},

--- a/metrics/qos/cosmos/metrics.go
+++ b/metrics/qos/cosmos/metrics.go
@@ -36,7 +36,8 @@ var (
 	// requestsTotal tracks total Cosmos SDK requests processed
 	//
 	// - Labels:
-	//   - chain_id: Target Cosmos SDK chain identifier
+	//   - cosmos_sdk_chain_id: Target Cosmos SDK chain identifier
+	//   - evm_chain_id: Target EVM chain identifier
 	//   - service_id: Service ID of the Cosmos SDK QoS instance
 	//   - request_origin: origin of the request: User or Hydrator.
 	//   - rpc_type: Backend service type (JSONRPC, REST, COMETBFT)
@@ -58,7 +59,7 @@ var (
 			Name:      requestsTotalMetric,
 			Help:      "Total number of requests processed by Cosmos SDK QoS instance(s)",
 		},
-		[]string{"chain_id", "service_id", "request_origin", "rpc_type", "request_method", "success", "error_type", "http_status_code"},
+		[]string{"cosmos_sdk_chain_id", "evm_chain_id", "service_id", "request_origin", "rpc_type", "request_method", "success", "error_type", "http_status_code"},
 	)
 )
 
@@ -84,14 +85,15 @@ func PublishMetrics(logger polylog.Logger, observations *qos.CosmosRequestObserv
 	// Increment request counters with all corresponding labels
 	requestsTotal.With(
 		prometheus.Labels{
-			"chain_id":         interpreter.GetChainID(),
-			"service_id":       interpreter.GetServiceID(),
-			"request_origin":   observations.GetRequestOrigin().String(),
-			"rpc_type":         interpreter.GetRPCType(),
-			"request_method":   interpreter.GetRequestMethod(),
-			"success":          fmt.Sprintf("%t", interpreter.IsRequestSuccessful()),
-			"error_type":       interpreter.GetRequestErrorType(),
-			"http_status_code": fmt.Sprintf("%d", interpreter.GetRequestHTTPStatus()),
+			"cosmos_sdk_chain_id": interpreter.GetCosmosSdkChainID(),
+			"evm_chain_id":        interpreter.GetEVMChainID(),
+			"service_id":          interpreter.GetServiceID(),
+			"request_origin":      observations.GetRequestOrigin().String(),
+			"rpc_type":            interpreter.GetRPCType(),
+			"request_method":      interpreter.GetRequestMethod(),
+			"success":             fmt.Sprintf("%t", interpreter.IsRequestSuccessful()),
+			"error_type":          interpreter.GetRequestErrorType(),
+			"http_status_code":    fmt.Sprintf("%d", interpreter.GetRequestHTTPStatus()),
 		},
 	).Inc()
 }

--- a/observation/qos/cosmos.pb.go
+++ b/observation/qos/cosmos.pb.go
@@ -24,21 +24,23 @@ const (
 // CosmosRequestObservations captures all observations made while serving a single Cosmos blockchain service request.
 type CosmosRequestObservations struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
-	// chain_id is the blockchain identifier for the QoS implementation.
-	ChainId string `protobuf:"bytes,1,opt,name=chain_id,json=chainId,proto3" json:"chain_id,omitempty"`
+	// cosmos_sdk_chain_id is the Cosmos SDK blockchain identifier for the QoS implementation.
+	CosmosSdkChainId string `protobuf:"bytes,1,opt,name=cosmos_sdk_chain_id,json=cosmosSdkChainId,proto3" json:"cosmos_sdk_chain_id,omitempty"`
+	// evm_chain_id is the EVM blockchain identifier for the QoS implementation.
+	EvmChainId string `protobuf:"bytes,2,opt,name=evm_chain_id,json=evmChainId,proto3" json:"evm_chain_id,omitempty"`
 	// service_id is the identifier for the QoS implementation.
-	ServiceId string `protobuf:"bytes,2,opt,name=service_id,json=serviceId,proto3" json:"service_id,omitempty"`
+	ServiceId string `protobuf:"bytes,3,opt,name=service_id,json=serviceId,proto3" json:"service_id,omitempty"`
 	// The origin of the request
-	RequestOrigin RequestOrigin `protobuf:"varint,3,opt,name=request_origin,json=requestOrigin,proto3,enum=path.qos.RequestOrigin" json:"request_origin,omitempty"`
+	RequestOrigin RequestOrigin `protobuf:"varint,4,opt,name=request_origin,json=requestOrigin,proto3,enum=path.qos.RequestOrigin" json:"request_origin,omitempty"`
 	// Profile of the request: backend service selection and format determination
-	RequestProfile *CosmosRequestProfile `protobuf:"bytes,4,opt,name=request_profile,json=requestProfile,proto3" json:"request_profile,omitempty"`
+	RequestProfile *CosmosRequestProfile `protobuf:"bytes,5,opt,name=request_profile,json=requestProfile,proto3" json:"request_profile,omitempty"`
 	// Request-level error, i.e. failed without any endpoint responses.
 	// Examples:
 	//   - Failed to parse request
 	//   - No endpoint response received, i.e. any protocol-level error.
-	RequestLevelError *RequestError `protobuf:"bytes,5,opt,name=request_level_error,json=requestLevelError,proto3,oneof" json:"request_level_error,omitempty"`
+	RequestLevelError *RequestError `protobuf:"bytes,6,opt,name=request_level_error,json=requestLevelError,proto3,oneof" json:"request_level_error,omitempty"`
 	// Cosmos-specific observations from endpoint(s) that responded to the service request.
-	EndpointObservations []*CosmosEndpointObservation `protobuf:"bytes,6,rep,name=endpoint_observations,json=endpointObservations,proto3" json:"endpoint_observations,omitempty"`
+	EndpointObservations []*CosmosEndpointObservation `protobuf:"bytes,7,rep,name=endpoint_observations,json=endpointObservations,proto3" json:"endpoint_observations,omitempty"`
 	unknownFields        protoimpl.UnknownFields
 	sizeCache            protoimpl.SizeCache
 }
@@ -73,9 +75,16 @@ func (*CosmosRequestObservations) Descriptor() ([]byte, []int) {
 	return file_path_qos_cosmos_proto_rawDescGZIP(), []int{0}
 }
 
-func (x *CosmosRequestObservations) GetChainId() string {
+func (x *CosmosRequestObservations) GetCosmosSdkChainId() string {
 	if x != nil {
-		return x.ChainId
+		return x.CosmosSdkChainId
+	}
+	return ""
+}
+
+func (x *CosmosRequestObservations) GetEvmChainId() string {
+	if x != nil {
+		return x.EvmChainId
 	}
 	return ""
 }
@@ -177,15 +186,17 @@ var File_path_qos_cosmos_proto protoreflect.FileDescriptor
 
 const file_path_qos_cosmos_proto_rawDesc = "" +
 	"\n" +
-	"\x15path/qos/cosmos.proto\x12\bpath.qos\x1a\x1dpath/qos/cosmos_request.proto\x1a\x1epath/qos/cosmos_response.proto\x1a\x1dpath/qos/request_origin.proto\x1a\x1cpath/qos/request_error.proto\"\x9d\x03\n" +
-	"\x19CosmosRequestObservations\x12\x19\n" +
-	"\bchain_id\x18\x01 \x01(\tR\achainId\x12\x1d\n" +
+	"\x15path/qos/cosmos.proto\x12\bpath.qos\x1a\x1dpath/qos/cosmos_request.proto\x1a\x1epath/qos/cosmos_response.proto\x1a\x1dpath/qos/request_origin.proto\x1a\x1cpath/qos/request_error.proto\"\xd3\x03\n" +
+	"\x19CosmosRequestObservations\x12-\n" +
+	"\x13cosmos_sdk_chain_id\x18\x01 \x01(\tR\x10cosmosSdkChainId\x12 \n" +
+	"\fevm_chain_id\x18\x02 \x01(\tR\n" +
+	"evmChainId\x12\x1d\n" +
 	"\n" +
-	"service_id\x18\x02 \x01(\tR\tserviceId\x12>\n" +
-	"\x0erequest_origin\x18\x03 \x01(\x0e2\x17.path.qos.RequestOriginR\rrequestOrigin\x12G\n" +
-	"\x0frequest_profile\x18\x04 \x01(\v2\x1e.path.qos.CosmosRequestProfileR\x0erequestProfile\x12K\n" +
-	"\x13request_level_error\x18\x05 \x01(\v2\x16.path.qos.RequestErrorH\x00R\x11requestLevelError\x88\x01\x01\x12X\n" +
-	"\x15endpoint_observations\x18\x06 \x03(\v2#.path.qos.CosmosEndpointObservationR\x14endpointObservationsB\x16\n" +
+	"service_id\x18\x03 \x01(\tR\tserviceId\x12>\n" +
+	"\x0erequest_origin\x18\x04 \x01(\x0e2\x17.path.qos.RequestOriginR\rrequestOrigin\x12G\n" +
+	"\x0frequest_profile\x18\x05 \x01(\v2\x1e.path.qos.CosmosRequestProfileR\x0erequestProfile\x12K\n" +
+	"\x13request_level_error\x18\x06 \x01(\v2\x16.path.qos.RequestErrorH\x00R\x11requestLevelError\x88\x01\x01\x12X\n" +
+	"\x15endpoint_observations\x18\a \x03(\v2#.path.qos.CosmosEndpointObservationR\x14endpointObservationsB\x16\n" +
 	"\x14_request_level_error\"\xc1\x01\n" +
 	"\x19CosmosEndpointObservation\x12#\n" +
 	"\rendpoint_addr\x18\x01 \x01(\tR\fendpointAddr\x12\x7f\n" +

--- a/observation/qos/cosmos_interpreter.go
+++ b/observation/qos/cosmos_interpreter.go
@@ -14,13 +14,24 @@ type CosmosSDKObservationInterpreter struct {
 	Observations *CosmosRequestObservations
 }
 
+// TODO_IN_THIS_PR(@commoddity): Add EVM chain ID to interpreter.
+
 // GetChainID returns the blockchain identifier from observations.
-func (i *CosmosSDKObservationInterpreter) GetChainID() string {
+func (i *CosmosSDKObservationInterpreter) GetCosmosSdkChainID() string {
 	if i.Observations == nil {
-		i.Logger.ProbabilisticDebugInfo(polylog.ProbabilisticDebugInfoProb).Msg("SHOULD RARELY HAPPEN: Cannot get chain ID: nil observations")
+		i.Logger.ProbabilisticDebugInfo(polylog.ProbabilisticDebugInfoProb).Msg("SHOULD RARELY HAPPEN: Cannot get Cosmos SDK chain ID: nil observations")
 		return ""
 	}
-	return i.Observations.ChainId
+	return i.Observations.CosmosSdkChainId
+}
+
+// GetEVMChainID returns the EVM chain identifier from observations.
+func (i *CosmosSDKObservationInterpreter) GetEVMChainID() string {
+	if i.Observations == nil {
+		i.Logger.ProbabilisticDebugInfo(polylog.ProbabilisticDebugInfoProb).Msg("SHOULD RARELY HAPPEN: Cannot get EVM chain ID: nil observations")
+		return ""
+	}
+	return i.Observations.EvmChainId
 }
 
 // GetServiceID returns the service identifier from observations.

--- a/observation/qos/cosmos_response.pb.go
+++ b/observation/qos/cosmos_response.pb.go
@@ -155,6 +155,7 @@ type CosmosEndpointResponseValidationResult struct {
 	//	*CosmosEndpointResponseValidationResult_ResponseCometBftHealth
 	//	*CosmosEndpointResponseValidationResult_ResponseCometBftStatus
 	//	*CosmosEndpointResponseValidationResult_ResponseCosmosSdkStatus
+	//	*CosmosEndpointResponseValidationResult_ResponseEvmJsonrpcChainId
 	//	*CosmosEndpointResponseValidationResult_ResponseUnrecognized
 	ParsedResponse isCosmosEndpointResponseValidationResult_ParsedResponse `protobuf_oneof:"parsed_response"`
 	unknownFields  protoimpl.UnknownFields
@@ -255,6 +256,15 @@ func (x *CosmosEndpointResponseValidationResult) GetResponseCosmosSdkStatus() *C
 	return nil
 }
 
+func (x *CosmosEndpointResponseValidationResult) GetResponseEvmJsonrpcChainId() *CosmosResponseEVMJSONRPCChainID {
+	if x != nil {
+		if x, ok := x.ParsedResponse.(*CosmosEndpointResponseValidationResult_ResponseEvmJsonrpcChainId); ok {
+			return x.ResponseEvmJsonrpcChainId
+		}
+	}
+	return nil
+}
+
 func (x *CosmosEndpointResponseValidationResult) GetResponseUnrecognized() *UnrecognizedResponse {
 	if x != nil {
 		if x, ok := x.ParsedResponse.(*CosmosEndpointResponseValidationResult_ResponseUnrecognized); ok {
@@ -287,10 +297,15 @@ type CosmosEndpointResponseValidationResult_ResponseCosmosSdkStatus struct {
 	ResponseCosmosSdkStatus *CosmosResponseCosmosSDKStatus `protobuf:"bytes,7,opt,name=response_cosmos_sdk_status,json=responseCosmosSdkStatus,proto3,oneof"`
 }
 
+type CosmosEndpointResponseValidationResult_ResponseEvmJsonrpcChainId struct {
+	// Response to Ethereum JSONRPC request using method `eth_chainId`
+	ResponseEvmJsonrpcChainId *CosmosResponseEVMJSONRPCChainID `protobuf:"bytes,8,opt,name=response_evm_jsonrpc_chain_id,json=responseEvmJsonrpcChainId,proto3,oneof"`
+}
+
 type CosmosEndpointResponseValidationResult_ResponseUnrecognized struct {
 	// For unrecognized responses.
 	// These are returned as-is to the user.
-	ResponseUnrecognized *UnrecognizedResponse `protobuf:"bytes,8,opt,name=response_unrecognized,json=responseUnrecognized,proto3,oneof"`
+	ResponseUnrecognized *UnrecognizedResponse `protobuf:"bytes,9,opt,name=response_unrecognized,json=responseUnrecognized,proto3,oneof"`
 }
 
 func (*CosmosEndpointResponseValidationResult_ResponseJsonrpc) isCosmosEndpointResponseValidationResult_ParsedResponse() {
@@ -303,6 +318,9 @@ func (*CosmosEndpointResponseValidationResult_ResponseCometBftStatus) isCosmosEn
 }
 
 func (*CosmosEndpointResponseValidationResult_ResponseCosmosSdkStatus) isCosmosEndpointResponseValidationResult_ParsedResponse() {
+}
+
+func (*CosmosEndpointResponseValidationResult_ResponseEvmJsonrpcChainId) isCosmosEndpointResponseValidationResult_ParsedResponse() {
 }
 
 func (*CosmosEndpointResponseValidationResult_ResponseUnrecognized) isCosmosEndpointResponseValidationResult_ParsedResponse() {
@@ -356,7 +374,7 @@ func (x *CosmosResponseCometBFTHealth) GetHealthStatus() bool {
 // CosmosResponseCometBFTStatus stores the response to a CometBFT `/status` request
 type CosmosResponseCometBFTStatus struct {
 	state             protoimpl.MessageState `protogen:"open.v1"`
-	ChainId           string                 `protobuf:"bytes,1,opt,name=chain_id,json=chainId,proto3" json:"chain_id,omitempty"`
+	CosmosSdkChainId  string                 `protobuf:"bytes,1,opt,name=cosmos_sdk_chain_id,json=cosmosSdkChainId,proto3" json:"cosmos_sdk_chain_id,omitempty"`
 	CatchingUp        bool                   `protobuf:"varint,2,opt,name=catching_up,json=catchingUp,proto3" json:"catching_up,omitempty"`
 	LatestBlockHeight string                 `protobuf:"bytes,3,opt,name=latest_block_height,json=latestBlockHeight,proto3" json:"latest_block_height,omitempty"`
 	unknownFields     protoimpl.UnknownFields
@@ -393,9 +411,9 @@ func (*CosmosResponseCometBFTStatus) Descriptor() ([]byte, []int) {
 	return file_path_qos_cosmos_response_proto_rawDescGZIP(), []int{2}
 }
 
-func (x *CosmosResponseCometBFTStatus) GetChainId() string {
+func (x *CosmosResponseCometBFTStatus) GetCosmosSdkChainId() string {
 	if x != nil {
-		return x.ChainId
+		return x.CosmosSdkChainId
 	}
 	return ""
 }
@@ -459,6 +477,62 @@ func (x *CosmosResponseCosmosSDKStatus) GetLatestBlockHeight() uint64 {
 	return 0
 }
 
+// CosmosResponseEVMJSONRPCChainID stores the response to an `eth_chainId` request
+// https://ethereum.org/en/developers/docs/apis/json-rpc/#eth_chainid
+type CosmosResponseEVMJSONRPCChainID struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// The HTTP status code received from the endpoint
+	HttpStatusCode int32 `protobuf:"varint,1,opt,name=http_status_code,json=httpStatusCode,proto3" json:"http_status_code,omitempty"`
+	// The chain ID value returned in the response
+	EvmChainId    string `protobuf:"bytes,2,opt,name=evm_chain_id,json=evmChainId,proto3" json:"evm_chain_id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *CosmosResponseEVMJSONRPCChainID) Reset() {
+	*x = CosmosResponseEVMJSONRPCChainID{}
+	mi := &file_path_qos_cosmos_response_proto_msgTypes[4]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *CosmosResponseEVMJSONRPCChainID) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*CosmosResponseEVMJSONRPCChainID) ProtoMessage() {}
+
+func (x *CosmosResponseEVMJSONRPCChainID) ProtoReflect() protoreflect.Message {
+	mi := &file_path_qos_cosmos_response_proto_msgTypes[4]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use CosmosResponseEVMJSONRPCChainID.ProtoReflect.Descriptor instead.
+func (*CosmosResponseEVMJSONRPCChainID) Descriptor() ([]byte, []int) {
+	return file_path_qos_cosmos_response_proto_rawDescGZIP(), []int{4}
+}
+
+func (x *CosmosResponseEVMJSONRPCChainID) GetHttpStatusCode() int32 {
+	if x != nil {
+		return x.HttpStatusCode
+	}
+	return 0
+}
+
+func (x *CosmosResponseEVMJSONRPCChainID) GetEvmChainId() string {
+	if x != nil {
+		return x.EvmChainId
+	}
+	return ""
+}
+
 // UnrecognizedResponse handles responses that are not validated before being returned to the user.
 type UnrecognizedResponse struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
@@ -470,7 +544,7 @@ type UnrecognizedResponse struct {
 
 func (x *UnrecognizedResponse) Reset() {
 	*x = UnrecognizedResponse{}
-	mi := &file_path_qos_cosmos_response_proto_msgTypes[4]
+	mi := &file_path_qos_cosmos_response_proto_msgTypes[5]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -482,7 +556,7 @@ func (x *UnrecognizedResponse) String() string {
 func (*UnrecognizedResponse) ProtoMessage() {}
 
 func (x *UnrecognizedResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_path_qos_cosmos_response_proto_msgTypes[4]
+	mi := &file_path_qos_cosmos_response_proto_msgTypes[5]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -495,7 +569,7 @@ func (x *UnrecognizedResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UnrecognizedResponse.ProtoReflect.Descriptor instead.
 func (*UnrecognizedResponse) Descriptor() ([]byte, []int) {
-	return file_path_qos_cosmos_response_proto_rawDescGZIP(), []int{4}
+	return file_path_qos_cosmos_response_proto_rawDescGZIP(), []int{5}
 }
 
 func (x *UnrecognizedResponse) GetEndpointPayloadLength() uint32 {
@@ -509,7 +583,7 @@ var File_path_qos_cosmos_response_proto protoreflect.FileDescriptor
 
 const file_path_qos_cosmos_response_proto_rawDesc = "" +
 	"\n" +
-	"\x1epath/qos/cosmos_response.proto\x12\bpath.qos\x1a\x16path/qos/jsonrpc.proto\"\x86\x06\n" +
+	"\x1epath/qos/cosmos_response.proto\x12\bpath.qos\x1a\x16path/qos/jsonrpc.proto\"\xf5\x06\n" +
 	"&CosmosEndpointResponseValidationResult\x12`\n" +
 	"\x18response_validation_type\x18\x01 \x01(\x0e2&.path.qos.CosmosResponseValidationTypeR\x16responseValidationType\x12(\n" +
 	"\x10http_status_code\x18\x02 \x01(\x05R\x0ehttpStatusCode\x12W\n" +
@@ -517,19 +591,24 @@ const file_path_qos_cosmos_response_proto_rawDesc = "" +
 	"\x10response_jsonrpc\x18\x04 \x01(\v2\x19.path.qos.JsonRpcResponseH\x00R\x0fresponseJsonrpc\x12c\n" +
 	"\x19response_comet_bft_health\x18\x05 \x01(\v2&.path.qos.CosmosResponseCometBFTHealthH\x00R\x16responseCometBftHealth\x12c\n" +
 	"\x19response_comet_bft_status\x18\x06 \x01(\v2&.path.qos.CosmosResponseCometBFTStatusH\x00R\x16responseCometBftStatus\x12f\n" +
-	"\x1aresponse_cosmos_sdk_status\x18\a \x01(\v2'.path.qos.CosmosResponseCosmosSDKStatusH\x00R\x17responseCosmosSdkStatus\x12U\n" +
-	"\x15response_unrecognized\x18\b \x01(\v2\x1e.path.qos.UnrecognizedResponseH\x00R\x14responseUnrecognizedB\x11\n" +
+	"\x1aresponse_cosmos_sdk_status\x18\a \x01(\v2'.path.qos.CosmosResponseCosmosSDKStatusH\x00R\x17responseCosmosSdkStatus\x12m\n" +
+	"\x1dresponse_evm_jsonrpc_chain_id\x18\b \x01(\v2).path.qos.CosmosResponseEVMJSONRPCChainIDH\x00R\x19responseEvmJsonrpcChainId\x12U\n" +
+	"\x15response_unrecognized\x18\t \x01(\v2\x1e.path.qos.UnrecognizedResponseH\x00R\x14responseUnrecognizedB\x11\n" +
 	"\x0fparsed_responseB\x13\n" +
 	"\x11_validation_error\"C\n" +
 	"\x1cCosmosResponseCometBFTHealth\x12#\n" +
-	"\rhealth_status\x18\x01 \x01(\bR\fhealthStatus\"\x8a\x01\n" +
-	"\x1cCosmosResponseCometBFTStatus\x12\x19\n" +
-	"\bchain_id\x18\x01 \x01(\tR\achainId\x12\x1f\n" +
+	"\rhealth_status\x18\x01 \x01(\bR\fhealthStatus\"\x9e\x01\n" +
+	"\x1cCosmosResponseCometBFTStatus\x12-\n" +
+	"\x13cosmos_sdk_chain_id\x18\x01 \x01(\tR\x10cosmosSdkChainId\x12\x1f\n" +
 	"\vcatching_up\x18\x02 \x01(\bR\n" +
 	"catchingUp\x12.\n" +
 	"\x13latest_block_height\x18\x03 \x01(\tR\x11latestBlockHeight\"O\n" +
 	"\x1dCosmosResponseCosmosSDKStatus\x12.\n" +
-	"\x13latest_block_height\x18\x01 \x01(\x04R\x11latestBlockHeight\"N\n" +
+	"\x13latest_block_height\x18\x01 \x01(\x04R\x11latestBlockHeight\"m\n" +
+	"\x1fCosmosResponseEVMJSONRPCChainID\x12(\n" +
+	"\x10http_status_code\x18\x01 \x01(\x05R\x0ehttpStatusCode\x12 \n" +
+	"\fevm_chain_id\x18\x02 \x01(\tR\n" +
+	"evmChainId\"N\n" +
 	"\x14UnrecognizedResponse\x126\n" +
 	"\x17endpoint_payload_length\x18\x01 \x01(\rR\x15endpointPayloadLength*\xe3\x01\n" +
 	"\x1dCosmosResponseValidationError\x120\n" +
@@ -556,7 +635,7 @@ func file_path_qos_cosmos_response_proto_rawDescGZIP() []byte {
 }
 
 var file_path_qos_cosmos_response_proto_enumTypes = make([]protoimpl.EnumInfo, 2)
-var file_path_qos_cosmos_response_proto_msgTypes = make([]protoimpl.MessageInfo, 5)
+var file_path_qos_cosmos_response_proto_msgTypes = make([]protoimpl.MessageInfo, 6)
 var file_path_qos_cosmos_response_proto_goTypes = []any{
 	(CosmosResponseValidationError)(0),             // 0: path.qos.CosmosResponseValidationError
 	(CosmosResponseValidationType)(0),              // 1: path.qos.CosmosResponseValidationType
@@ -564,22 +643,24 @@ var file_path_qos_cosmos_response_proto_goTypes = []any{
 	(*CosmosResponseCometBFTHealth)(nil),           // 3: path.qos.CosmosResponseCometBFTHealth
 	(*CosmosResponseCometBFTStatus)(nil),           // 4: path.qos.CosmosResponseCometBFTStatus
 	(*CosmosResponseCosmosSDKStatus)(nil),          // 5: path.qos.CosmosResponseCosmosSDKStatus
-	(*UnrecognizedResponse)(nil),                   // 6: path.qos.UnrecognizedResponse
-	(*JsonRpcResponse)(nil),                        // 7: path.qos.JsonRpcResponse
+	(*CosmosResponseEVMJSONRPCChainID)(nil),        // 6: path.qos.CosmosResponseEVMJSONRPCChainID
+	(*UnrecognizedResponse)(nil),                   // 7: path.qos.UnrecognizedResponse
+	(*JsonRpcResponse)(nil),                        // 8: path.qos.JsonRpcResponse
 }
 var file_path_qos_cosmos_response_proto_depIdxs = []int32{
 	1, // 0: path.qos.CosmosEndpointResponseValidationResult.response_validation_type:type_name -> path.qos.CosmosResponseValidationType
 	0, // 1: path.qos.CosmosEndpointResponseValidationResult.validation_error:type_name -> path.qos.CosmosResponseValidationError
-	7, // 2: path.qos.CosmosEndpointResponseValidationResult.response_jsonrpc:type_name -> path.qos.JsonRpcResponse
+	8, // 2: path.qos.CosmosEndpointResponseValidationResult.response_jsonrpc:type_name -> path.qos.JsonRpcResponse
 	3, // 3: path.qos.CosmosEndpointResponseValidationResult.response_comet_bft_health:type_name -> path.qos.CosmosResponseCometBFTHealth
 	4, // 4: path.qos.CosmosEndpointResponseValidationResult.response_comet_bft_status:type_name -> path.qos.CosmosResponseCometBFTStatus
 	5, // 5: path.qos.CosmosEndpointResponseValidationResult.response_cosmos_sdk_status:type_name -> path.qos.CosmosResponseCosmosSDKStatus
-	6, // 6: path.qos.CosmosEndpointResponseValidationResult.response_unrecognized:type_name -> path.qos.UnrecognizedResponse
-	7, // [7:7] is the sub-list for method output_type
-	7, // [7:7] is the sub-list for method input_type
-	7, // [7:7] is the sub-list for extension type_name
-	7, // [7:7] is the sub-list for extension extendee
-	0, // [0:7] is the sub-list for field type_name
+	6, // 6: path.qos.CosmosEndpointResponseValidationResult.response_evm_jsonrpc_chain_id:type_name -> path.qos.CosmosResponseEVMJSONRPCChainID
+	7, // 7: path.qos.CosmosEndpointResponseValidationResult.response_unrecognized:type_name -> path.qos.UnrecognizedResponse
+	8, // [8:8] is the sub-list for method output_type
+	8, // [8:8] is the sub-list for method input_type
+	8, // [8:8] is the sub-list for extension type_name
+	8, // [8:8] is the sub-list for extension extendee
+	0, // [0:8] is the sub-list for field type_name
 }
 
 func init() { file_path_qos_cosmos_response_proto_init() }
@@ -593,6 +674,7 @@ func file_path_qos_cosmos_response_proto_init() {
 		(*CosmosEndpointResponseValidationResult_ResponseCometBftHealth)(nil),
 		(*CosmosEndpointResponseValidationResult_ResponseCometBftStatus)(nil),
 		(*CosmosEndpointResponseValidationResult_ResponseCosmosSdkStatus)(nil),
+		(*CosmosEndpointResponseValidationResult_ResponseEvmJsonrpcChainId)(nil),
 		(*CosmosEndpointResponseValidationResult_ResponseUnrecognized)(nil),
 	}
 	type x struct{}
@@ -601,7 +683,7 @@ func file_path_qos_cosmos_response_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_path_qos_cosmos_response_proto_rawDesc), len(file_path_qos_cosmos_response_proto_rawDesc)),
 			NumEnums:      2,
-			NumMessages:   5,
+			NumMessages:   6,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/proto/path/qos/cosmos.proto
+++ b/proto/path/qos/cosmos.proto
@@ -11,26 +11,29 @@ import "path/qos/request_error.proto";
 
 // CosmosRequestObservations captures all observations made while serving a single Cosmos blockchain service request.
 message CosmosRequestObservations {
-    // chain_id is the blockchain identifier for the QoS implementation.
-    string chain_id = 1;
+    // cosmos_sdk_chain_id is the Cosmos SDK blockchain identifier for the QoS implementation.
+    string cosmos_sdk_chain_id = 1;
+
+    // evm_chain_id is the EVM blockchain identifier for the QoS implementation.
+    string evm_chain_id = 2;
 
     // service_id is the identifier for the QoS implementation.
-    string service_id = 2;
+    string service_id = 3;
 
     // The origin of the request
-    RequestOrigin request_origin = 3;
+    RequestOrigin request_origin = 4;
 
     // Profile of the request: backend service selection and format determination
-    CosmosRequestProfile request_profile = 4;
+    CosmosRequestProfile request_profile = 5;
 
     // Request-level error, i.e. failed without any endpoint responses.
     // Examples: 
     //   - Failed to parse request
     //   - No endpoint response received, i.e. any protocol-level error.
-    optional RequestError request_level_error = 5;
+    optional RequestError request_level_error = 6;
 
     // Cosmos-specific observations from endpoint(s) that responded to the service request.
-    repeated CosmosEndpointObservation endpoint_observations = 6;
+    repeated CosmosEndpointObservation endpoint_observations = 7;
 }
 
 // CosmosEndpointObservation stores a single observation from an endpoint

--- a/proto/path/qos/cosmos_response.proto
+++ b/proto/path/qos/cosmos_response.proto
@@ -56,10 +56,13 @@ message CosmosEndpointResponseValidationResult {
 
 		// Response to CosmosSDK request against API path `/cosmos/base/node/v1beta1/status`
 		CosmosResponseCosmosSDKStatus response_cosmos_sdk_status = 7;
+
+		// Response to Ethereum JSONRPC request using method `eth_chainId`
+		CosmosResponseEVMJSONRPCChainID response_evm_jsonrpc_chain_id = 8;
 		
 		// For unrecognized responses.
 		// These are returned as-is to the user.
-		UnrecognizedResponse response_unrecognized = 8;
+		UnrecognizedResponse response_unrecognized = 9;
 	}
 }
 
@@ -70,7 +73,7 @@ message CosmosResponseCometBFTHealth {
 
 // CosmosResponseCometBFTStatus stores the response to a CometBFT `/status` request
 message CosmosResponseCometBFTStatus {
-    string chain_id = 1;
+    string cosmos_sdk_chain_id = 1;
     bool catching_up = 2;
     string latest_block_height = 3;
 }
@@ -79,6 +82,16 @@ message CosmosResponseCometBFTStatus {
 message CosmosResponseCosmosSDKStatus {
     uint64 latest_block_height = 1;
 }
+
+// CosmosResponseEVMJSONRPCChainID stores the response to an `eth_chainId` request
+// https://ethereum.org/en/developers/docs/apis/json-rpc/#eth_chainid
+message CosmosResponseEVMJSONRPCChainID {
+	// The HTTP status code received from the endpoint
+	int32 http_status_code = 1;
+  
+	// The chain ID value returned in the response
+	string evm_chain_id = 2;
+  }
 
 // UnrecognizedResponse handles responses that are not validated before being returned to the user.
 message UnrecognizedResponse {

--- a/qos/cosmos/check_cometbft_status.go
+++ b/qos/cosmos/check_cometbft_status.go
@@ -19,10 +19,10 @@ const methodStatusCheck = jsonrpc.Method("status")
 const checkStatusInterval = 10 * time.Second
 
 var (
-	errNoStatusObs       = fmt.Errorf("endpoint has not had an observation of its response to a %q request", methodStatusCheck)
-	errInvalidStatusObs  = fmt.Errorf("endpoint returned an invalid response to a %q request", methodStatusCheck)
-	errInvalidChainIDObs = fmt.Errorf("endpoint returned an invalid chain ID in its response to a %q request", methodStatusCheck)
-	errCatchingUpObs     = fmt.Errorf("endpoint is catching up to the network in its response to a %q request", methodStatusCheck)
+	errNoCometBFTStatusObs       = fmt.Errorf("endpoint has not had an observation of its response to a %q request", methodStatusCheck)
+	errInvalidCometBFTStatusObs  = fmt.Errorf("endpoint returned an invalid response to a %q request", methodStatusCheck)
+	errInvalidCometBFTChainIDObs = fmt.Errorf("endpoint returned an invalid chain ID in its response to a %q request", methodStatusCheck)
+	errCometBFTCatchingUpObs     = fmt.Errorf("endpoint is catching up to the network in its response to a %q request", methodStatusCheck)
 )
 
 // endpointCheckCometBFTStatus is a check that ensures the endpoint's status information is valid.
@@ -57,10 +57,10 @@ func (e *endpointCheckCometBFTStatus) getRequest() jsonrpc.Request {
 // GetChainID returns the parsed chain ID value for the endpoint.
 func (e *endpointCheckCometBFTStatus) GetChainID() (string, error) {
 	if e.chainID == nil {
-		return "", errNoStatusObs
+		return "", errNoCometBFTStatusObs
 	}
 	if *e.chainID == "" {
-		return "", errInvalidChainIDObs
+		return "", errInvalidCometBFTStatusObs
 	}
 	return *e.chainID, nil
 }
@@ -68,7 +68,7 @@ func (e *endpointCheckCometBFTStatus) GetChainID() (string, error) {
 // GetCatchingUp returns whether the endpoint is catching up.
 func (e *endpointCheckCometBFTStatus) GetCatchingUp() (bool, error) {
 	if e.catchingUp == nil {
-		return false, errNoStatusObs
+		return false, errNoCometBFTStatusObs
 	}
 	return *e.catchingUp, nil
 }
@@ -76,10 +76,10 @@ func (e *endpointCheckCometBFTStatus) GetCatchingUp() (bool, error) {
 // GetLatestBlockHeight returns the parsed latest block height value for the endpoint.
 func (e *endpointCheckCometBFTStatus) GetLatestBlockHeight() (uint64, error) {
 	if e.latestBlockHeight == nil {
-		return 0, errNoStatusObs
+		return 0, errNoCometBFTStatusObs
 	}
 	if *e.latestBlockHeight == 0 {
-		return 0, errInvalidStatusObs
+		return 0, errInvalidCometBFTStatusObs
 	}
 	return *e.latestBlockHeight, nil
 }

--- a/qos/cosmos/check_evm_chainid.go
+++ b/qos/cosmos/check_evm_chainid.go
@@ -14,7 +14,7 @@ const idEVMChainIDCheck = 1001
 const methodEVMChainID = jsonrpc.Method("eth_chainId")
 
 // TODO_IMPROVE(@commoddity): determine an appropriate interval for checking the chain ID.
-const checkChainIDInterval = 20 * time.Minute
+const checkEVMChainIDInterval = 20 * time.Minute
 
 var (
 	errNoEVMChainIDObs      = fmt.Errorf("endpoint has not had an observation of its response to a %q request", methodEVMChainID)

--- a/qos/cosmos/check_evm_chainid.go
+++ b/qos/cosmos/check_evm_chainid.go
@@ -1,0 +1,54 @@
+package cosmos
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/buildwithgrove/path/qos/jsonrpc"
+)
+
+const idEVMChainIDCheck = 1001
+
+// methodChainID is the JSON-RPC method for getting the chain ID.
+// Reference: https://ethereum.org/en/developers/docs/apis/json-rpc/#eth_chainid
+const methodEVMChainID = jsonrpc.Method("eth_chainId")
+
+// TODO_IMPROVE(@commoddity): determine an appropriate interval for checking the chain ID.
+const checkChainIDInterval = 20 * time.Minute
+
+var (
+	errNoEVMChainIDObs      = fmt.Errorf("endpoint has not had an observation of its response to a %q request", methodEVMChainID)
+	errInvalidEVMChainIDObs = fmt.Errorf("endpoint returned an invalid response to a %q request", methodEVMChainID)
+)
+
+// endpointCheckChainID is a check that ensures the endpoint's chain ID is the same as the expected chain ID.
+// It is used to ensure that the endpoint is on the correct chain.
+type endpointCheckEVMChainID struct {
+	// chainIDResponse stores the result of processing the endpoint's response to an `eth_chainId` request.
+	// It is nil if there has NOT been an observation of the endpoint's response to an `eth_chainId` request.
+	chainID   *string
+	expiresAt time.Time
+}
+
+// getRequest returns a JSONRPC request to check the chain ID.
+// eg. '{"jsonrpc":"2.0","id":1,"method":"eth_chainId"}'
+func (e *endpointCheckEVMChainID) getRequest() jsonrpc.Request {
+	return jsonrpc.Request{
+		JSONRPC: jsonrpc.Version2,
+		ID:      jsonrpc.IDFromInt(idEVMChainIDCheck),
+		Method:  jsonrpc.Method(methodEVMChainID),
+	}
+}
+
+// IsExpired returns true if the check has expired and needs to be refreshed.
+func (e *endpointCheckEVMChainID) IsExpired() bool {
+	return time.Now().After(e.expiresAt)
+}
+
+// GetChainID returns the chain ID from the check.
+func (e *endpointCheckEVMChainID) GetChainID() (string, error) {
+	if e.chainID == nil {
+		return "", errNoEVMChainIDObs
+	}
+	return *e.chainID, nil
+}

--- a/qos/cosmos/endpoint.go
+++ b/qos/cosmos/endpoint.go
@@ -16,4 +16,5 @@ type endpoint struct {
 	checkCometBFTStatus endpointCheckCometBFTStatus // Checks chain ID, catching up status, and latest block height via /status
 	checkCometBFTHealth endpointCheckCometBFTHealth // Checks node health via /health
 	checkCosmosStatus   endpointCheckCosmosStatus   // Checks Cosmos SDK status via /status
+	checkEVMChainID     endpointCheckEVMChainID     // Checks EVM chain ID via eth_chainId
 }

--- a/qos/cosmos/endpoint_selection.go
+++ b/qos/cosmos/endpoint_selection.go
@@ -242,23 +242,23 @@ func (ss *serviceState) isCometBFTStatusValid(check endpointCheckCometBFTStatus)
 	// Check chain ID
 	chainID, err := check.GetChainID()
 	if err != nil {
-		return fmt.Errorf("%w: %v", errNoStatusObs, err)
+		return fmt.Errorf("%w: %v", errNoCometBFTStatusObs, err)
 	}
 
 	expectedChainID := ss.serviceQoSConfig.getCosmosSDKChainID()
 	if chainID != expectedChainID {
 		return fmt.Errorf("%w: chain ID %s does not match expected chain ID %s",
-			errInvalidChainIDObs, chainID, expectedChainID)
+			errInvalidCometBFTChainIDObs, chainID, expectedChainID)
 	}
 
 	// Check if the endpoint is catching up to the network.
 	catchingUp, err := check.GetCatchingUp()
 	if err != nil {
-		return fmt.Errorf("%w: %v", errNoStatusObs, err)
+		return fmt.Errorf("%w: %v", errNoCometBFTStatusObs, err)
 	}
 
 	if catchingUp {
-		return fmt.Errorf("%w: endpoint is catching up to the network", errCatchingUpObs)
+		return fmt.Errorf("%w: endpoint is catching up to the network", errCometBFTCatchingUpObs)
 	}
 
 	return nil
@@ -274,7 +274,7 @@ func (ss *serviceState) isCometBFTBlockHeightValid(check endpointCheckCometBFTSt
 	// Check if the endpoint's block height is within the sync allowance.
 	latestBlockHeight, err := check.GetLatestBlockHeight()
 	if err != nil {
-		return fmt.Errorf("%w: %v", errNoStatusObs, err)
+		return fmt.Errorf("%w: %v", errNoCometBFTStatusObs, err)
 	}
 	if err := ss.validateBlockHeightSyncAllowance(latestBlockHeight); err != nil {
 		return fmt.Errorf("cometBFT block height sync allowance validation failed: %w", err)
@@ -302,7 +302,7 @@ func (ss *serviceState) isCosmosStatusValid(check endpointCheckCosmosStatus) err
 	// Check if the endpoint's block height is within the sync allowance.
 	latestBlockHeight, err := check.GetHeight()
 	if err != nil {
-		return fmt.Errorf("%w: %v", errNoStatusObs, err)
+		return fmt.Errorf("%w: %v", errNoCosmosStatusObs, err)
 	}
 	if err := ss.validateBlockHeightSyncAllowance(latestBlockHeight); err != nil {
 		return fmt.Errorf("cosmos SDK block height sync allowance validation failed: %w", err)
@@ -342,13 +342,13 @@ func (ss *serviceState) validateEndpointEVMChecks(endpoint endpoint) error {
 func (ss *serviceState) isEVMChainIDValid(check endpointCheckEVMChainID) error {
 	evmChainID, err := check.GetChainID()
 	if err != nil {
-		return fmt.Errorf("%w: %v", errNoStatusObs, err)
+		return err
 	}
 
 	expectedEVMChainID := ss.serviceQoSConfig.getEVMChainID()
 	if evmChainID != expectedEVMChainID {
 		return fmt.Errorf("%w: chain ID %s does not match expected chain ID %s",
-			errInvalidChainIDObs, evmChainID, expectedEVMChainID)
+			errInvalidEVMChainIDObs, evmChainID, expectedEVMChainID)
 	}
 
 	return nil

--- a/qos/cosmos/endpoint_store.go
+++ b/qos/cosmos/endpoint_store.go
@@ -119,6 +119,9 @@ func applyObservation(
 	case *qosobservations.CosmosEndpointResponseValidationResult_ResponseUnrecognized:
 		applyUnrecognizedResponseObservation(endpoint, response.ResponseUnrecognized)
 		endpointWasMutated = true
+	case *qosobservations.CosmosEndpointResponseValidationResult_ResponseEvmJsonrpcChainId:
+		applyEVMChainIDObservation(endpoint, response.ResponseEvmJsonrpcChainId)
+		endpointWasMutated = true
 	}
 
 	return endpointWasMutated
@@ -167,6 +170,15 @@ func applyCosmosSDKStatusObservation(endpoint *endpoint, statusResponse *qosobse
 	latestBlockHeight := statusResponse.LatestBlockHeight
 	endpoint.checkCosmosStatus = endpointCheckCosmosStatus{
 		latestBlockHeight: &latestBlockHeight,
+	}
+}
+
+// applyEVMChainIDObservation updates the chain ID check if a valid observation is provided.
+func applyEVMChainIDObservation(endpoint *endpoint, chainIDResponse *qosobservations.CosmosResponseEVMJSONRPCChainID) {
+	evmChainID := chainIDResponse.EvmChainId
+	endpoint.checkEVMChainID = endpointCheckEVMChainID{
+		chainID:   &evmChainID,
+		expiresAt: time.Now().Add(checkEVMChainIDInterval),
 	}
 }
 

--- a/qos/cosmos/endpoint_store.go
+++ b/qos/cosmos/endpoint_store.go
@@ -150,7 +150,7 @@ func applyCometBFTHealthObservation(endpoint *endpoint, healthResponse *qosobser
 
 // applyCometBFTStatusObservation updates the status check if a valid observation is provided.
 func applyCometBFTStatusObservation(endpoint *endpoint, statusResponse *qosobservations.CosmosResponseCometBFTStatus) {
-	chainID := statusResponse.ChainId
+	chainID := statusResponse.CosmosSdkChainId
 	catchingUp := statusResponse.CatchingUp
 	blockHeight := parseBlockHeightResponse(statusResponse.LatestBlockHeight)
 

--- a/qos/cosmos/qos.go
+++ b/qos/cosmos/qos.go
@@ -33,14 +33,20 @@ type QoS struct {
 
 // NewQoSInstance builds and returns an instance of the CosmosSDK QoS service.
 func NewQoSInstance(logger polylog.Logger, config CosmosSDKServiceQoSConfig) *QoS {
-	cosmosSDKChainID := config.getCosmosSDKChainID()
 	serviceId := config.GetServiceID()
+
+	cosmosSDKChainID := config.getCosmosSDKChainID()
+	// Some CosmosSDK services may have an EVM chain ID.
+	evmChainID := config.getEVMChainID()
 
 	logger = logger.With(
 		"qos_instance", "cosmossdk",
 		"service_id", serviceId,
-		"cosmossdk_chain_id", cosmosSDKChainID,
+		"cosmos_sdk_chain_id", cosmosSDKChainID,
 	)
+	if evmChainID != "" {
+		logger = logger.With("evm_chain_id", evmChainID)
+	}
 
 	store := &endpointStore{
 		logger: logger,
@@ -55,11 +61,12 @@ func NewQoSInstance(logger polylog.Logger, config CosmosSDKServiceQoSConfig) *Qo
 	}
 
 	requestValidator := &requestValidator{
-		logger:        logger,
-		serviceID:     serviceId,
-		chainID:       cosmosSDKChainID,
-		serviceState:  serviceState,
-		supportedAPIs: config.getSupportedAPIs(),
+		logger:           logger,
+		serviceID:        serviceId,
+		cosmosSDKChainID: cosmosSDKChainID,
+		evmChainID:       evmChainID,
+		serviceState:     serviceState,
+		supportedAPIs:    config.getSupportedAPIs(),
 	}
 
 	return &QoS{

--- a/qos/cosmos/request_validator.go
+++ b/qos/cosmos/request_validator.go
@@ -18,11 +18,12 @@ import (
 // requestValidator handles validation for all Cosmos service requests
 // Coordinates between different protocol validators (JSONRPC, REST)
 type requestValidator struct {
-	logger        polylog.Logger
-	chainID       string
-	serviceID     protocol.ServiceID
-	supportedAPIs map[sharedtypes.RPCType]struct{}
-	serviceState  *serviceState
+	logger           polylog.Logger
+	cosmosSDKChainID string
+	evmChainID       string
+	serviceID        protocol.ServiceID
+	supportedAPIs    map[sharedtypes.RPCType]struct{}
+	serviceState     *serviceState
 }
 
 // validateHTTPRequest validates an HTTP request and routes to appropriate sub-validator
@@ -86,7 +87,7 @@ func (rv *requestValidator) createHTTPBodyReadFailureContext(err error) gateway.
 	response := jsonrpc.NewErrResponseInternalErr(jsonrpc.ID{}, err)
 
 	// Create the observations object with the HTTP body read failure observation
-	observations := createHTTPBodyReadFailureObservation(rv.serviceID, rv.chainID, err, response)
+	observations := createHTTPBodyReadFailureObservation(rv.serviceID, rv.cosmosSDKChainID, err, response)
 
 	// Build and return the error context
 	return &qos.RequestErrorContext{
@@ -100,14 +101,14 @@ func (rv *requestValidator) createHTTPBodyReadFailureContext(err error) gateway.
 
 func createHTTPBodyReadFailureObservation(
 	serviceID protocol.ServiceID,
-	chainID string,
+	cosmosSDKChainID string,
 	err error,
 	jsonrpcResponse jsonrpc.Response,
 ) *qosobservations.Observations_Cosmos {
 	return &qosobservations.Observations_Cosmos{
 		Cosmos: &qosobservations.CosmosRequestObservations{
-			ServiceId: string(serviceID),
-			ChainId:   chainID,
+			ServiceId:        string(serviceID),
+			CosmosSdkChainId: cosmosSDKChainID,
 			RequestLevelError: &qosobservations.RequestError{
 				ErrorKind:      qosobservations.RequestErrorKind_REQUEST_ERROR_INTERNAL_READ_HTTP_ERROR,
 				ErrorDetails:   err.Error(),

--- a/qos/cosmos/request_validator_jsonrpc.go
+++ b/qos/cosmos/request_validator_jsonrpc.go
@@ -162,9 +162,9 @@ func (rv *requestValidator) buildJSONRPCRequestObservations(
 ) *qosobservations.CosmosRequestObservations {
 
 	return &qosobservations.CosmosRequestObservations{
-		ChainId:       rv.chainID,
-		ServiceId:     string(rv.serviceID),
-		RequestOrigin: requestOrigin,
+		CosmosSdkChainId: rv.cosmosSDKChainID,
+		ServiceId:        string(rv.serviceID),
+		RequestOrigin:    requestOrigin,
 		RequestProfile: &qosobservations.CosmosRequestProfile{
 			BackendServiceDetails: &qosobservations.BackendServiceDetails{
 				BackendServiceType: convertToProtoBackendServiceType(rpcType),
@@ -223,9 +223,9 @@ func (rv *requestValidator) createJSONRPCParseFailureObservation(
 	jsonrpcResponse jsonrpc.Response,
 ) *qosobservations.CosmosRequestObservations {
 	return &qosobservations.CosmosRequestObservations{
-		ServiceId:     string(rv.serviceID),
-		ChainId:       rv.chainID,
-		RequestOrigin: qosobservations.RequestOrigin_REQUEST_ORIGIN_ORGANIC,
+		ServiceId:        string(rv.serviceID),
+		CosmosSdkChainId: rv.cosmosSDKChainID,
+		RequestOrigin:    qosobservations.RequestOrigin_REQUEST_ORIGIN_ORGANIC,
 		RequestLevelError: &qosobservations.RequestError{
 			ErrorKind:      qosobservations.RequestErrorKind_REQUEST_ERROR_USER_ERROR_JSONRPC_PARSE_ERROR,
 			ErrorDetails:   truncateErrorMessage(err.Error()),
@@ -261,9 +261,9 @@ func (rv *requestValidator) createJSONRPCUnsupportedRPCTypeObservation(
 	jsonrpcResponse jsonrpc.Response,
 ) *qosobservations.CosmosRequestObservations {
 	return &qosobservations.CosmosRequestObservations{
-		ServiceId:     string(rv.serviceID),
-		ChainId:       rv.chainID,
-		RequestOrigin: qosobservations.RequestOrigin_REQUEST_ORIGIN_ORGANIC,
+		ServiceId:        string(rv.serviceID),
+		CosmosSdkChainId: rv.cosmosSDKChainID,
+		RequestOrigin:    qosobservations.RequestOrigin_REQUEST_ORIGIN_ORGANIC,
 		RequestProfile: &qosobservations.CosmosRequestProfile{
 			BackendServiceDetails: &qosobservations.BackendServiceDetails{
 				BackendServiceType: convertToProtoBackendServiceType(rpcType),
@@ -307,9 +307,9 @@ func (rv *requestValidator) createJSONRPCServicePayloadBuildFailureObservation(
 	jsonrpcResponse jsonrpc.Response,
 ) *qosobservations.CosmosRequestObservations {
 	return &qosobservations.CosmosRequestObservations{
-		ServiceId:     string(rv.serviceID),
-		ChainId:       rv.chainID,
-		RequestOrigin: qosobservations.RequestOrigin_REQUEST_ORIGIN_ORGANIC,
+		ServiceId:        string(rv.serviceID),
+		CosmosSdkChainId: rv.cosmosSDKChainID,
+		RequestOrigin:    qosobservations.RequestOrigin_REQUEST_ORIGIN_ORGANIC,
 		RequestProfile: &qosobservations.CosmosRequestProfile{
 			ParsedRequest: &qosobservations.CosmosRequestProfile_JsonrpcRequest{
 				JsonrpcRequest: jsonrpcReq.GetObservation(),

--- a/qos/cosmos/request_validator_rest.go
+++ b/qos/cosmos/request_validator_rest.go
@@ -151,9 +151,9 @@ func (rv *requestValidator) buildRESTRequestObservations(
 	// Note: We don't have access to headers here, but this would be where we'd extract it
 
 	return &qosobservations.CosmosRequestObservations{
-		ChainId:       rv.chainID,
-		ServiceId:     string(rv.serviceID),
-		RequestOrigin: requestOrigin,
+		CosmosSdkChainId: rv.cosmosSDKChainID,
+		ServiceId:        string(rv.serviceID),
+		RequestOrigin:    requestOrigin,
 		RequestProfile: &qosobservations.CosmosRequestProfile{
 			BackendServiceDetails: &qosobservations.BackendServiceDetails{
 				BackendServiceType: convertToProtoBackendServiceType(rpcType),
@@ -225,9 +225,9 @@ func (rv *requestValidator) createRESTUnsupportedRPCTypeObservation(
 	jsonrpcResponse jsonrpc.Response,
 ) *qosobservations.CosmosRequestObservations {
 	return &qosobservations.CosmosRequestObservations{
-		ServiceId:     string(rv.serviceID),
-		ChainId:       rv.chainID,
-		RequestOrigin: qosobservations.RequestOrigin_REQUEST_ORIGIN_ORGANIC,
+		ServiceId:        string(rv.serviceID),
+		CosmosSdkChainId: rv.cosmosSDKChainID,
+		RequestOrigin:    qosobservations.RequestOrigin_REQUEST_ORIGIN_ORGANIC,
 		RequestProfile: &qosobservations.CosmosRequestProfile{
 			BackendServiceDetails: &qosobservations.BackendServiceDetails{
 				BackendServiceType: convertToProtoBackendServiceType(rpcType),

--- a/qos/cosmos/response_cometbft_status.go
+++ b/qos/cosmos/response_cometbft_status.go
@@ -46,7 +46,7 @@ type (
 	}
 )
 
-// responseValidatorCometBFTStatus implements jsonrpcResponseValidator for /status endpoint
+// responseValidatorCometBFTStatus implements jsonrpcResponseValidator for status method
 // Takes a parsed JSONRPC response and validates it as a status response
 func responseValidatorCometBFTStatus(logger polylog.Logger, jsonrpcResponse jsonrpc.Response) response {
 	logger = logger.With("response_validator", "status")
@@ -102,7 +102,7 @@ func responseValidatorCometBFTStatus(logger polylog.Logger, jsonrpcResponse json
 	return &responseCometBFTStatus{
 		logger:            logger,
 		jsonRPCResponse:   jsonrpcResponse,
-		chainID:           result.NodeInfo.Network,
+		cosmosSDKChainID:  result.NodeInfo.Network,
 		catchingUp:        result.SyncInfo.CatchingUp,
 		latestBlockHeight: result.SyncInfo.LatestBlockHeight,
 	}
@@ -116,10 +116,10 @@ type responseCometBFTStatus struct {
 	// jsonRPCResponse stores the JSON-RPC response parsed from an endpoint's response bytes
 	jsonRPCResponse jsonrpc.Response
 
-	// chainID stores the chain ID of the endpoint
+	// cosmosSDKChainID stores the chain ID of the endpoint
 	// Comes from the `NodeInfo.Network` field in the `/status` response
 	// Reference: https://docs.cometbft.com/v1.0/spec/rpc/#status
-	chainID string
+	cosmosSDKChainID string
 
 	// catchingUp indicates if the endpoint is catching up to the network
 	// Comes from the `SyncInfo.CatchingUp` field in the `/status` response
@@ -143,7 +143,7 @@ func (r *responseCometBFTStatus) GetObservation() qosobservations.CosmosEndpoint
 			ValidationError:        nil, // No validation error for successfully processed responses
 			ParsedResponse: &qosobservations.CosmosEndpointResponseValidationResult_ResponseCometBftStatus{
 				ResponseCometBftStatus: &qosobservations.CosmosResponseCometBFTStatus{
-					ChainId:           r.chainID,
+					CosmosSdkChainId:  r.cosmosSDKChainID,
 					CatchingUp:        r.catchingUp,
 					LatestBlockHeight: r.latestBlockHeight,
 				},

--- a/qos/cosmos/response_evm_chainid.go
+++ b/qos/cosmos/response_evm_chainid.go
@@ -1,0 +1,116 @@
+package cosmos
+
+import (
+	"encoding/json"
+
+	"github.com/pokt-network/poktroll/pkg/polylog"
+
+	"github.com/buildwithgrove/path/gateway"
+	qosobservations "github.com/buildwithgrove/path/observation/qos"
+	"github.com/buildwithgrove/path/qos"
+	"github.com/buildwithgrove/path/qos/jsonrpc"
+)
+
+// responseEVMChainID provides the functionality required from a response by a requestContext instance.
+var _ response = responseEVMChainID{}
+
+// responseValidatorEVMChainID implements jsonrpcResponseValidator for eth_chainId method
+// Takes a parsed JSONRPC response and validates it as a chain ID response
+func responseValidatorEVMChainID(logger polylog.Logger, jsonrpcResponse jsonrpc.Response) response {
+	logger = logger.With("response_validator", "eth_chainId")
+
+	// The endpoint returned an error: no need to do further processing of the response
+	if jsonrpcResponse.IsError() {
+		logger.Warn().
+			Str("jsonrpc_error", jsonrpcResponse.Error.Message).
+			Int("jsonrpc_error_code", jsonrpcResponse.Error.Code).
+			Msg("Endpoint returned JSON-RPC error for eth_chainId request")
+
+		return &responseEVMChainID{
+			logger:          logger,
+			jsonRPCResponse: jsonrpcResponse,
+		}
+	}
+
+	// Marshal the result to parse it as ResultStatus
+	resultBytes, err := json.Marshal(jsonrpcResponse.Result)
+	if err != nil {
+		logger.Error().
+			Err(err).
+			Msg("Failed to marshal JSON-RPC result for eth_chainId")
+
+		// Return error response but still include the original JSONRPC response
+		return &responseEVMChainID{
+			logger:          logger,
+			jsonRPCResponse: jsonrpcResponse,
+		}
+	}
+
+	// Then unmarshal the JSON bytes into the ResultStatus struct
+	var evmChainID string
+	if err := json.Unmarshal(resultBytes, &evmChainID); err != nil {
+		logger.Error().
+			Err(err).
+			Str("result_data", string(resultBytes)).
+			Msg("Failed to unmarshal JSON-RPC result into string")
+
+		// Return error response but still include the original JSONRPC response
+		return &responseEVMChainID{
+			logger:          logger,
+			jsonRPCResponse: jsonrpcResponse,
+		}
+	}
+
+	logger.Error().
+		Str("evm_chain_id", evmChainID).
+		Msg("Successfully parsed eth_chainId response")
+
+	return &responseEVMChainID{
+		logger:          logger,
+		jsonRPCResponse: jsonrpcResponse,
+		evmChainID:      evmChainID,
+	}
+}
+
+// responseEVMChainID captures the fields expected in a
+// response to an `eth_chainId` request.
+type responseEVMChainID struct {
+	logger polylog.Logger
+
+	// jsonRPCResponse stores the JSONRPC response parsed from an endpoint's response bytes.
+	jsonRPCResponse jsonrpc.Response
+
+	// evmChainID captures the `result` field of a JSONRPC response to an `eth_chainId` request.
+	evmChainID string
+}
+
+// GetObservation returns an observation of the endpoint's response to an `eth_chainId` request.
+// Implements the response interface.
+// Reference: https://ethereum.org/en/developers/docs/apis/json-rpc/#eth_chainid
+func (r responseEVMChainID) GetObservation() qosobservations.CosmosEndpointObservation {
+	return qosobservations.CosmosEndpointObservation{
+		EndpointResponseValidationResult: &qosobservations.CosmosEndpointResponseValidationResult{
+			ResponseValidationType: qosobservations.CosmosResponseValidationType_COSMOS_RESPONSE_VALIDATION_TYPE_JSONRPC,
+			HttpStatusCode:         int32(r.jsonRPCResponse.GetRecommendedHTTPStatusCode()),
+			ValidationError:        nil, // No validation error for successfully processed responses
+			ParsedResponse: &qosobservations.CosmosEndpointResponseValidationResult_ResponseEvmJsonrpcChainId{
+				ResponseEvmJsonrpcChainId: &qosobservations.CosmosResponseEVMJSONRPCChainID{
+					HttpStatusCode: int32(r.getHTTPStatusCode()),
+					EvmChainId:     r.evmChainID,
+				},
+			},
+		},
+	}
+}
+
+// GetHTTPResponse builds and returns the HTTP response
+// Implements the response interface
+func (r responseEVMChainID) GetHTTPResponse() gateway.HTTPResponse {
+	return qos.BuildHTTPResponseFromJSONRPCResponse(r.logger, r.jsonRPCResponse)
+}
+
+// getHTTPStatusCode returns an HTTP status code corresponding to the underlying JSON-RPC response code.
+// DEV_NOTE: This is an opinionated mapping following best practice but not enforced by any specifications or standards.
+func (r responseEVMChainID) getHTTPStatusCode() int {
+	return r.jsonRPCResponse.GetRecommendedHTTPStatusCode()
+}

--- a/qos/cosmos/response_jsonrpc.go
+++ b/qos/cosmos/response_jsonrpc.go
@@ -36,8 +36,9 @@ var (
 
 	// Maps JSONRPC requests to their corresponding response validators, based on the JSONRPC method.
 	jsonrpcRequestEndpointResponseValidators = map[string]jsonrpcResponseValidator{
-		"health": responseValidatorCometBFTHealth,
-		"status": responseValidatorCometBFTStatus,
+		"health":      responseValidatorCometBFTHealth,
+		"status":      responseValidatorCometBFTStatus,
+		"eth_chainId": responseValidatorEVMChainID,
 	}
 )
 

--- a/qos/cosmos/service_qos_config.go
+++ b/qos/cosmos/service_qos_config.go
@@ -25,6 +25,7 @@ type ServiceQoSConfig interface {
 type CosmosSDKServiceQoSConfig interface {
 	ServiceQoSConfig // Using locally defined interface to avoid circular dependency
 	getCosmosSDKChainID() string
+	getEVMChainID() string
 	getSyncAllowance() uint64
 	getSupportedAPIs() map[sharedtypes.RPCType]struct{}
 }
@@ -33,11 +34,13 @@ type CosmosSDKServiceQoSConfig interface {
 func NewCosmosSDKServiceQoSConfig(
 	serviceID protocol.ServiceID,
 	cosmosSDKChainID string,
+	evmChainID string,
 	supportedAPIs map[sharedtypes.RPCType]struct{},
 ) CosmosSDKServiceQoSConfig {
 	return cosmosSDKServiceQoSConfig{
 		serviceID:        serviceID,
 		cosmosSDKChainID: cosmosSDKChainID,
+		evmChainID:       evmChainID,
 		supportedAPIs:    supportedAPIs,
 	}
 }
@@ -48,6 +51,7 @@ var _ CosmosSDKServiceQoSConfig = (*cosmosSDKServiceQoSConfig)(nil)
 type cosmosSDKServiceQoSConfig struct {
 	serviceID        protocol.ServiceID
 	cosmosSDKChainID string
+	evmChainID       string
 	syncAllowance    uint64
 	supportedAPIs    map[sharedtypes.RPCType]struct{}
 }
@@ -68,6 +72,12 @@ func (cosmosSDKServiceQoSConfig) GetServiceQoSType() string {
 // Implements the CosmosSDKServiceQoSConfig interface.
 func (c cosmosSDKServiceQoSConfig) getCosmosSDKChainID() string {
 	return c.cosmosSDKChainID
+}
+
+// getEVMChainID returns the EVM chain ID.
+// Implements the CosmosSDKServiceQoSConfig interface.
+func (c cosmosSDKServiceQoSConfig) getEVMChainID() string {
+	return c.evmChainID
 }
 
 // getSyncAllowance returns the amount of blocks behind the perceived

--- a/qos/cosmos/service_state.go
+++ b/qos/cosmos/service_state.go
@@ -132,20 +132,20 @@ func (ss *serviceState) getDisqualifiedEndpointsResponse(serviceID protocol.Serv
 				qosLevelDataResponse.EmptyResponseCount++
 
 			// Endpoint is disqualified due to a missing or invalid chain ID (status check related).
-			case errors.Is(err, errInvalidChainIDObs):
+			case errors.Is(err, errInvalidCometBFTChainIDObs),
+				errors.Is(err, errNoEVMChainIDObs),
+				errors.Is(err, errInvalidEVMChainIDObs):
 				qosLevelDataResponse.ChainIDCheckErrorsCount++
 
 			// Endpoint is disqualified due to block number issues (status check related).
-			case errors.Is(err, errOutsideSyncAllowanceBlockNumberObs):
+			case errors.Is(err, errOutsideSyncAllowanceBlockNumberObs),
+				errors.Is(err, errNoCometBFTStatusObs):
 				qosLevelDataResponse.BlockNumberCheckErrorsCount++
 
-			// Other CosmosSDK-specific errors (health, status, catching up) - not tracked individually
-			case errors.Is(err, errNoHealthObs),
-				errors.Is(err, errInvalidHealthObs),
-				errors.Is(err, errNoStatusObs),
-				errors.Is(err, errInvalidStatusObs),
-				errors.Is(err, errCatchingUpObs):
-				// These are tracked in the DisqualifiedEndpoints map but not counted separately
+			// TODO_TECHDEBT(@commoddity): Update QoSDisqualifiedEndpoint to
+			// track all CosmosSDK-specific errors in a dedicated struct.
+			//
+			// Other CosmosSDK-specific errors - not tracked individually
 
 			default:
 				ss.logger.Error().Err(err).Msgf("SHOULD NEVER HAPPEN: unknown error for endpoint: %s", endpointAddr)


### PR DESCRIPTION

## 🚨 TODO_IN_THIS_PR 

Do not merge until these TODOs are resolved:
- TODO_IN_THIS_PR(@commoddity): Add EVM chain ID to interpreter. - observation/qos/cosmos_interpreter.go

## 🌿 Summary

Add EVM chain ID validation for Cosmos SDK QoS checks to ensure endpoints are on the correct EVM-compatible chain.

### 🌱 Primary Changes:
- Added EVM chain ID validation via `eth_chainId` JSON-RPC method for Cosmos SDK QoS checks
- Updated Cosmos SDK QoS config to include optional EVM chain ID parameter
- Implemented new response validator for `eth_chainId` JSON-RPC responses

### 🍃 Secondary changes:
- Renamed `chain_id` references to `cosmos_sdk_chain_id` for clarity
- Updated metrics and protobuf definitions to include both Cosmos SDK and EVM chain IDs
- Added new error types for EVM chain ID validation failures


## 💡 New TODOs 

New TODOs introduced in this PR:
- TODO_IMPROVE(@commoddity): determine an appropriate interval for checking the chain ID. - qos/cosmos/check_evm_chainid.go
- TODO_TECHDEBT(@commoddity): Update QoSDisqualifiedEndpoint to track all CosmosSDK-specific errors in a dedicated struct.  Other CosmosSDK-specific errors - not tracked individually - qos/cosmos/service_state.go

## 🛠️ Type of change

Select one or more from the following:

- [ ] New feature, functionality or library
- [ ] Bug fix
- [ ] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## 🤯 Sanity Checklist

- [ ] I have updated the GitHub Issue 'assignees', 'reviewers', 'labels', 'project', 'iteration' and 'milestone'
- [ ] For docs, I have run 'make docusaurus_start'
- [ ] For code, I have run 'make test_all'
- [ ] For configurations, I have update the documentation
- [ ] I added TODOs where applicable
