### PR TITLE
[QoS] Add part 1 of 3 of new chains July 2025

### DIFF
--- a/config/service_qos_config.go
+++ b/config/service_qos_config.go
@@ -404,16 +404,60 @@ var shannonServices = []ServiceQoSConfig{
 
 	// *** Cosmos SDK Services ***
 
-	// TODO_MVP(@commoddity): Ensure that QoS observations are being applied correctly and that
-	// the correct chain ID is being used for each service in the CosmosSDK config.
+	// Akash - https://github.com/cosmos/chain-registry/blob/master/akash/chain.json#L9
+	cosmos.NewCosmosSDKServiceQoSConfig("akash", "akashnet-2", map[sharedtypes.RPCType]struct{}{
+		sharedtypes.RPCType_REST:      {}, // CosmosSDK
+		sharedtypes.RPCType_COMET_BFT: {},
+	}),
 
-	// Osmosis
+	// Babylon - https://github.com/cosmos/chain-registry/blob/master/babylon/chain.json#L9
+	cosmos.NewCosmosSDKServiceQoSConfig("babylon", "bbn-1", map[sharedtypes.RPCType]struct{}{
+		sharedtypes.RPCType_REST:      {}, // CosmosSDK
+		sharedtypes.RPCType_COMET_BFT: {},
+	}),
+
+	// Chihuahua - https://github.com/cosmos/chain-registry/blob/master/chihuahua/chain.json#L9
+	cosmos.NewCosmosSDKServiceQoSConfig("chihuahua", "chihuahua-1", map[sharedtypes.RPCType]struct{}{
+		sharedtypes.RPCType_REST:      {}, // CosmosSDK
+		sharedtypes.RPCType_COMET_BFT: {},
+	}),
+
+	// Cosmos Hub
+	cosmos.NewCosmosSDKServiceQoSConfig("cometbft", "cosmoshub-4", map[sharedtypes.RPCType]struct{}{
+		sharedtypes.RPCType_COMET_BFT: {},
+	}),
+
+	// Elys Network - https://github.com/cosmos/chain-registry/blob/master/elys/chain.json#L9
+	cosmos.NewCosmosSDKServiceQoSConfig("elys-network", "elys-1", map[sharedtypes.RPCType]struct{}{
+		sharedtypes.RPCType_REST:      {}, // CosmosSDK
+		sharedtypes.RPCType_COMET_BFT: {},
+	}),
+
+	// Juno - https://github.com/cosmos/chain-registry/blob/master/juno/chain.json#L9
+	cosmos.NewCosmosSDKServiceQoSConfig("juno", "juno-1", map[sharedtypes.RPCType]struct{}{
+		sharedtypes.RPCType_REST:      {}, // CosmosSDK
+		sharedtypes.RPCType_COMET_BFT: {},
+	}),
+
+	// Neutron - https://github.com/cosmos/chain-registry/blob/master/neutron/chain.json#L9
+	cosmos.NewCosmosSDKServiceQoSConfig("neutron", "neutron-1", map[sharedtypes.RPCType]struct{}{
+		sharedtypes.RPCType_REST:      {}, // CosmosSDK
+		sharedtypes.RPCType_COMET_BFT: {},
+	}),
+
+	// Osmosis - https://github.com/cosmos/chain-registry/blob/master/osmosis/chain.json#L9
 	cosmos.NewCosmosSDKServiceQoSConfig("osmosis", "osmosis-1", map[sharedtypes.RPCType]struct{}{
 		sharedtypes.RPCType_REST:      {}, // CosmosSDK
 		sharedtypes.RPCType_COMET_BFT: {},
 	}),
 
-	// Pocket Mainnet and Beta Testnet
+	// Passage - https://github.com/cosmos/chain-registry/blob/master/passage/chain.json#L9
+	cosmos.NewCosmosSDKServiceQoSConfig("passage", "passage-2", map[sharedtypes.RPCType]struct{}{
+		sharedtypes.RPCType_REST:      {}, // CosmosSDK
+		sharedtypes.RPCType_COMET_BFT: {},
+	}),
+
+	// Pocket Mainnet - https://github.com/cosmos/chain-registry/blob/master/pocket/chain.json#L9
 	cosmos.NewCosmosSDKServiceQoSConfig("pocket", "pocket", map[sharedtypes.RPCType]struct{}{
 		sharedtypes.RPCType_REST:      {}, // CosmosSDK
 		sharedtypes.RPCType_COMET_BFT: {},
@@ -447,13 +491,25 @@ var shannonServices = []ServiceQoSConfig{
 		sharedtypes.RPCType_COMET_BFT: {},
 	}),
 
-	// Cosmos Hub
-	cosmos.NewCosmosSDKServiceQoSConfig("cometbft", "cosmoshub-4", map[sharedtypes.RPCType]struct{}{
+	// Quicksilver - https://github.com/cosmos/chain-registry/blob/master/quicksilver/chain.json#L9
+	cosmos.NewCosmosSDKServiceQoSConfig("quicksilver", "quicksilver-2", map[sharedtypes.RPCType]struct{}{
+		sharedtypes.RPCType_REST:      {}, // CosmosSDK
 		sharedtypes.RPCType_COMET_BFT: {},
 	}),
 
-	// XRPL EVM
-	// Reference: https://docs.xrplevm.org/pages/developers/developing-smart-contracts/deploy-the-smart-contract#1.-set-up-your-wallet
+	// Shentu - https://github.com/cosmos/chain-registry/blob/master/shentu/chain.json#L9
+	cosmos.NewCosmosSDKServiceQoSConfig("shentu", "shentu-2.2", map[sharedtypes.RPCType]struct{}{
+		sharedtypes.RPCType_REST:      {}, // CosmosSDK
+		sharedtypes.RPCType_COMET_BFT: {},
+	}),
+
+	// Stride - https://github.com/cosmos/chain-registry/blob/master/stride/chain.json#L9
+	cosmos.NewCosmosSDKServiceQoSConfig("stride", "stride-1", map[sharedtypes.RPCType]struct{}{
+		sharedtypes.RPCType_REST:      {}, // CosmosSDK
+		sharedtypes.RPCType_COMET_BFT: {},
+	}),
+
+	// XRPLEVM - https://github.com/cosmos/chain-registry/blob/master/xrplevm/chain.json#L9
 	cosmos.NewCosmosSDKServiceQoSConfig("xrplevm", "xrplevm_1440000-1", map[sharedtypes.RPCType]struct{}{
 		sharedtypes.RPCType_JSON_RPC:  {}, // XRPLEVM supports the EVM API over JSON-RPC.
 		sharedtypes.RPCType_REST:      {}, // CosmosSDK
@@ -461,7 +517,7 @@ var shannonServices = []ServiceQoSConfig{
 		sharedtypes.RPCType_WEBSOCKET: {}, // XRPLEVM supports the EVM API over JSON-RPC WebSockets.
 	}),
 
-	// XRPL EVM Testnet
+	// XRPLEVM Testnet - https://github.com/cosmos/chain-registry/blob/master/testnets/xrplevmtestnet/chain.json#L9
 	cosmos.NewCosmosSDKServiceQoSConfig("xrplevm-testnet", "xrplevm_1449000-1", map[sharedtypes.RPCType]struct{}{
 		sharedtypes.RPCType_JSON_RPC:  {}, // XRPLEVM supports the EVM API over JSON-RPC.
 		sharedtypes.RPCType_REST:      {}, // CosmosSDK

--- a/docusaurus/docs/learn/qos/1_supported_services.md
+++ b/docusaurus/docs/learn/qos/1_supported_services.md
@@ -28,7 +28,7 @@ hydrator_config:
     - "eth"
 ```
 
-See [PATH Configuration File](../../develop/configs/2_gateway_config.md#hydrator_config-optional) for more details.
+See [PATH Configuration File](../../develop/path/5_configurations_path.md#hydrator_config-optional) for more details.
 
 ## ⛓️ Supported QoS Services
 
@@ -42,69 +42,59 @@ If a Service ID is not specified in the tables below, it does not have a QoS imp
 
 ## 🌿 Current PATH QoS Support
 
-**🗓️ Document Last Updated: 2025-07-14**
+**🗓️ Document Last Updated: 2025-07-28**
 
 ## Shannon Protocol Services
 
-| Service Name                                               | Authoritative Service ID | Service QoS Type | Chain ID (if applicable) | Archival Check Configured |
-| ---------------------------------------------------------- | ------------------------ | ---------------- | ------------------------ | ------------------------- |
-| Arbitrum One                                               | arb-one                  | EVM              | 42161                    | ✅                        |
-| Arbitrum Sepolia Testnet                                   | arb-sepolia-testnet      | EVM              | 421614                   | ✅                        |
-| Avalanche                                                  | avax                     | EVM              | 43114                    | ✅                        |
-| Avalanche-DFK                                              | avax-dfk                 | EVM              | 53935                    | ✅                        |
-| Base                                                       | base                     | EVM              | 8453                     | ✅                        |
-| Base Sepolia Testnet                                       | base-sepolia-testnet     | EVM              | 84532                    | ✅                        |
-| Berachain                                                  | bera                     | EVM              | 80094                    | ✅                        |
-| Blast                                                      | blast                    | EVM              | 81457                    | ✅                        |
-| BNB Smart Chain                                            | bsc                      | EVM              | 56                       | ✅                        |
-| Boba                                                       | boba                     | EVM              | 288                      | ✅                        |
-| Celo                                                       | celo                     | EVM              | 42220                    | ✅                        |
-| Ethereum                                                   | eth                      | EVM              | 1                        | ✅                        |
-| Ethereum Holesky Testnet                                   | eth-holesky-testnet      | EVM              | 17000                    | ✅                        |
-| Ethereum Sepolia Testnet                                   | eth-sepolia-testnet      | EVM              | 11155111                 | ✅                        |
-| Fantom                                                     | fantom                   | EVM              | 250                      | ✅                        |
-| Fuse                                                       | fuse                     | EVM              | 122                      | ✅                        |
-| Gnosis                                                     | gnosis                   | EVM              | 100                      | ✅                        |
-| Harmony-0                                                  | harmony                  | EVM              | 1666600000               | ✅                        |
-| Ink                                                        | ink                      | EVM              | 57073                    | ✅                        |
-| IoTeX                                                      | iotex                    | EVM              | 4689                     | ✅                        |
-| Kaia                                                       | kaia                     | EVM              | 8217                     | ✅                        |
-| Linea                                                      | linea                    | EVM              | 59144                    | ✅                        |
-| Mantle                                                     | mantle                   | EVM              | 5000                     | ✅                        |
-| Metis                                                      | metis                    | EVM              | 1088                     | ✅                        |
-| Moonbeam                                                   | moonbeam                 | EVM              | 1284                     | ✅                        |
-| Oasys                                                      | oasys                    | EVM              | 248                      | ✅                        |
-| Optimism                                                   | op                       | EVM              | 10                       | ✅                        |
-| Optimism Sepolia Testnet                                   | op-sepolia-testnet       | EVM              | 11155420                 | ✅                        |
-| Polygon                                                    | poly                     | EVM              | 137                      | ✅                        |
-| Polygon Amoy Testnet                                       | poly-amoy-testnet        | EVM              | 80002                    | ✅                        |
-| Polygon zkEVM                                              | poly-zkevm               | EVM              | 1101                     | ✅                        |
-| Scroll                                                     | scroll                   | EVM              | 534352                   | ✅                        |
-| Sonic                                                      | sonic                    | EVM              | 146                      | ✅                        |
-| Taiko                                                      | taiko                    | EVM              | 167000                   | ✅                        |
-| Taiko Hekla Testnet                                        | taiko-hekla-testnet      | EVM              | 167009                   | ✅                        |
-| zkLink                                                     | zklink-nova              | EVM              | 810180                   | ✅                        |
-| zkSync                                                     | zksync-era               | EVM              | 324                      | ✅                        |
-| Anvil - Ethereum development/testing                       | anvil                    | EVM              | 31337                    |                           |
-| Anvil WebSockets - Ethereum WebSockets development/testing | anvilws                  | EVM              | 31337                    |                           |
-| Evmos                                                      | evmos                    | EVM              | 9001                     |                           |
-| Fraxtal                                                    | fraxtal                  | EVM              | 252                      |                           |
-| Kava                                                       | kava                     | EVM              | 2222                     |                           |
-| Moonriver                                                  | moonriver                | EVM              | 1285                     |                           |
-| opBNB                                                      | opbnb                    | EVM              | 204                      |                           |
-| Radix                                                      | radix                    | EVM              | 4919                     |                           |
-| Sui                                                        | sui                      | EVM              | 257                      |                           |
-| XRPL EVM Devnet                                            | xrpl_evm_dev             | EVM              | 1440002                  |                           |
-| TRON                                                       | tron                     | EVM              | 728126428                |                           |
-| Sei                                                        | sei                      | EVM              | 1329                     |                           |
-| Solana                                                     | solana                   | Solana           |                          |                           |
-| Osmosis                                                    | osmosis                  | CosmosSDK        | osmosis                  |                           |
-| Pocket Network                                             | pocket                   | CosmosSDK        | pocket                   |                           |
-| Pocket Network Alpha                                       | pocket-alpha             | CosmosSDK        | pocket-alpha             |                           |
-| Pocket Network Beta                                        | pocket-beta              | CosmosSDK        | pocket-beta              |                           |
-| Pocket Network Beta 1                                      | pocket-beta1             | CosmosSDK        | pocket-beta1             |                           |
-| Pocket Network Beta 2                                      | pocket-beta2             | CosmosSDK        | pocket-beta2             |                           |
-| Pocket Network Beta 3                                      | pocket-beta3             | CosmosSDK        | pocket-beta3             |                           |
-| Pocket Network Beta 4                                      | pocket-beta4             | CosmosSDK        | pocket-beta4             |                           |
-| Cosmos Hub                                                 | cometbft                 | CosmosSDK        | cosmoshub-4              |                           |
-| XRPL EVM Testnet                                           | xrplevm-testnet          | CosmosSDK        | xrplevm_1449000-1        |                           |
+| Service Name | Authoritative Service ID | Service QoS Type | Chain ID (if applicable) | Archival Check Configured |
+|-------------|------------|-----------------|----------|---------------------------|
+| Arbitrum One | arb-one | EVM | 42161 | ✅ |
+| Arbitrum Sepolia Testnet | arb-sepolia-testnet | EVM | 421614 | ✅ |
+| Avalanche | avax | EVM | 43114 | ✅ |
+| Avalanche-DFK | avax-dfk | EVM | 53935 | ✅ |
+| Base | base | EVM | 8453 | ✅ |
+| Base Sepolia Testnet | base-sepolia-testnet | EVM | 84532 | ✅ |
+| Berachain | bera | EVM | 80094 | ✅ |
+| Blast | blast | EVM | 81457 | ✅ |
+| BNB Smart Chain | bsc | EVM | 56 | ✅ |
+| Boba | boba | EVM | 288 | ✅ |
+| Celo | celo | EVM | 42220 | ✅ |
+| Ethereum | eth | EVM | 1 | ✅ |
+| Ethereum Holesky Testnet | eth-holesky-testnet | EVM | 17000 | ✅ |
+| Ethereum Sepolia Testnet | eth-sepolia-testnet | EVM | 11155111 | ✅ |
+| Fantom | fantom | EVM | 250 | ✅ |
+| Fuse | fuse | EVM | 122 | ✅ |
+| Gnosis | gnosis | EVM | 100 | ✅ |
+| Harmony-0 | harmony | EVM | 1666600000 | ✅ |
+| Ink | ink | EVM | 57073 | ✅ |
+| IoTeX | iotex | EVM | 4689 | ✅ |
+| Kaia | kaia | EVM | 8217 | ✅ |
+| Linea | linea | EVM | 59144 | ✅ |
+| Mantle | mantle | EVM | 5000 | ✅ |
+| Metis | metis | EVM | 1088 | ✅ |
+| Moonbeam | moonbeam | EVM | 1284 | ✅ |
+| Oasys | oasys | EVM | 248 | ✅ |
+| Optimism | op | EVM | 10 | ✅ |
+| Optimism Sepolia Testnet | op-sepolia-testnet | EVM | 11155420 | ✅ |
+| Polygon | poly | EVM | 137 | ✅ |
+| Polygon Amoy Testnet | poly-amoy-testnet | EVM | 80002 | ✅ |
+| Polygon zkEVM | poly-zkevm | EVM | 1101 | ✅ |
+| Scroll | scroll | EVM | 534352 | ✅ |
+| Sonic | sonic | EVM | 146 | ✅ |
+| Taiko | taiko | EVM | 167000 | ✅ |
+| Taiko Hekla Testnet | taiko-hekla-testnet | EVM | 167009 | ✅ |
+| zkLink | zklink-nova | EVM | 810180 | ✅ |
+| zkSync | zksync-era | EVM | 324 | ✅ |
+| Anvil - Ethereum development/testing | anvil | EVM | 31337 |  |
+| Anvil WebSockets - Ethereum WebSockets development/testing | anvilws | EVM | 31337 |  |
+| Evmos | evmos | EVM | 9001 |  |
+| Fraxtal | fraxtal | EVM | 252 |  |
+| Kava | kava | EVM | 2222 |  |
+| Moonriver | moonriver | EVM | 1285 |  |
+| opBNB | opbnb | EVM | 204 |  |
+| Radix | radix | EVM | 4919 |  |
+| Sui | sui | EVM | 257 |  |
+| XRPL EVM Devnet | xrpl_evm_dev | EVM | 1440002 |  |
+| TRON | tron | EVM | 728126428 |  |
+| Sei | sei | EVM | 1329 |  |
+| Solana | solana | Solana |  |  |

--- a/e2e/config/services_shannon.yaml
+++ b/e2e/config/services_shannon.yaml
@@ -545,9 +545,44 @@ services:
 
   # ------------- CometBFT Services -------------
 
+  # Akash
+  - name: "Shannon - akash (Akash) Test"
+    service_id: "akash"
+    service_type: "cometbft"
+
+  # Babylon
+  - name: "Shannon - babylon (Babylon) Test"
+    service_id: "babylon"
+    service_type: "cometbft"
+
+  # Chihuahua
+  - name: "Shannon - chihuahua (Chihuahua) Test"
+    service_id: "chihuahua"
+    service_type: "cometbft"
+
+  # Elys Network
+  - name: "Shannon - elys-network (Elys Network) Test"
+    service_id: "elys-network"
+    service_type: "cometbft"
+
+  # Juno
+  - name: "Shannon - juno (Juno) Test"
+    service_id: "juno"
+    service_type: "cometbft"
+
+  # Neutron
+  - name: "Shannon - neutron (Neutron) Test"
+    service_id: "neutron"
+    service_type: "cometbft"
+
   # Osmosis
   - name: "Shannon - osmosis (Osmosis) Test"
     service_id: "osmosis"
+    service_type: "cometbft"
+
+  # Passage
+  - name: "Shannon - passage (Passage) Test"
+    service_id: "passage"
     service_type: "cometbft"
 
   # pocket-beta1
@@ -573,6 +608,21 @@ services:
   # pocket-beta5
   - name: "Shannon - pocket-beta5"
     service_id: "pocket-beta5"
+    service_type: "cometbft"
+
+  # Quicksilver
+  - name: "Shannon - quicksilver (Quicksilver) Test"
+    service_id: "quicksilver"
+    service_type: "cometbft"
+
+  # Shentu
+  - name: "Shannon - shentu (Shentu) Test"
+    service_id: "shentu"
+    service_type: "cometbft"
+
+  # Stride
+  - name: "Shannon - stride (Stride) Test"
+    service_id: "stride"
     service_type: "cometbft"
 
   # TODO_NEXT(@commoddity): Add `service_params` for the below services


### PR DESCRIPTION
## 🌿 Summary

Add part 1 of 3 of new Cosmos SDK chains to PATH service QoS configuration

### 🌱 Primary Changes:
- Added 10 new Cosmos SDK chains (`akash`, `babylon`, `chihuahua`, `elys-network`, `juno`, `neutron`, `passage`, `quicksilver`, `shentu`, `stride`) to QoS config
- Updated e2e test configuration with new chain test cases
- Added chain registry references for all new chains

### 🍃 Secondary changes:
- Updated documentation file path reference in QoS supported services doc
- Refreshed documentation last updated date
- Cleaned up table formatting in supported services documentation

## 🛠️ Type of change

Select one or more from the following:

- [ ] New feature, functionality or library
- [ ] Bug fix
- [ ] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## 🤯 Sanity Checklist

- [ ] I have updated the GitHub Issue 'assignees', 'reviewers', 'labels', 'project', 'iteration' and 'milestone'
- [ ] For docs, I have run 'make docusaurus_start'
- [ ] For code, I have run 'make test_all'
- [ ] For configurations, I have update the documentation
- [ ] I added TODOs where applicable
