### PR TITLE
[Protocol][Shannon][Observability] Add fallback label to Shannon relays metric

### DIFF
--- a/protocol/shannon/observation.go
+++ b/protocol/shannon/observation.go
@@ -168,9 +168,10 @@ func buildEndpointObservation(
 	// app, serviceID, session ID, session start and end heights
 	observation := buildEndpointObservationFromSession(logger, endpoint.session)
 
-	// Add endpoint-level details: supplier, URL.
+	// Add endpoint-level details: supplier, URL, isFallback.
 	observation.Supplier = endpoint.supplier
 	observation.EndpointUrl = endpoint.url
+	observation.IsFallbackEndpoint = endpoint.isFallback()
 
 	// Add endpoint response details if not nil (i.e. success)
 	if endpointResponse != nil {


### PR DESCRIPTION
## Summary

 Add fallback label to Shannon relays metric

### Primary Changes:

-  Add a `used_fallback` label to Shannon total relays metric

## Issue

Observability of traffic percentage using fallback endpoints.

- Issue or PR: #{ISSUE_OR_PR_NUMBER}

## Type of change

Select one or more from the following:

- [x] New feature, functionality or library
- [ ] Bug fix
- [ ] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## QoS Checklist

### E2E Validation & Tests

- [ ] `make path_up`
- [ ] `make test_e2e_evm_shannon`

### Observability

- [x] 1. `make path_up`
- [ ] 2. Run the following E2E test: `make test_request__shannon_relay_util_100`
- [ ] 3. View results in LocalNet's [PATH Relay Grafana Dashboard](http://localhost:3003/d/relays/path-service-requests)

## Sanity Checklist

- [x] I have updated the GitHub Issue `assignees`, `reviewers`, `labels`, `project`, `iteration` and `milestone`
- [ ] For docs, I have run `make docusaurus_start`
- [ ] For code, I have run `make test_all`
- [ ] For configurations, I have updated the documentation
- [ ] I added `TODO`s where applicable
