### PR TITLE
[Merge after #378][QoS] Add part 2 of 3 of new chains July 2025

### DIFF
--- a/config/service_qos_config.go
+++ b/config/service_qos_config.go
@@ -410,8 +410,20 @@ var shannonServices = []ServiceQoSConfig{
 		sharedtypes.RPCType_COMET_BFT: {},
 	}),
 
+	// Arkeo - https://github.com/cosmos/chain-registry/blob/master/arkeo/chain.json#L9
+	cosmos.NewCosmosSDKServiceQoSConfig("arkeo", "arkeo-main-v1", map[sharedtypes.RPCType]struct{}{
+		sharedtypes.RPCType_REST:      {}, // CosmosSDK
+		sharedtypes.RPCType_COMET_BFT: {},
+	}),
+
 	// Babylon - https://github.com/cosmos/chain-registry/blob/master/babylon/chain.json#L9
 	cosmos.NewCosmosSDKServiceQoSConfig("babylon", "bbn-1", map[sharedtypes.RPCType]struct{}{
+		sharedtypes.RPCType_REST:      {}, // CosmosSDK
+		sharedtypes.RPCType_COMET_BFT: {},
+	}),
+
+	// Celestia - https://github.com/cosmos/chain-registry/blob/master/celestia/chain.json#L5
+	cosmos.NewCosmosSDKServiceQoSConfig("celestia", "celestia", map[sharedtypes.RPCType]struct{}{
 		sharedtypes.RPCType_REST:      {}, // CosmosSDK
 		sharedtypes.RPCType_COMET_BFT: {},
 	}),
@@ -433,14 +445,32 @@ var shannonServices = []ServiceQoSConfig{
 		sharedtypes.RPCType_COMET_BFT: {},
 	}),
 
+	// Fetch - https://github.com/cosmos/chain-registry/blob/master/fetchhub/chain.json#L8
+	cosmos.NewCosmosSDKServiceQoSConfig("fetch", "fetchhub-4", map[sharedtypes.RPCType]struct{}{
+		sharedtypes.RPCType_REST:      {}, // CosmosSDK
+		sharedtypes.RPCType_COMET_BFT: {},
+	}),
+
 	// Juno - https://github.com/cosmos/chain-registry/blob/master/juno/chain.json#L9
 	cosmos.NewCosmosSDKServiceQoSConfig("juno", "juno-1", map[sharedtypes.RPCType]struct{}{
 		sharedtypes.RPCType_REST:      {}, // CosmosSDK
 		sharedtypes.RPCType_COMET_BFT: {},
 	}),
 
+	// KYVE - https://github.com/cosmos/chain-registry/blob/master/kyve/chain.json#L5
+	cosmos.NewCosmosSDKServiceQoSConfig("kyve", "kyve-1", map[sharedtypes.RPCType]struct{}{
+		sharedtypes.RPCType_REST:      {}, // CosmosSDK
+		sharedtypes.RPCType_COMET_BFT: {},
+	}),
+
 	// Neutron - https://github.com/cosmos/chain-registry/blob/master/neutron/chain.json#L9
 	cosmos.NewCosmosSDKServiceQoSConfig("neutron", "neutron-1", map[sharedtypes.RPCType]struct{}{
+		sharedtypes.RPCType_REST:      {}, // CosmosSDK
+		sharedtypes.RPCType_COMET_BFT: {},
+	}),
+
+	// Nillion - https://github.com/cosmos/chain-registry/blob/master/nillion/chain.json#L8
+	cosmos.NewCosmosSDKServiceQoSConfig("nillion", "nillion-1", map[sharedtypes.RPCType]struct{}{
 		sharedtypes.RPCType_REST:      {}, // CosmosSDK
 		sharedtypes.RPCType_COMET_BFT: {},
 	}),
@@ -453,6 +483,12 @@ var shannonServices = []ServiceQoSConfig{
 
 	// Passage - https://github.com/cosmos/chain-registry/blob/master/passage/chain.json#L9
 	cosmos.NewCosmosSDKServiceQoSConfig("passage", "passage-2", map[sharedtypes.RPCType]struct{}{
+		sharedtypes.RPCType_REST:      {}, // CosmosSDK
+		sharedtypes.RPCType_COMET_BFT: {},
+	}),
+
+	// Persistence - https://github.com/cosmos/chain-registry/blob/master/persistence/chain.json#L5
+	cosmos.NewCosmosSDKServiceQoSConfig("persistence", "core-1", map[sharedtypes.RPCType]struct{}{
 		sharedtypes.RPCType_REST:      {}, // CosmosSDK
 		sharedtypes.RPCType_COMET_BFT: {},
 	}),
@@ -497,8 +533,20 @@ var shannonServices = []ServiceQoSConfig{
 		sharedtypes.RPCType_COMET_BFT: {},
 	}),
 
+	// Router - https://github.com/cosmos/chain-registry/blob/master/routerchain/chain.json#L5
+	cosmos.NewCosmosSDKServiceQoSConfig("router", "router_9600-1", map[sharedtypes.RPCType]struct{}{
+		sharedtypes.RPCType_REST:      {}, // CosmosSDK
+		sharedtypes.RPCType_COMET_BFT: {},
+	}),
+
 	// Shentu - https://github.com/cosmos/chain-registry/blob/master/shentu/chain.json#L9
 	cosmos.NewCosmosSDKServiceQoSConfig("shentu", "shentu-2.2", map[sharedtypes.RPCType]struct{}{
+		sharedtypes.RPCType_REST:      {}, // CosmosSDK
+		sharedtypes.RPCType_COMET_BFT: {},
+	}),
+
+	// Side Protocol - https://github.com/cosmos/chain-registry/blob/master/sidechain/chain.json#L9
+	cosmos.NewCosmosSDKServiceQoSConfig("side-protocol", "sidechain-1", map[sharedtypes.RPCType]struct{}{
 		sharedtypes.RPCType_REST:      {}, // CosmosSDK
 		sharedtypes.RPCType_COMET_BFT: {},
 	}),

--- a/config/service_qos_config.go
+++ b/config/service_qos_config.go
@@ -516,6 +516,7 @@ var shannonServices = []ServiceQoSConfig{
 	cosmos.NewCosmosSDKServiceQoSConfig("router", "router_9600-1", map[sharedtypes.RPCType]struct{}{
 		sharedtypes.RPCType_REST:      {}, // CosmosSDK
 		sharedtypes.RPCType_COMET_BFT: {},
+		sharedtypes.RPCType_JSON_RPC:  {},
 	}),
 
 	// Shentu - https://github.com/cosmos/chain-registry/blob/master/shentu/chain.json#L9

--- a/config/service_qos_config.go
+++ b/config/service_qos_config.go
@@ -434,8 +434,9 @@ var shannonServices = []ServiceQoSConfig{
 		sharedtypes.RPCType_COMET_BFT: {},
 	}),
 
-	// Cosmos Hub
-	cosmos.NewCosmosSDKServiceQoSConfig("cometbft", "cosmoshub-4", map[sharedtypes.RPCType]struct{}{
+	// Cosmos Hub - https://github.com/cosmos/chain-registry/blob/master/cosmoshub/chain.json#L5
+	cosmos.NewCosmosSDKServiceQoSConfig("cosmoshub", "cosmoshub-4", map[sharedtypes.RPCType]struct{}{
+		sharedtypes.RPCType_REST:      {}, // CosmosSDK
 		sharedtypes.RPCType_COMET_BFT: {},
 	}),
 

--- a/docusaurus/docs/learn/qos/1_supported_services.md
+++ b/docusaurus/docs/learn/qos/1_supported_services.md
@@ -98,18 +98,26 @@ If a Service ID is not specified in the tables below, it does not have a QoS imp
 | TRON                                                       | tron                     | EVM              | 728126428                |                           |
 | Sei                                                        | sei                      | EVM              | 1329                     |                           |
 | Akash                                                      | akash                    | Cosmos SDK       | akashnet-2               |                           |
+| Arkeo                                                      | arkeo                    | Cosmos SDK       | arkeo-main-v1            |                           |
 | Babylon                                                    | babylon                  | Cosmos SDK       | bbn-1                    |                           |
+| Celestia                                                   | celestia                 | Cosmos SDK       | celestia                 |                           |
 | Chihuahua                                                  | chihuahua                | Cosmos SDK       | chihuahua-1              |                           |
-| Cosmos Hub                                                 | cometbft                 | Cosmos SDK       | cosmoshub-4              |                           |
+| Cosmos Hub                                                 | cosmoshub                | Cosmos SDK       | cosmoshub-4              |                           |
 | Elys Network                                               | elys-network             | Cosmos SDK       | elys-1                   |                           |
+| Fetch                                                      | fetch                    | Cosmos SDK       | fetchhub-4               |                           |
 | Juno                                                       | juno                     | Cosmos SDK       | juno-1                   |                           |
+| KYVE                                                       | kyve                     | Cosmos SDK       | kyve-1                   |                           |
 | Neutron                                                    | neutron                  | Cosmos SDK       | neutron-1                |                           |
+| Nillion                                                    | nillion                  | Cosmos SDK       | nillion-1                |                           |
 | Osmosis                                                    | osmosis                  | Cosmos SDK       | osmosis-1                |                           |
 | Passage                                                    | passage                  | Cosmos SDK       | passage-2                |                           |
+| Persistence                                                | persistence              | Cosmos SDK       | core-1                   |                           |
 | Pocket Mainnet                                             | pocket                   | Cosmos SDK       | pocket                   |                           |
 | Pocket Beta Testnet                                        | pocket-beta              | Cosmos SDK       | pocket-beta              |                           |
 | Quicksilver                                                | quicksilver              | Cosmos SDK       | quicksilver-2            |                           |
+| Router                                                     | router                   | Cosmos SDK       | router_9600-1            |                           |
 | Shentu                                                     | shentu                   | Cosmos SDK       | shentu-2.2               |                           |
+| Side Protocol                                              | side-protocol            | Cosmos SDK       | sidechain-1              |                           |
 | Stride                                                     | stride                   | Cosmos SDK       | stride-1                 |                           |
 | XRPLEVM                                                    | xrplevm                  | Cosmos SDK       | xrplevm_1440000-1        |                           |
 | XRPLEVM Testnet                                            | xrplevm-testnet          | Cosmos SDK       | xrplevm_1449000-1        |                           |

--- a/e2e/config/services_shannon.yaml
+++ b/e2e/config/services_shannon.yaml
@@ -550,9 +550,19 @@ services:
     service_id: "akash"
     service_type: "cometbft"
 
+  # Arkeo
+  - name: "Shannon - arkeo (Arkeo) Test"
+    service_id: "arkeo"
+    service_type: "cometbft"
+
   # Babylon
   - name: "Shannon - babylon (Babylon) Test"
     service_id: "babylon"
+    service_type: "cometbft"
+
+  # Celestia
+  - name: "Shannon - celestia (Celestia) Test"
+    service_id: "celestia"
     service_type: "cometbft"
 
   # Chihuahua
@@ -565,14 +575,29 @@ services:
     service_id: "elys-network"
     service_type: "cometbft"
 
+  # Fetch
+  - name: "Shannon - fetch (Fetch) Test"
+    service_id: "fetch"
+    service_type: "cometbft"
+
   # Juno
   - name: "Shannon - juno (Juno) Test"
     service_id: "juno"
     service_type: "cometbft"
 
+  # KYVE
+  - name: "Shannon - kyve (KYVE) Test"
+    service_id: "kyve"
+    service_type: "cometbft"
+
   # Neutron
   - name: "Shannon - neutron (Neutron) Test"
     service_id: "neutron"
+    service_type: "cometbft"
+
+  # Nillion
+  - name: "Shannon - nillion (Nillion) Test"
+    service_id: "nillion"
     service_type: "cometbft"
 
   # Osmosis
@@ -583,6 +608,11 @@ services:
   # Passage
   - name: "Shannon - passage (Passage) Test"
     service_id: "passage"
+    service_type: "cometbft"
+
+  # Persistence
+  - name: "Shannon - persistence (Persistence) Test"
+    service_id: "persistence"
     service_type: "cometbft"
 
   # pocket-beta1
@@ -615,9 +645,19 @@ services:
     service_id: "quicksilver"
     service_type: "cometbft"
 
+  # Router
+  - name: "Shannon - router (Router) Test"
+    service_id: "router"
+    service_type: "cometbft"
+
   # Shentu
   - name: "Shannon - shentu (Shentu) Test"
     service_id: "shentu"
+    service_type: "cometbft"
+
+  # Side Protocol
+  - name: "Shannon - side-protocol (Side Protocol) Test"
+    service_id: "side-protocol"
     service_type: "cometbft"
 
   # Stride


### PR DESCRIPTION
## 🌿 Summary

Add part 2 of 3 of new Cosmos SDK chains to PATH service QoS configuration

### 🌱 Primary Changes:
| Group 2 Service IDs |
|---------------------|
| arkeo               |
| celestia            |
| cosmoshub           |
| fetch               |
| kyve                |
| nillion             |
| persistence         |
| router              |
| side-protocol       |
- Updated e2e test configuration with new chain test cases
- Added chain registry references for all new chains