### PR TITLE
[QoS][JSONRPC] Invalid user request receives correct JSONRPC error code

### DIFF
--- a/qos/jsonrpc/errors.go
+++ b/qos/jsonrpc/errors.go
@@ -6,6 +6,7 @@ import (
 
 const (
 	ResponseCodeDefaultInternalErr = -32000 // JSON-RPC standard server error code; https://www.jsonrpc.org/historical/json-rpc-2-0.html
+	ResponseCodeDefaultBadRequest  = -32600 // JSON-RPC error code indicating bad user request
 )
 
 // NewErrResponseInternalErr creates a JSON-RPC error response when an internal error has occurred (e.g. reading HTTP request's body)
@@ -34,8 +35,8 @@ func NewErrResponseInternalErr(requestID ID, err error) Response {
 // The error is marked as permanent since retrying without correcting the request will fail.
 func NewErrResponseInvalidRequest(requestID ID, err error) Response {
 	return GetErrorResponse(
-		requestID,                      // Use request's original ID if present
-		ResponseCodeDefaultInternalErr, // JSON-RPC standard server error code; https://www.jsonrpc.org/historical/json-rpc-2-0.html
+		requestID,                     // Use request's original ID if present
+		ResponseCodeDefaultBadRequest, // -32600 code indicates an invalid user request.
 		fmt.Sprintf("invalid request: %s", err.Error()), // Error Message
 		map[string]string{
 			"error": err.Error(),


### PR DESCRIPTION
## Summary

Returns JSONRPC error code `-32600` in response to bad requests (e.g. malformed payloads that cannot be parsed into a JSONRPC request)

### Primary Changes:

- Returns JSONRPC error code `-32600` in response to bad requests (e.g. malformed payloads that cannot be parsed into a JSONRPC request)


## Issue

-32000 error code results in metrics inaccuracy: bad requests are counted as failures.

- Issue or PR: #{ISSUE_OR_PR_NUMBER}

## Type of change

Select one or more from the following:

- [ ] New feature, functionality or library
- [x] Bug fix
- [ ] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## QoS Checklist

### E2E Validation & Tests

- [ ] `make path_up`
- [ ] `make test_e2e_evm_shannon`

### Observability

- [ ] 1. `make path_up`
- [ ] 2. Run the following E2E test: `make test_request__shannon_relay_util_100`
- [ ] 3. View results in LocalNet's [PATH Relay Grafana Dashboard](http://localhost:3003/d/relays/path-service-requests)

## Sanity Checklist

- [ ] I have updated the GitHub Issue `assignees`, `reviewers`, `labels`, `project`, `iteration` and `milestone`
- [ ] For docs, I have run `make docusaurus_start`
- [ ] For code, I have run `make test_all`
- [ ] For configurations, I have updated the documentation
- [ ] I added `TODO`s where applicable
