### PR TITLE
[QoS] feat: add sessionRolloverState and session rollover awareness to full node

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -37,7 +37,7 @@ var (
 const defaultConfigPath = "config/.config.yaml"
 
 func main() {
-	log.Printf("🌿 PATH gateway starting...")
+	log.Printf(`{"level":"info","message":"PATH 🌿 gateway starting..."}`)
 
 	// Initialize version metrics for Prometheus monitoring
 	metrics.SetVersionInfo(Version, Commit, BuildDate)
@@ -45,17 +45,17 @@ func main() {
 	// Get the config path
 	configPath, err := getConfigPath(defaultConfigPath)
 	if err != nil {
-		log.Fatalf("failed to get config path: %v", err)
+		log.Fatalf(`{"level":"fatal","error":"%v","message":"failed to get config path"}`, err)
 	}
 
 	// Load the config
 	config, err := configpkg.LoadGatewayConfigFromYAML(configPath)
 	if err != nil {
-		log.Fatalf("failed to load config: %v", err)
+		log.Fatalf(`{"level":"fatal","error":"%v","message":"failed to load config"}`, err)
 	}
 
 	// Initialize the logger
-	log.Printf("Initializing PATH logger with level: %s", config.Logger.Level)
+	log.Printf(`{"level":"info","message":"Initializing PATH logger with level: %s"}`, config.Logger.Level)
 	loggerOpts := []polylog.LoggerOption{
 		polyzero.WithLevel(polyzero.ParseLevel(config.Logger.Level)),
 	}
@@ -67,19 +67,19 @@ func main() {
 	// Create Shannon protocol instance (now the only supported protocol)
 	protocol, err := getShannonProtocol(logger, config.GetGatewayConfig())
 	if err != nil {
-		log.Fatalf("failed to create protocol: %v", err)
+		log.Fatalf(`{"level":"fatal","error":"%v","message":"failed to create protocol"}`, err)
 	}
 
 	// Prepare the QoS instances
 	qosInstances, err := getServiceQoSInstances(logger, config, protocol)
 	if err != nil {
-		log.Fatalf("failed to setup QoS instances: %v", err)
+		log.Fatalf(`{"level":"fatal","error":"%v","message":"failed to setup QoS instances"}`, err)
 	}
 
 	// Setup metrics reporter, to be used by Gateway and Hydrator
 	metricsReporter, err := setupMetricsServer(logger, prometheusMetricsServerAddr)
 	if err != nil {
-		log.Fatalf("failed to start metrics server: %v", err)
+		log.Fatalf(`{"level":"fatal","error":"%v","message":"failed to start metrics server"}`, err)
 	}
 
 	// Setup the pprof server
@@ -88,7 +88,7 @@ func main() {
 	// Setup the data reporter
 	dataReporter, err := setupHTTPDataReporter(logger, config.DataReporterConfig)
 	if err != nil {
-		log.Fatalf("failed to start the configured HTTP data reporter: %v", err)
+		log.Fatalf(`{"level":"fatal","error":"%v","message":"failed to start the configured HTTP data reporter"}`, err)
 	}
 
 	// TODO_IMPROVE: consider using a separate protocol instance for the hydrator,
@@ -103,7 +103,7 @@ func main() {
 		config.HydratorConfig,
 	)
 	if err != nil {
-		log.Fatalf("failed to setup endpoint hydrator: %v", err)
+		log.Fatalf(`{"level":"fatal","error":"%v","message":"failed to setup endpoint hydrator"}`, err)
 	}
 
 	// Setup the request parser which maps requests to the correct QoS instance.

--- a/protocol/shannon/full_node.go
+++ b/protocol/shannon/full_node.go
@@ -70,4 +70,21 @@ type FullNode interface {
 
 	// GetAccountClient returns the account client from the fullnode, to be used in building relay request signers.
 	GetAccountClient() *sdk.AccountClient
+
+	// TODO_NEXT(@adshmh): Incorporate this with changes in PR #396 to
+	// only use parallel fallback request when in session rollover period
+	// Reference: https://github.com/buildwithgrove/path/pull/396
+	//
+	// IsInSessionRollover returns true if the system is currently in a session rollover period.
+	//
+	// A session rollover period is a critical time window that occurs around session transitions
+	// and can cause reliability issues for relay operations. The rollover period is defined as:
+	// - 1 block before the session end height
+	// - Plus a configurable grace period after the session end (default: 10 blocks)
+	//
+	// This method enables the gateway to implement adaptive retry strategies during rollover periods
+	//
+	// The monitoring is performed automatically in the background and this method
+	// provides a thread-safe way to check the current rollover status.
+	IsInSessionRollover() bool
 }

--- a/protocol/shannon/fullnode_cache.go
+++ b/protocol/shannon/fullnode_cache.go
@@ -410,3 +410,10 @@ func (cfn *cachingFullNode) GetCurrentBlockHeight(ctx context.Context) (int64, e
 
 	return height, err
 }
+
+// IsInSessionRollover: passthrough to underlying lazy full node.
+// The lazy full node manages session rollover monitoring in the background,
+// so we simply delegate to its rollover state.
+func (cfn *cachingFullNode) IsInSessionRollover() bool {
+	return cfn.lazyFullNode.IsInSessionRollover()
+}

--- a/protocol/shannon/fullnode_session_rollover.go
+++ b/protocol/shannon/fullnode_session_rollover.go
@@ -1,0 +1,159 @@
+package shannon
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	sessiontypes "github.com/pokt-network/poktroll/x/session/types"
+)
+
+const (
+	// TODO_TECHDEBT(@commoddity): Make this configurable via config file
+	// Grace period after session end where rollover issues may occur
+	sessionRolloverGracePeriodBlocks = 10
+
+	// How often to check for block height updates
+	blockCheckInterval = 15 * time.Second
+)
+
+// sessionRolloverState tracks session rollover status for the LazyFullNode.
+//
+// Session rollovers are critical periods that occur around session transitions
+// where relay operations may experience higher failure rates due to:
+// - Session synchronization issues between gateways and suppliers
+// - Temporary endpoint unavailability during session changes
+// - Inconsistent session state across the network
+//
+// This state is maintained automatically by background monitoring that:
+// 1. Periodically fetches the current block height
+// 2. Updates when new sessions are retrieved via GetSession()
+// 3. Calculates rollover status based on the rollover window
+//
+// The rollover window spans from 1 block before session end through
+// sessionRolloverGracePeriodBlocks after session end. This provides
+// early warning and extended monitoring of potentially problematic periods.
+//
+// All access to this state is protected by rolloverStateMu for thread safety,
+// allowing safe concurrent access from multiple goroutines.
+type sessionRolloverState struct {
+	currentBlockHeight      int64 // Latest block height from the blockchain
+	currentSessionEndHeight int64 // End height of the current/latest session
+	isInSessionRollover     bool  // Cached rollover status (true = in rollover period)
+
+	rolloverStateMu sync.RWMutex // Protects all fields above
+}
+
+// getSessionRolloverState returns whether we're currently in a session rollover period.
+// Thread-safe.
+func (lfn *LazyFullNode) getSessionRolloverState() bool {
+	lfn.rolloverState.rolloverStateMu.RLock()
+	defer lfn.rolloverState.rolloverStateMu.RUnlock()
+	return lfn.rolloverState.isInSessionRollover
+}
+
+// updateSessionEndHeight updates session end height when we fetch a new session.
+// Called from GetSession() to keep rollover monitoring current.
+func (lfn *LazyFullNode) updateSessionEndHeight(session sessiontypes.Session) {
+	if session.Header == nil {
+		lfn.logger.Warn().Msg("Session header is nil, cannot update session end height")
+		return
+	}
+
+	newSessionEndHeight := session.Header.SessionEndBlockHeight
+
+	lfn.rolloverState.rolloverStateMu.Lock()
+	defer lfn.rolloverState.rolloverStateMu.Unlock()
+
+	previousSessionEndHeight := lfn.rolloverState.currentSessionEndHeight
+	lfn.rolloverState.currentSessionEndHeight = newSessionEndHeight
+
+	// When we get a new session, check rollover against the previous session that just ended
+	rolloverCheckHeight := previousSessionEndHeight
+	if previousSessionEndHeight == 0 {
+		// First session - check against the new session
+		rolloverCheckHeight = newSessionEndHeight
+	}
+
+	lfn.rolloverState.isInSessionRollover = lfn.isInRolloverWindow(
+		lfn.rolloverState.currentBlockHeight,
+		rolloverCheckHeight,
+	)
+
+	// Log session changes
+	if previousSessionEndHeight != newSessionEndHeight {
+		lfn.logger.Debug().
+			Int64("previous_session_end_height", previousSessionEndHeight).
+			Int64("new_session_end_height", newSessionEndHeight).
+			Int64("current_block_height", lfn.rolloverState.currentBlockHeight).
+			Bool("in_rollover", lfn.rolloverState.isInSessionRollover).
+			Msg("Session end height updated")
+	}
+}
+
+// startSessionRolloverMonitoring starts background monitoring for session rollovers.
+// Called automatically when LazyFullNode is created.
+func (lfn *LazyFullNode) startSessionRolloverMonitoring() {
+	lfn.logger.Info().
+		Dur("check_interval", blockCheckInterval).
+		Int("grace_period_blocks", sessionRolloverGracePeriodBlocks).
+		Msg("Starting session rollover monitoring")
+
+	go lfn.monitorLoop()
+}
+
+// monitorLoop continuously checks block height to detect session rollovers
+func (lfn *LazyFullNode) monitorLoop() {
+	ticker := time.NewTicker(blockCheckInterval)
+	defer ticker.Stop()
+
+	for range ticker.C {
+		lfn.updateBlockHeight()
+	}
+}
+
+// updateBlockHeight fetches current block height and recalculates rollover status
+func (lfn *LazyFullNode) updateBlockHeight() {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	newHeight, err := lfn.GetCurrentBlockHeight(ctx)
+	if err != nil {
+		lfn.logger.Error().Err(err).Msg("Failed to get current block height")
+		return
+	}
+
+	lfn.rolloverState.rolloverStateMu.Lock()
+	defer lfn.rolloverState.rolloverStateMu.Unlock()
+
+	previousHeight := lfn.rolloverState.currentBlockHeight
+	lfn.rolloverState.currentBlockHeight = newHeight
+
+	// Recalculate rollover status with new block height
+	lfn.rolloverState.isInSessionRollover = lfn.isInRolloverWindow(
+		newHeight,
+		lfn.rolloverState.currentSessionEndHeight,
+	)
+
+	// Log block height changes
+	if previousHeight != newHeight {
+		lfn.logger.Debug().
+			Int64("current_height", newHeight).
+			Int64("session_end_height", lfn.rolloverState.currentSessionEndHeight).
+			Bool("in_rollover", lfn.rolloverState.isInSessionRollover).
+			Msg("Block height updated")
+	}
+}
+
+// isInRolloverWindow checks if blockHeight falls within the rollover window around sessionEndHeight.
+// Rollover window = [sessionEndHeight - 1, sessionEndHeight + gracePeriod]
+func (lfn *LazyFullNode) isInRolloverWindow(blockHeight, sessionEndHeight int64) bool {
+	if sessionEndHeight == 0 || blockHeight == 0 {
+		return false
+	}
+
+	rolloverStart := sessionEndHeight - 1
+	rolloverEnd := sessionEndHeight + sessionRolloverGracePeriodBlocks
+
+	return blockHeight >= rolloverStart && blockHeight <= rolloverEnd
+}


### PR DESCRIPTION
## 🌿 Summary

Add session rollover awareness to full node implementation to improve reliability during session transitions.

### 🌱 Primary Changes:
- Implement `sessionRolloverState` to track session transition periods
- Add background monitoring for session rollover periods via `startSessionRolloverMonitoring`
- Expose `IsInSessionRollover()` method to check current rollover status

### 🍃 Secondary changes:
- Convert log messages to structured JSON format in `cmd/main.go`
- Add passthrough implementation for `IsInSessionRollover()` in caching full node
- Add detailed logging for session and block height changes


## 💡 New TODOs 

New TODOs introduced in this PR:
- TODO_NEXT(@adshmh): Incorporate this with changes in PR #396 to only use parallel fallback request when in session rollover period Reference: https://github.com/buildwithgrove/path/pull/396  IsInSessionRollover returns true if the system is currently in a session rollover period.  A session rollover period is a critical time window that occurs around session transitions and can cause reliability issues for relay operations. The rollover period is defined as: - 1 block before the session end height - Plus a configurable grace period after the session end (default: 10 blocks)  This method enables the gateway to implement adaptive retry strategies during rollover periods  The monitoring is performed automatically in the background and this method provides a thread-safe way to check the current rollover status. - protocol/shannon/full_node.go
- TODO_TECHDEBT(@commoddity): Make this configurable via config file Grace period after session end where rollover issues may occur - protocol/shannon/fullnode_session_rollover.go

## 🛠️ Type of change

Select one or more from the following:

- [ ] New feature, functionality or library
- [ ] Bug fix
- [ ] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## 🤯 Sanity Checklist

- [ ] I have updated the GitHub Issue 'assignees', 'reviewers', 'labels', 'project', 'iteration' and 'milestone'
- [ ] For docs, I have run 'make docusaurus_start'
- [ ] For code, I have run 'make test_all'
- [ ] For configurations, I have update the documentation
- [ ] I added TODOs where applicable
