### PR TITLE
[Protocol][Shannon] Protocol only sets RPCType HTTP header on valid values

### DIFF
--- a/protocol/shannon/context.go
+++ b/protocol/shannon/context.go
@@ -14,6 +14,7 @@ import (
 	apptypes "github.com/pokt-network/poktroll/x/application/types"
 	servicetypes "github.com/pokt-network/poktroll/x/service/types"
 	sessiontypes "github.com/pokt-network/poktroll/x/session/types"
+	sharedtypes "github.com/pokt-network/poktroll/x/shared/types"
 	sdk "github.com/pokt-network/shannon-sdk"
 
 	"github.com/buildwithgrove/path/gateway"
@@ -189,8 +190,11 @@ func buildHeaders(payload protocol.Payload) map[string]string {
 		headers[key] = value
 	}
 
-	// Add RPCType header
-	headers[proxy.RPCTypeHeader] = strconv.Itoa(int(payload.RPCType))
+	// Set the RPCType HTTP header, if set on the payload.
+	// Used by endpoint/relay miner to determine correct backend service.
+	if payload.RPCType != sharedtypes.RPCType_UNKNOWN_RPC {
+		headers[proxy.RPCTypeHeader] = strconv.Itoa(int(payload.RPCType))
+	}
 
 	return headers
 }

--- a/protocol/shannon/log.go
+++ b/protocol/shannon/log.go
@@ -4,6 +4,7 @@ import (
 	"github.com/pokt-network/poktroll/pkg/polylog"
 	"github.com/pokt-network/poktroll/x/session/types"
 
+	"github.com/buildwithgrove/path/log"
 	"github.com/buildwithgrove/path/protocol"
 )
 
@@ -92,5 +93,6 @@ func hydrateLoggerWithPayload(
 		"payload_method", payload.Method,
 		"payload_path", payload.Path,
 		"payload_timeout_millisec", payload.TimeoutMillisec,
+		"payload_data_preview", log.Preview(payload.Data),
 	)
 }

--- a/qos/cosmos/request_validator_rest.go
+++ b/qos/cosmos/request_validator_rest.go
@@ -87,10 +87,15 @@ func (rv *requestValidator) buildRESTRequestContext(
 		servicePayload,
 	)
 
-	logger.With(
+	// Hydrate the logger with REST request details.
+	logger = logger.With(
+		"rest_backend_service", rpcType,
 		"payload_length", len(servicePayload.Data),
-		"request_path", servicePayload.Path,
-	).Debug().Msg("REST request validation successful.")
+		"rest_request_path", servicePayload.Path,
+		"rest_request_method", servicePayload.Method,
+	)
+
+	logger.Debug().Msg("REST request validation successful.")
 
 	// Create specialized REST context
 	return &requestContext{


### PR DESCRIPTION
## Summary

Protocol only sets RPCType HTTP header on valid values

### Primary Changes:

- Protocol only sets RPCType HTTP header on valid values

### Secondary Changes:

- Add a preview of request payload to logs to help analyze and fix endpoint errors.

## Issue

- Issue or PR: #{ISSUE_OR_PR_NUMBER}

## Type of change

Select one or more from the following:

- [x] New feature, functionality or library
- [ ] Bug fix
- [ ] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## QoS Checklist

### E2E Validation & Tests

- [ ] `make path_up`
- [ ] `make test_e2e_evm_shannon`

### Observability

- [ ] 1. `make path_up`
- [ ] 2. Run the following E2E test: `make test_request__shannon_relay_util_100`
- [ ] 3. View results in LocalNet's [PATH Relay Grafana Dashboard](http://localhost:3003/d/relays/path-service-requests)

## Sanity Checklist

- [ ] I have updated the GitHub Issue `assignees`, `reviewers`, `labels`, `project`, `iteration` and `milestone`
- [ ] For docs, I have run `make docusaurus_start`
- [ ] For code, I have run `make test_all`
- [ ] For configurations, I have updated the documentation
- [ ] I added `TODO`s where applicable
