### PR TITLE
[Merge after #379][QoS] Add part 3 of 3 of new chains July 2025

### DIFF
--- a/config/service_qos_config.go
+++ b/config/service_qos_config.go
@@ -488,11 +488,12 @@ var shannonServices = []ServiceQoSConfig{
 		sharedtypes.RPCType_COMET_BFT: {},
 	}),
 
-	// Namada - https://github.com/cosmos/chain-registry/blob/master/namada/chain.json#L9
-	cosmos.NewCosmosSDKServiceQoSConfig("namada", "namada-1", map[sharedtypes.RPCType]struct{}{
-		sharedtypes.RPCType_REST:      {}, // CosmosSDK
-		sharedtypes.RPCType_COMET_BFT: {},
-	}),
+	// Namada TODO_TECHDEBT(@commoddity): Namada is not a conventional Cosmos SDK chain and likely requires a custom implementation.
+	// Reference: https://github.com/buildwithgrove/path/issues/376#issuecomment-3127611273
+	// cosmos.NewCosmosSDKServiceQoSConfig("namada", "", map[sharedtypes.RPCType]struct{}{
+	// 	sharedtypes.RPCType_REST:      {}, // CosmosSDK
+	// 	sharedtypes.RPCType_COMET_BFT: {},
+	// }),
 
 	// Neutron - https://github.com/cosmos/chain-registry/blob/master/neutron/chain.json#L8
 	cosmos.NewCosmosSDKServiceQoSConfig("neutron", "neutron-1", map[sharedtypes.RPCType]struct{}{

--- a/config/service_qos_config.go
+++ b/config/service_qos_config.go
@@ -416,6 +416,12 @@ var shannonServices = []ServiceQoSConfig{
 		sharedtypes.RPCType_COMET_BFT: {},
 	}),
 
+	// AtomOne - https://github.com/cosmos/chain-registry/blob/master/atomone/chain.json#L5
+	cosmos.NewCosmosSDKServiceQoSConfig("atomone", "atomone-1", map[sharedtypes.RPCType]struct{}{
+		sharedtypes.RPCType_REST:      {}, // CosmosSDK
+		sharedtypes.RPCType_COMET_BFT: {},
+	}),
+
 	// Babylon - https://github.com/cosmos/chain-registry/blob/master/babylon/chain.json#L9
 	cosmos.NewCosmosSDKServiceQoSConfig("babylon", "bbn-1", map[sharedtypes.RPCType]struct{}{
 		sharedtypes.RPCType_REST:      {}, // CosmosSDK
@@ -424,6 +430,12 @@ var shannonServices = []ServiceQoSConfig{
 
 	// Celestia - https://github.com/cosmos/chain-registry/blob/master/celestia/chain.json#L5
 	cosmos.NewCosmosSDKServiceQoSConfig("celestia", "celestia", map[sharedtypes.RPCType]struct{}{
+		sharedtypes.RPCType_REST:      {}, // CosmosSDK
+		sharedtypes.RPCType_COMET_BFT: {},
+	}),
+
+	// Cheqd - https://github.com/cosmos/chain-registry/blob/master/cheqd/chain.json#L9
+	cosmos.NewCosmosSDKServiceQoSConfig("cheqd", "cheqd-mainnet-1", map[sharedtypes.RPCType]struct{}{
 		sharedtypes.RPCType_REST:      {}, // CosmosSDK
 		sharedtypes.RPCType_COMET_BFT: {},
 	}),
@@ -440,6 +452,12 @@ var shannonServices = []ServiceQoSConfig{
 		sharedtypes.RPCType_COMET_BFT: {},
 	}),
 
+	// Dungeon Chain - https://github.com/cosmos/chain-registry/blob/master/dungeon1/chain.json#L9
+	cosmos.NewCosmosSDKServiceQoSConfig("dungeon-chain", "dungeon-1", map[sharedtypes.RPCType]struct{}{
+		sharedtypes.RPCType_REST:      {}, // CosmosSDK
+		sharedtypes.RPCType_COMET_BFT: {},
+	}),
+
 	// Elys Network - https://github.com/cosmos/chain-registry/blob/master/elys/chain.json#L9
 	cosmos.NewCosmosSDKServiceQoSConfig("elys-network", "elys-1", map[sharedtypes.RPCType]struct{}{
 		sharedtypes.RPCType_REST:      {}, // CosmosSDK
@@ -452,6 +470,12 @@ var shannonServices = []ServiceQoSConfig{
 		sharedtypes.RPCType_COMET_BFT: {},
 	}),
 
+	// Jackal - https://github.com/cosmos/chain-registry/blob/master/jackal/chain.json#L5
+	cosmos.NewCosmosSDKServiceQoSConfig("jackal", "jackal-1", map[sharedtypes.RPCType]struct{}{
+		sharedtypes.RPCType_REST:      {}, // CosmosSDK
+		sharedtypes.RPCType_COMET_BFT: {},
+	}),
+
 	// Juno - https://github.com/cosmos/chain-registry/blob/master/juno/chain.json#L9
 	cosmos.NewCosmosSDKServiceQoSConfig("juno", "juno-1", map[sharedtypes.RPCType]struct{}{
 		sharedtypes.RPCType_REST:      {}, // CosmosSDK
@@ -460,6 +484,12 @@ var shannonServices = []ServiceQoSConfig{
 
 	// KYVE - https://github.com/cosmos/chain-registry/blob/master/kyve/chain.json#L5
 	cosmos.NewCosmosSDKServiceQoSConfig("kyve", "kyve-1", map[sharedtypes.RPCType]struct{}{
+		sharedtypes.RPCType_REST:      {}, // CosmosSDK
+		sharedtypes.RPCType_COMET_BFT: {},
+	}),
+
+	// Namada - https://github.com/cosmos/chain-registry/blob/master/namada/chain.json#L9
+	cosmos.NewCosmosSDKServiceQoSConfig("namada", "namada-1", map[sharedtypes.RPCType]struct{}{
 		sharedtypes.RPCType_REST:      {}, // CosmosSDK
 		sharedtypes.RPCType_COMET_BFT: {},
 	}),
@@ -490,6 +520,12 @@ var shannonServices = []ServiceQoSConfig{
 
 	// Persistence - https://github.com/cosmos/chain-registry/blob/master/persistence/chain.json#L5
 	cosmos.NewCosmosSDKServiceQoSConfig("persistence", "core-1", map[sharedtypes.RPCType]struct{}{
+		sharedtypes.RPCType_REST:      {}, // CosmosSDK
+		sharedtypes.RPCType_COMET_BFT: {},
+	}),
+
+	// Provenance - https://github.com/cosmos/chain-registry/blob/master/provenance/chain.json#L9
+	cosmos.NewCosmosSDKServiceQoSConfig("provenance", "pio-mainnet-1", map[sharedtypes.RPCType]struct{}{
 		sharedtypes.RPCType_REST:      {}, // CosmosSDK
 		sharedtypes.RPCType_COMET_BFT: {},
 	}),
@@ -540,6 +576,12 @@ var shannonServices = []ServiceQoSConfig{
 		sharedtypes.RPCType_COMET_BFT: {},
 	}),
 
+	// Seda - https://github.com/cosmos/chain-registry/blob/master/seda/chain.json#L9
+	cosmos.NewCosmosSDKServiceQoSConfig("seda", "seda-1", map[sharedtypes.RPCType]struct{}{
+		sharedtypes.RPCType_REST:      {}, // CosmosSDK
+		sharedtypes.RPCType_COMET_BFT: {},
+	}),
+
 	// Shentu - https://github.com/cosmos/chain-registry/blob/master/shentu/chain.json#L9
 	cosmos.NewCosmosSDKServiceQoSConfig("shentu", "shentu-2.2", map[sharedtypes.RPCType]struct{}{
 		sharedtypes.RPCType_REST:      {}, // CosmosSDK
@@ -548,6 +590,12 @@ var shannonServices = []ServiceQoSConfig{
 
 	// Side Protocol - https://github.com/cosmos/chain-registry/blob/master/sidechain/chain.json#L9
 	cosmos.NewCosmosSDKServiceQoSConfig("side-protocol", "sidechain-1", map[sharedtypes.RPCType]struct{}{
+		sharedtypes.RPCType_REST:      {}, // CosmosSDK
+		sharedtypes.RPCType_COMET_BFT: {},
+	}),
+
+	// Stargaze - https://github.com/cosmos/chain-registry/blob/master/stargaze/chain.json#L9
+	cosmos.NewCosmosSDKServiceQoSConfig("stargaze", "stargaze-1", map[sharedtypes.RPCType]struct{}{
 		sharedtypes.RPCType_REST:      {}, // CosmosSDK
 		sharedtypes.RPCType_COMET_BFT: {},
 	}),

--- a/e2e/config/services_shannon.yaml
+++ b/e2e/config/services_shannon.yaml
@@ -555,6 +555,11 @@ services:
     service_id: "arkeo"
     service_type: "cometbft"
 
+  # AtomOne
+  - name: "Shannon - atomone (AtomOne) Test"
+    service_id: "atomone"
+    service_type: "cometbft"
+
   # Babylon
   - name: "Shannon - babylon (Babylon) Test"
     service_id: "babylon"
@@ -565,9 +570,19 @@ services:
     service_id: "celestia"
     service_type: "cometbft"
 
+  # Cheqd
+  - name: "Shannon - cheqd (Cheqd) Test"
+    service_id: "cheqd"
+    service_type: "cometbft"
+
   # Chihuahua
   - name: "Shannon - chihuahua (Chihuahua) Test"
     service_id: "chihuahua"
+    service_type: "cometbft"
+
+  # Dungeon Chain
+  - name: "Shannon - dungeon-chain (Dungeon Chain) Test"
+    service_id: "dungeon-chain"
     service_type: "cometbft"
 
   # Elys Network
@@ -580,6 +595,11 @@ services:
     service_id: "fetch"
     service_type: "cometbft"
 
+  # Jackal
+  - name: "Shannon - jackal (Jackal) Test"
+    service_id: "jackal"
+    service_type: "cometbft"
+
   # Juno
   - name: "Shannon - juno (Juno) Test"
     service_id: "juno"
@@ -588,6 +608,11 @@ services:
   # KYVE
   - name: "Shannon - kyve (KYVE) Test"
     service_id: "kyve"
+    service_type: "cometbft"
+
+  # Namada
+  - name: "Shannon - namada (Namada) Test"
+    service_id: "namada"
     service_type: "cometbft"
 
   # Neutron
@@ -613,6 +638,11 @@ services:
   # Persistence
   - name: "Shannon - persistence (Persistence) Test"
     service_id: "persistence"
+    service_type: "cometbft"
+
+  # Provenance
+  - name: "Shannon - provenance (Provenance) Test"
+    service_id: "provenance"
     service_type: "cometbft"
 
   # pocket-beta1
@@ -650,6 +680,11 @@ services:
     service_id: "router"
     service_type: "cometbft"
 
+  # Seda
+  - name: "Shannon - seda (Seda) Test"
+    service_id: "seda"
+    service_type: "cometbft"
+
   # Shentu
   - name: "Shannon - shentu (Shentu) Test"
     service_id: "shentu"
@@ -658,6 +693,11 @@ services:
   # Side Protocol
   - name: "Shannon - side-protocol (Side Protocol) Test"
     service_id: "side-protocol"
+    service_type: "cometbft"
+
+  # Stargaze
+  - name: "Shannon - stargaze (Stargaze) Test"
+    service_id: "stargaze"
     service_type: "cometbft"
 
   # Stride


### PR DESCRIPTION
## 🌿 Summary

Add part 3 of 3 of new Cosmos SDK chains to PATH service QoS configuration

### 🌱 Primary Changes:
| Group 3 Service IDs |
|---------------------|
| atomone             |
| cheqd               |
| dungeon-chain       |
| jackal              |
| namada              |
| provenance          |
| seda                |
| stargaze            |
_(`osmosis` was already present in config file)_
- Updated e2e test configuration with new chain test cases
- Added chain registry references for all new chains