### PR TITLE
[WebSockets][Refactor] Move Shannon-specific protocol logic to `protocol/shannon`

### DIFF
--- a/protocol/shannon/context.go
+++ b/protocol/shannon/context.go
@@ -19,7 +19,6 @@ import (
 	"github.com/buildwithgrove/path/gateway"
 	protocolobservations "github.com/buildwithgrove/path/observation/protocol"
 	"github.com/buildwithgrove/path/protocol"
-	"github.com/buildwithgrove/path/websockets"
 )
 
 // Maximum endpoint payload length for error logging (100 chars)
@@ -136,28 +135,13 @@ func (rc *requestContext) HandleWebsocketRequest(logger polylog.Logger, req *htt
 	// Record endpoint query time.
 	endpointQueryTime := time.Now()
 
-	// Upgrade HTTP request from client to websocket connection.
-	// - Connection is passed to websocket bridge for Client <-> Gateway communication.
-	clientConn, err := websockets.UpgradeClientWebsocketConnection(wsLogger, req, w)
-	if err != nil {
-		return nil, err
-	}
-
-	// Create a websocket bridge for the selected endpoint.
+	// Create a Shannon-specific websocket bridge for the selected endpoint.
 	// One bridge represents a single persistent connection to a single endpoint.
 	//
 	// Note that this Bridge is returned by the Shannon protocol method and
 	// started in the Gateway package in order to pass gateway-level observations
 	// and data reporters without leaking Gateway-level logic to the protocol package.
-	bridge, err := websockets.NewBridge(
-		wsLogger,
-		clientConn,
-		rc.selectedEndpoint,
-		rc.relayRequestSigner,
-		rc.fullNode,
-		rc.serviceID,
-		buildWebsocketBridgeEndpointObservation(rc.logger, rc.serviceID, rc.selectedEndpoint),
-	)
+	bridge, err := rc.createShannonWebsocketBridge(wsLogger, req, w)
 	if err != nil {
 		wrappedErr := fmt.Errorf("%w: %v", errCreatingWebSocketConnection, err)
 		wsLogger.Error().Err(wrappedErr).Msg("Error creating websocket bridge")

--- a/protocol/shannon/websocket_connection.go
+++ b/protocol/shannon/websocket_connection.go
@@ -1,0 +1,142 @@
+package shannon
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
+
+	"github.com/gorilla/websocket"
+	"github.com/pokt-network/poktroll/pkg/polylog"
+	"github.com/pokt-network/poktroll/pkg/relayer/proxy"
+	sessiontypes "github.com/pokt-network/poktroll/x/session/types"
+	sharedtypes "github.com/pokt-network/poktroll/x/shared/types"
+
+	"github.com/buildwithgrove/path/gateway"
+	"github.com/buildwithgrove/path/request"
+	"github.com/buildwithgrove/path/websockets"
+)
+
+// createShannonWebsocketBridge creates a Shannon-specific websocket bridge.
+// This function encapsulates all Shannon-specific logic for websocket handling.
+func (rc *requestContext) createShannonWebsocketBridge(
+	logger polylog.Logger,
+	req *http.Request,
+	w http.ResponseWriter,
+) (gateway.WebsocketsBridge, error) {
+	logger = logger.With(
+		"component", "shannon_websocket_bridge",
+		"endpoint_url", rc.selectedEndpoint.PublicURL(),
+	)
+
+	protocolObservations := buildWebsocketBridgeEndpointObservation(rc.logger, rc.serviceID, rc.selectedEndpoint)
+
+	// Upgrade HTTP request from client to websocket connection.
+	// - Connection is passed to websocket bridge for Client <-> Gateway communication.
+	clientConn, err := websockets.UpgradeClientWebsocketConnection(logger, req, w)
+	if err != nil {
+		return nil, fmt.Errorf("createShannonWebsocketBridge: %s", err.Error())
+	}
+
+	// Connect to the endpoint
+	endpointConn, err := connectWebsocketEndpoint(logger, rc.selectedEndpoint)
+	if err != nil {
+		return nil, fmt.Errorf("createShannonWebsocketBridge: %s", err.Error())
+	}
+
+	// Create Shannon-specific message handlers
+	clientHandler := &shannonClientMessageHandler{
+		logger:             logger,
+		selectedEndpoint:   rc.selectedEndpoint,
+		relayRequestSigner: rc.relayRequestSigner,
+		serviceID:          rc.serviceID,
+	}
+	endpointHandler := &shannonEndpointMessageHandler{
+		logger:           logger,
+		selectedEndpoint: rc.selectedEndpoint,
+		fullNode:         rc.fullNode,
+		serviceID:        rc.serviceID,
+	}
+
+	// Create observation publisher
+	observationPublisher := &shannonObservationPublisher{
+		serviceID:            rc.serviceID,
+		protocolObservations: protocolObservations,
+	}
+
+	// Create the generic websocket bridge with Shannon-specific handlers
+	bridge, err := websockets.NewBridge(
+		logger,
+		clientConn,
+		endpointConn,
+		clientHandler,
+		endpointHandler,
+		observationPublisher,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return bridge, nil
+}
+
+// connectWebsocketEndpoint makes a websocket connection to the websocket Endpoint.
+func connectWebsocketEndpoint(logger polylog.Logger, selectedEndpoint endpoint) (*websocket.Conn, error) {
+	// Get the websocket-specific URL from the selected endpoint.
+	websocketURL, err := selectedEndpoint.WebsocketURL()
+	if err != nil {
+		logger.Error().Err(err).Msgf("❌ Selected endpoint does not support websocket RPC type: %s", selectedEndpoint.Addr())
+		return nil, err
+	}
+
+	logger.Info().Msgf("🔗 Connecting to websocket endpoint: %s", websocketURL)
+
+	// Ensure the websocket URL is valid.
+	u, err := url.Parse(websocketURL)
+	if err != nil {
+		logger.Error().Err(err).Msgf("❌ Error parsing endpoint URL: %s", websocketURL)
+		return nil, err
+	}
+
+	// Prepare the headers for the websocket connection.
+	headers := http.Header{}
+
+	// If the selected endpoint is a protocol endpoint, add the headers
+	// that the RelayMiner requires to forward the request to the Endpoint.
+	//
+	// Requests to fallback endpoints bypass the protocol so RelayMiner headers are not needed.
+	if !selectedEndpoint.IsFallback() {
+		headers = getRelayMinerConnectionHeaders(logger, selectedEndpoint.Session().GetHeader())
+	}
+
+	// Connect to the websocket endpoint using the default websocket dialer.
+	conn, _, err := websocket.DefaultDialer.Dial(u.String(), headers)
+	if err != nil {
+		logger.Error().Err(err).Msgf("❌ Error connecting to endpoint: %s", u.String())
+		return nil, err
+	}
+
+	logger.Debug().Msgf("🔗 Connected to websocket endpoint: %s", websocketURL)
+
+	return conn, nil
+}
+
+// getRelayMinerConnectionHeaders returns the headers that should be sent to the RelayMiner
+// when establishing a new websocket connection to the Endpoint.
+//
+// The headers are:
+//   - `Target-Service-Id`: The service ID of the target service.
+//   - `App-Address:` The address of the session's application.
+//   - `Rpc-Type`: The type of RPC request. Always "websocket" for websocket connection requests.
+func getRelayMinerConnectionHeaders(logger polylog.Logger, sessionHeader *sessiontypes.SessionHeader) http.Header {
+	if sessionHeader == nil {
+		logger.Error().Msg("❌ SHOULD NEVER HAPPEN: Error getting relay miner connection headers: session header is nil")
+		return http.Header{}
+	}
+
+	return http.Header{
+		request.HTTPHeaderTargetServiceID: {sessionHeader.ServiceId},
+		request.HTTPHeaderAppAddress:      {sessionHeader.ApplicationAddress},
+		proxy.RPCTypeHeader:               {strconv.Itoa(int(sharedtypes.RPCType_WEBSOCKET))},
+	}
+}

--- a/protocol/shannon/websocket_handlers.go
+++ b/protocol/shannon/websocket_handlers.go
@@ -1,0 +1,131 @@
+package shannon
+
+import (
+	"fmt"
+
+	"github.com/buildwithgrove/path/gateway"
+	"github.com/buildwithgrove/path/observation"
+	protocolobservations "github.com/buildwithgrove/path/observation/protocol"
+	"github.com/buildwithgrove/path/protocol"
+	"github.com/buildwithgrove/path/websockets"
+	"github.com/pokt-network/poktroll/pkg/polylog"
+	servicetypes "github.com/pokt-network/poktroll/x/service/types"
+	sdk "github.com/pokt-network/shannon-sdk"
+)
+
+// ---------- Shannon Client Message Handler ----------
+
+var _ websockets.MessageHandler = &shannonClientMessageHandler{}
+
+// shannonClientMessageHandler handles client messages with Shannon-specific logic.
+type shannonClientMessageHandler struct {
+	logger             polylog.Logger
+	selectedEndpoint   endpoint
+	relayRequestSigner RelayRequestSigner
+	serviceID          protocol.ServiceID
+}
+
+// HandleMessage processes a message from the client.
+func (h *shannonClientMessageHandler) HandleMessage(msg websockets.Message) ([]byte, error) {
+	h.logger.Debug().Msgf("received message from client: %s", string(msg.Data))
+
+	// If the selected endpoint is a fallback endpoint, skip protocol-level signing of the request.
+	if h.selectedEndpoint.IsFallback() {
+		return msg.Data, nil
+	}
+
+	// Sign the client message before sending it to the Endpoint
+	return h.signClientMessage(msg)
+}
+
+// signClientMessage signs the client message in order to send it to the Endpoint
+func (h *shannonClientMessageHandler) signClientMessage(msg websockets.Message) ([]byte, error) {
+	unsignedRelayRequest := &servicetypes.RelayRequest{
+		Meta: servicetypes.RelayRequestMetadata{
+			SessionHeader:           h.selectedEndpoint.Session().GetHeader(),
+			SupplierOperatorAddress: h.selectedEndpoint.Supplier(),
+		},
+		Payload: msg.Data,
+	}
+
+	app := h.selectedEndpoint.Session().GetApplication()
+	signedRelayRequest, err := h.relayRequestSigner.SignRelayRequest(unsignedRelayRequest, *app)
+	if err != nil {
+		return nil, fmt.Errorf("error signing client message: %s", err.Error())
+	}
+
+	relayRequestBz, err := signedRelayRequest.Marshal()
+	if err != nil {
+		return nil, fmt.Errorf("error marshalling signed client message: %s", err.Error())
+	}
+
+	return relayRequestBz, nil
+}
+
+// ---------- Shannon Endpoint Message Handler ----------
+
+var _ websockets.MessageHandler = &shannonEndpointMessageHandler{}
+
+// shannonEndpointMessageHandler handles endpoint messages with Shannon-specific logic.
+type shannonEndpointMessageHandler struct {
+	logger           polylog.Logger
+	selectedEndpoint endpoint
+	fullNode         FullNode
+	serviceID        protocol.ServiceID
+}
+
+// HandleMessage processes a message from the endpoint.
+func (h *shannonEndpointMessageHandler) HandleMessage(msg websockets.Message) ([]byte, error) {
+	h.logger.Debug().Msgf("received message from endpoint: %s", string(msg.Data))
+
+	// If the selected endpoint is a fallback endpoint, skip protocol-level validation of the relay response.
+	if h.selectedEndpoint.IsFallback() {
+		return msg.Data, nil
+	}
+
+	// Validate the relay response using the Shannon FullNode
+	relayResponse, err := h.fullNode.ValidateRelayResponse(sdk.SupplierAddress(h.selectedEndpoint.Supplier()), msg.Data)
+	if err != nil {
+		return nil, fmt.Errorf("error validating relay response: %w", err)
+	}
+
+	return relayResponse.Payload, nil
+}
+
+// ---------- Shannon Observation Publisher ----------
+
+var _ websockets.ObservationPublisher = &shannonObservationPublisher{}
+
+// shannonObservationPublisher handles publishing Shannon-specific observations.
+type shannonObservationPublisher struct {
+	serviceID            protocol.ServiceID
+	protocolObservations *protocolobservations.Observations
+	gatewayObservations  *observation.GatewayObservations
+	dataReporter         gateway.RequestResponseReporter
+}
+
+// SetObservationContext sets the gateway observations and data reporter.
+// This is called by the gateway when starting the bridge.
+func (p *shannonObservationPublisher) SetObservationContext(
+	gatewayObservations *observation.GatewayObservations,
+	dataReporter gateway.RequestResponseReporter,
+) {
+	p.gatewayObservations = gatewayObservations
+	p.dataReporter = dataReporter
+}
+
+// PublishObservations publishes the Shannon-specific observations for this websocket message.
+func (p *shannonObservationPublisher) PublishObservations() {
+	if p.dataReporter == nil || p.gatewayObservations == nil {
+		return
+	}
+
+	// Create the request-response observations for this websocket message
+	observations := &observation.RequestResponseObservations{
+		ServiceId: string(p.serviceID),
+		Gateway:   p.gatewayObservations,
+		Protocol:  p.protocolObservations,
+	}
+
+	p.dataReporter.Publish(observations)
+}

--- a/protocol/shannon/websocket_test.go
+++ b/protocol/shannon/websocket_test.go
@@ -1,0 +1,688 @@
+package shannon
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+	"github.com/pokt-network/poktroll/pkg/polylog/polyzero"
+	apptypes "github.com/pokt-network/poktroll/x/application/types"
+	servicetypes "github.com/pokt-network/poktroll/x/service/types"
+	sessiontypes "github.com/pokt-network/poktroll/x/session/types"
+	sharedtypes "github.com/pokt-network/poktroll/x/shared/types"
+	sdk "github.com/pokt-network/shannon-sdk"
+	"github.com/stretchr/testify/require"
+
+	"github.com/buildwithgrove/path/observation"
+	protocolobservations "github.com/buildwithgrove/path/observation/protocol"
+	"github.com/buildwithgrove/path/protocol"
+	"github.com/buildwithgrove/path/websockets"
+)
+
+type (
+	clientReq         string // clientReq is a JSON RPC request sent from client to endpoint
+	endpointResp      string // endpointResp is a JSON RPC response from endpoint to client
+	subscriptionEvent string // subscriptionEvent is a subscription push event from endpoint to client
+)
+
+var capturedShannonMessages struct {
+	sync.Mutex
+	clientRequests     map[clientReq]struct{}
+	endpointResponses  map[endpointResp]struct{}
+	subscriptionEvents map[subscriptionEvent]struct{}
+	relayRequests      []servicetypes.RelayRequest
+	relayResponses     []servicetypes.RelayResponse
+}
+
+func Test_ShannonWebsocketBridge_ProtocolEndpoints(t *testing.T) {
+	tests := []struct {
+		name               string
+		selectedEndpoint   *mockEndpoint
+		jsonrpcRequests    map[clientReq]endpointResp
+		subscriptionEvents map[subscriptionEvent]struct{}
+		expectSigning      bool
+		expectValidation   bool
+	}{
+		{
+			name: "should sign client messages and validate endpoint responses for protocol endpoints",
+			selectedEndpoint: &mockEndpoint{
+				addr:     "protocol-endpoint-1",
+				url:      "",
+				supplier: "supplier1",
+				session: &sessiontypes.Session{
+					SessionId: "session1",
+					Header: &sessiontypes.SessionHeader{
+						ServiceId:          "ethereum-mainnet",
+						ApplicationAddress: "app_address_1",
+					},
+					Application: &apptypes.Application{
+						Address: "app_address_1",
+					},
+				},
+				isFallback: false,
+			},
+			jsonrpcRequests: map[clientReq]endpointResp{
+				`{"jsonrpc":"2.0","id":1,"method":"eth_gasPrice"}`:    `{"jsonrpc":"2.0","id":1,"result":"0x337d04a3b"}`,
+				`{"jsonrpc":"2.0","id":2,"method":"eth_blockNumber"}`: `{"jsonrpc":"2.0","id":2,"result":"0x12c1b21"}`,
+			},
+			expectSigning:    true,
+			expectValidation: true,
+		},
+		{
+			name: "should handle subscription events for protocol endpoints",
+			selectedEndpoint: &mockEndpoint{
+				addr:     "protocol-endpoint-2",
+				url:      "",
+				supplier: "supplier2",
+				session: &sessiontypes.Session{
+					SessionId: "session2",
+					Header: &sessiontypes.SessionHeader{
+						ServiceId:          "ethereum-mainnet",
+						ApplicationAddress: "app_address_2",
+					},
+					Application: &apptypes.Application{
+						Address: "app_address_2",
+					},
+				},
+				isFallback: false,
+			},
+			jsonrpcRequests: map[clientReq]endpointResp{
+				`{"jsonrpc":"2.0","id":1,"method":"eth_subscribe","params":["newPendingTransactions"]}`: `{"jsonrpc":"2.0","id":1,"result":"0x456"}`,
+			},
+			subscriptionEvents: map[subscriptionEvent]struct{}{
+				`{"jsonrpc":"2.0","method":"eth_subscription","params":{"result":"0x123","subscription":"0x456"}}`: {},
+				`{"jsonrpc":"2.0","method":"eth_subscription","params":{"result":"0x789","subscription":"0x456"}}`: {},
+			},
+			expectSigning:    true,
+			expectValidation: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			c := require.New(t)
+
+			// Reset captured messages
+			capturedShannonMessages.clientRequests = make(map[clientReq]struct{})
+			capturedShannonMessages.endpointResponses = make(map[endpointResp]struct{})
+			capturedShannonMessages.subscriptionEvents = make(map[subscriptionEvent]struct{})
+			capturedShannonMessages.relayRequests = []servicetypes.RelayRequest{}
+			capturedShannonMessages.relayResponses = []servicetypes.RelayResponse{}
+
+			// Create mock request context
+			rc := &requestContext{
+				logger:             polyzero.NewLogger(),
+				selectedEndpoint:   test.selectedEndpoint,
+				relayRequestSigner: &mockRelayRequestSigner{},
+				fullNode:           &mockFullNode{},
+				serviceID:          "ethereum-mainnet",
+			}
+
+			// Create test WebSocket connections directly
+			clientConn, endpointConn := createTestWebSocketConnections(t, test.jsonrpcRequests, test.subscriptionEvents, false)
+			test.selectedEndpoint.url = "ws://test-endpoint"
+			test.selectedEndpoint.websocketURL = "ws://test-endpoint"
+
+			// Create Shannon-specific message handlers
+			clientHandler := &shannonClientMessageHandler{
+				logger:             polyzero.NewLogger(),
+				selectedEndpoint:   test.selectedEndpoint,
+				relayRequestSigner: rc.relayRequestSigner,
+				serviceID:          rc.serviceID,
+			}
+			endpointHandler := &shannonEndpointMessageHandler{
+				logger:           polyzero.NewLogger(),
+				selectedEndpoint: test.selectedEndpoint,
+				fullNode:         rc.fullNode,
+				serviceID:        rc.serviceID,
+			}
+			observationPublisher := &shannonObservationPublisher{
+				serviceID:            rc.serviceID,
+				protocolObservations: buildWebsocketBridgeEndpointObservation(rc.logger, rc.serviceID, test.selectedEndpoint),
+			}
+
+			// Create the bridge directly using the generic websocket bridge
+			bridge, err := websockets.NewBridge(
+				polyzero.NewLogger(),
+				clientConn,
+				endpointConn,
+				clientHandler,
+				endpointHandler,
+				observationPublisher,
+			)
+			c.NoError(err)
+
+			// Start the bridge
+			mockObservations := &observation.GatewayObservations{}
+			go bridge.StartAsync(mockObservations, nil)
+
+			// Wait for processing
+			time.Sleep(2 * time.Second)
+
+			// Verify message flow
+			for clientReq, endpointResp := range test.jsonrpcRequests {
+				_, exists := capturedShannonMessages.clientRequests[clientReq]
+				c.True(exists, "Client request not captured: %s", clientReq)
+				_, exists = capturedShannonMessages.endpointResponses[endpointResp]
+				c.True(exists, "Endpoint response not captured: %s", endpointResp)
+			}
+
+			// Verify protocol-specific behavior
+			if test.expectSigning {
+				c.True(len(capturedShannonMessages.relayRequests) > 0, "Expected relay requests to be signed")
+			}
+
+			if test.expectValidation {
+				c.True(len(capturedShannonMessages.relayResponses) > 0, "Expected relay responses to be validated")
+			}
+		})
+	}
+}
+
+func Test_ShannonWebsocketBridge_FallbackEndpoints(t *testing.T) {
+	c := require.New(t)
+
+	// Reset captured messages
+	capturedShannonMessages.clientRequests = make(map[clientReq]struct{})
+	capturedShannonMessages.endpointResponses = make(map[endpointResp]struct{})
+	capturedShannonMessages.relayRequests = []servicetypes.RelayRequest{}
+	capturedShannonMessages.relayResponses = []servicetypes.RelayResponse{}
+
+	fallbackEndpoint := &mockEndpoint{
+		addr:     "fallback-endpoint-1",
+		url:      "",
+		supplier: "fallback",
+		session: &sessiontypes.Session{
+			SessionId: "fallback-session",
+			Header: &sessiontypes.SessionHeader{
+				ServiceId:          "ethereum-mainnet",
+				ApplicationAddress: "fallback_app_address",
+			},
+			Application: &apptypes.Application{
+				Address: "fallback_app_address",
+			},
+		},
+		isFallback: true,
+	}
+
+	jsonrpcRequests := map[clientReq]endpointResp{
+		`{"jsonrpc":"2.0","id":1,"method":"eth_gasPrice"}`:    `{"jsonrpc":"2.0","id":1,"result":"0x337d04a3b"}`,
+		`{"jsonrpc":"2.0","id":2,"method":"eth_blockNumber"}`: `{"jsonrpc":"2.0","id":2,"result":"0x12c1b21"}`,
+	}
+
+	// Create mock request context
+	rc := &requestContext{
+		logger:             polyzero.NewLogger(),
+		selectedEndpoint:   fallbackEndpoint,
+		relayRequestSigner: &mockRelayRequestSigner{},
+		fullNode:           &mockFullNode{},
+		serviceID:          "ethereum-mainnet",
+	}
+
+	// Create test WebSocket connections directly for fallback endpoint
+	clientConn, endpointConn := createTestWebSocketConnections(t, jsonrpcRequests, nil, true)
+	fallbackEndpoint.url = "ws://fallback-endpoint"
+	fallbackEndpoint.websocketURL = "ws://fallback-endpoint"
+
+	// Create Shannon-specific message handlers for fallback endpoint
+	clientHandler := &shannonClientMessageHandler{
+		logger:             polyzero.NewLogger(),
+		selectedEndpoint:   fallbackEndpoint,
+		relayRequestSigner: rc.relayRequestSigner,
+		serviceID:          rc.serviceID,
+	}
+	endpointHandler := &shannonEndpointMessageHandler{
+		logger:           polyzero.NewLogger(),
+		selectedEndpoint: fallbackEndpoint,
+		fullNode:         rc.fullNode,
+		serviceID:        rc.serviceID,
+	}
+	observationPublisher := &shannonObservationPublisher{
+		serviceID:            rc.serviceID,
+		protocolObservations: buildWebsocketBridgeEndpointObservation(rc.logger, rc.serviceID, fallbackEndpoint),
+	}
+
+	// Create the bridge directly using the generic websocket bridge
+	bridge, err := websockets.NewBridge(
+		polyzero.NewLogger(),
+		clientConn,
+		endpointConn,
+		clientHandler,
+		endpointHandler,
+		observationPublisher,
+	)
+	c.NoError(err)
+
+	// Start the bridge
+	go bridge.StartAsync(&observation.GatewayObservations{}, nil)
+
+	// Wait for processing
+	time.Sleep(2 * time.Second)
+
+	// Verify message flow
+	for clientReq, endpointResp := range jsonrpcRequests {
+		_, exists := capturedShannonMessages.clientRequests[clientReq]
+		c.True(exists, "Client request not captured: %s", clientReq)
+		_, exists = capturedShannonMessages.endpointResponses[endpointResp]
+		c.True(exists, "Endpoint response not captured: %s", endpointResp)
+	}
+
+	// Verify fallback behavior (no signing/validation)
+	c.Equal(0, len(capturedShannonMessages.relayRequests), "Fallback endpoints should not sign requests")
+	c.Equal(0, len(capturedShannonMessages.relayResponses), "Fallback endpoints should not validate responses")
+}
+
+func Test_ShannonMessageHandlers(t *testing.T) {
+	t.Run("ClientMessageHandler", func(t *testing.T) {
+		c := require.New(t)
+
+		endpoint := &mockEndpoint{
+			addr:     "test-endpoint",
+			supplier: "supplier1",
+			session: &sessiontypes.Session{
+				Header: &sessiontypes.SessionHeader{
+					ServiceId:          "ethereum-mainnet",
+					ApplicationAddress: "app_address_1",
+				},
+				Application: &apptypes.Application{
+					Address: "app_address_1",
+				},
+			},
+			isFallback: false,
+		}
+
+		handler := &shannonClientMessageHandler{
+			logger:             polyzero.NewLogger(),
+			selectedEndpoint:   endpoint,
+			relayRequestSigner: &mockRelayRequestSigner{},
+			serviceID:          "ethereum-mainnet",
+		}
+
+		msg := websockets.Message{
+			Data:        []byte(`{"jsonrpc":"2.0","id":1,"method":"eth_gasPrice"}`),
+			MessageType: websocket.TextMessage,
+		}
+
+		result, err := handler.HandleMessage(msg)
+		c.NoError(err)
+		c.NotNil(result)
+
+		// Verify the message was signed (should be different from original)
+		c.NotEqual(msg.Data, result)
+	})
+
+	t.Run("EndpointMessageHandler", func(t *testing.T) {
+		c := require.New(t)
+
+		endpoint := &mockEndpoint{
+			addr:       "test-endpoint",
+			supplier:   "supplier1",
+			isFallback: false,
+		}
+
+		handler := &shannonEndpointMessageHandler{
+			logger:           polyzero.NewLogger(),
+			selectedEndpoint: endpoint,
+			fullNode:         &mockFullNode{},
+			serviceID:        "ethereum-mainnet",
+		}
+
+		// Create a mock relay response
+		relayResponse := &servicetypes.RelayResponse{
+			Payload: []byte(`{"jsonrpc":"2.0","id":1,"result":"0x337d04a3b"}`),
+		}
+		responseBytes, _ := relayResponse.Marshal()
+
+		msg := websockets.Message{
+			Data:        responseBytes,
+			MessageType: websocket.TextMessage,
+		}
+
+		result, err := handler.HandleMessage(msg)
+		c.NoError(err)
+		c.Equal(relayResponse.Payload, result)
+	})
+
+	t.Run("ObservationPublisher", func(t *testing.T) {
+		c := require.New(t)
+
+		publisher := &shannonObservationPublisher{
+			serviceID:            "ethereum-mainnet",
+			protocolObservations: &protocolobservations.Observations{},
+		}
+
+		// Set observation context
+		gatewayObs := &observation.GatewayObservations{}
+		mockReporter := &mockDataReporter{}
+		publisher.SetObservationContext(gatewayObs, mockReporter)
+
+		// Publish observations
+		publisher.PublishObservations()
+
+		c.True(mockReporter.publishCalled, "Publish should have been called")
+		c.NotNil(mockReporter.lastObservation, "Observation should have been published")
+	})
+}
+
+func Test_ConnectWebsocketEndpoint(t *testing.T) {
+	tests := []struct {
+		name          string
+		endpoint      *mockEndpoint
+		expectedError bool
+		testHeaders   bool
+	}{
+		{
+			name: "should connect successfully to protocol endpoint with headers",
+			endpoint: &mockEndpoint{
+				addr:       "protocol-endpoint",
+				supplier:   "supplier1",
+				isFallback: false,
+				session: &sessiontypes.Session{
+					Header: &sessiontypes.SessionHeader{
+						ServiceId:          "ethereum-mainnet",
+						ApplicationAddress: "app_address_1",
+					},
+				},
+			},
+			expectedError: false,
+			testHeaders:   true,
+		},
+		{
+			name: "should connect successfully to fallback endpoint without headers",
+			endpoint: &mockEndpoint{
+				addr:       "fallback-endpoint",
+				supplier:   "fallback",
+				isFallback: true,
+			},
+			expectedError: false,
+			testHeaders:   false,
+		},
+		{
+			name: "should fail with invalid URL",
+			endpoint: &mockEndpoint{
+				addr:          "invalid-endpoint",
+				websocketURL:  "invalid-url",
+				shouldFailURL: true,
+			},
+			expectedError: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			c := require.New(t)
+
+			if !test.endpoint.shouldFailURL {
+				// Create a test server
+				server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					upgrader := websocket.Upgrader{}
+					_, err := upgrader.Upgrade(w, r, nil)
+					if err != nil {
+						t.Error("Error during connection upgrade:", err)
+						return
+					}
+
+					// Verify headers for protocol endpoints
+					if test.testHeaders && !test.endpoint.isFallback {
+						c.NotEmpty(r.Header.Get("Target-Service-Id"))
+						c.NotEmpty(r.Header.Get("App-Address"))
+						c.NotEmpty(r.Header.Get("Rpc-Type"))
+					}
+				}))
+				defer server.Close()
+
+				wsURL := "ws" + strings.TrimPrefix(server.URL, "http")
+				test.endpoint.websocketURL = wsURL
+			}
+
+			conn, err := connectWebsocketEndpoint(polyzero.NewLogger(), test.endpoint)
+
+			if test.expectedError {
+				c.Error(err)
+				c.Nil(conn)
+			} else {
+				c.NoError(err)
+				c.NotNil(conn)
+				if conn != nil {
+					conn.Close()
+				}
+			}
+		})
+	}
+}
+
+// Helper functions and mocks
+
+func createTestWebSocketConnections(t *testing.T, jsonrpcRequests map[clientReq]endpointResp, subscriptionEvents map[subscriptionEvent]struct{}, isFallback bool) (*websocket.Conn, *websocket.Conn) {
+	// Create client connection
+	clientServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		upgrader := websocket.Upgrader{}
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			t.Error("Error upgrading client connection:", err)
+			return
+		}
+
+		// Read responses from endpoint and capture them
+		go func() {
+			for {
+				_, message, err := conn.ReadMessage()
+				if err != nil {
+					return // Connection closed
+				}
+
+				capturedShannonMessages.Lock()
+				capturedShannonMessages.endpointResponses[endpointResp(string(message))] = struct{}{}
+				capturedShannonMessages.subscriptionEvents[subscriptionEvent(string(message))] = struct{}{}
+				capturedShannonMessages.Unlock()
+			}
+		}()
+
+		// Send test messages to endpoint
+		for req := range jsonrpcRequests {
+			if err := conn.WriteMessage(websocket.TextMessage, []byte(req)); err != nil {
+				t.Error("Error sending client message:", err)
+			}
+		}
+	}))
+
+	// Create endpoint connection
+	endpointServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		upgrader := websocket.Upgrader{}
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			t.Error("Error upgrading endpoint connection:", err)
+			return
+		}
+
+		// Handle incoming messages from client
+		go func() {
+			for {
+				_, requestBz, err := conn.ReadMessage()
+				if err != nil {
+					return
+				}
+
+				var message []byte
+				if isFallback {
+					message = requestBz
+				} else {
+					var relayRequest servicetypes.RelayRequest
+					if err := relayRequest.Unmarshal(requestBz); err != nil {
+						t.Error("Error unmarshalling relay request:", err)
+						return
+					}
+					capturedShannonMessages.Lock()
+					capturedShannonMessages.relayRequests = append(capturedShannonMessages.relayRequests, relayRequest)
+					capturedShannonMessages.Unlock()
+					message = relayRequest.Payload
+				}
+
+				capturedShannonMessages.Lock()
+				capturedShannonMessages.clientRequests[clientReq(message)] = struct{}{}
+				capturedShannonMessages.Unlock()
+
+				// Send response if exists
+				if response, ok := jsonrpcRequests[clientReq(message)]; ok {
+					var responseBz []byte
+					if isFallback {
+						responseBz = []byte(response)
+					} else {
+						relayResponse := &servicetypes.RelayResponse{
+							Payload: []byte(response),
+						}
+						responseBz, _ = relayResponse.Marshal()
+						capturedShannonMessages.Lock()
+						capturedShannonMessages.relayResponses = append(capturedShannonMessages.relayResponses, *relayResponse)
+						capturedShannonMessages.Unlock()
+					}
+
+					if err := conn.WriteMessage(websocket.TextMessage, responseBz); err != nil {
+						t.Error("Error sending response:", err)
+					}
+				}
+			}
+		}()
+
+		// Send subscription events
+		for event := range subscriptionEvents {
+			var eventBz []byte
+			if isFallback {
+				eventBz = []byte(event)
+			} else {
+				relayResponse := &servicetypes.RelayResponse{
+					Payload: []byte(event),
+				}
+				eventBz, _ = relayResponse.Marshal()
+			}
+
+			if err := conn.WriteMessage(websocket.TextMessage, eventBz); err != nil {
+				t.Error("Error sending subscription event:", err)
+			}
+
+			capturedShannonMessages.Lock()
+			capturedShannonMessages.subscriptionEvents[event] = struct{}{}
+			capturedShannonMessages.Unlock()
+		}
+	}))
+
+	// Connect to both servers
+	clientWSURL := "ws" + strings.TrimPrefix(clientServer.URL, "http")
+	endpointWSURL := "ws" + strings.TrimPrefix(endpointServer.URL, "http")
+
+	clientConn, _, err := websocket.DefaultDialer.Dial(clientWSURL, nil)
+	if err != nil {
+		t.Fatal("Error connecting to client server:", err)
+	}
+
+	endpointConn, _, err := websocket.DefaultDialer.Dial(endpointWSURL, nil)
+	if err != nil {
+		t.Fatal("Error connecting to endpoint server:", err)
+	}
+
+	return clientConn, endpointConn
+}
+
+// Mock implementations
+
+type mockEndpoint struct {
+	addr          string
+	url           string
+	websocketURL  string
+	supplier      string
+	session       *sessiontypes.Session
+	isFallback    bool
+	shouldFailURL bool
+}
+
+func (e *mockEndpoint) Addr() protocol.EndpointAddr {
+	return protocol.EndpointAddr(e.addr)
+}
+
+func (e *mockEndpoint) PublicURL() string {
+	return e.url
+}
+
+func (e *mockEndpoint) WebsocketURL() (string, error) {
+	if e.shouldFailURL {
+		return "", fmt.Errorf("invalid websocket URL")
+	}
+	return e.websocketURL, nil
+}
+
+func (e *mockEndpoint) Supplier() string {
+	return e.supplier
+}
+
+func (e *mockEndpoint) Session() *sessiontypes.Session {
+	return e.session
+}
+
+func (e *mockEndpoint) IsFallback() bool {
+	return e.isFallback
+}
+
+func (e *mockEndpoint) FallbackURL(rpcType sharedtypes.RPCType) string {
+	return e.websocketURL
+}
+
+type mockRelayRequestSigner struct{}
+
+func (m *mockRelayRequestSigner) SignRelayRequest(req *servicetypes.RelayRequest, app apptypes.Application) (*servicetypes.RelayRequest, error) {
+	// Return the request as-is (mock signing)
+	return req, nil
+}
+
+type mockFullNode struct{}
+
+func (m *mockFullNode) GetApp(ctx context.Context, appAddr string) (*apptypes.Application, error) {
+	return &apptypes.Application{Address: appAddr}, nil
+}
+
+func (m *mockFullNode) GetSession(ctx context.Context, serviceID protocol.ServiceID, appAddr string) (sessiontypes.Session, error) {
+	return sessiontypes.Session{}, nil
+}
+
+func (m *mockFullNode) GetSessionWithExtendedValidity(ctx context.Context, serviceID protocol.ServiceID, appAddr string) (sessiontypes.Session, error) {
+	return sessiontypes.Session{}, nil
+}
+
+func (m *mockFullNode) GetSharedParams(ctx context.Context) (*sharedtypes.Params, error) {
+	return &sharedtypes.Params{}, nil
+}
+
+func (m *mockFullNode) GetCurrentBlockHeight(ctx context.Context) (int64, error) {
+	return 100, nil
+}
+
+func (m *mockFullNode) ValidateRelayResponse(supplierAddr sdk.SupplierAddress, responseBz []byte) (*servicetypes.RelayResponse, error) {
+	var relayResponse servicetypes.RelayResponse
+	if err := relayResponse.Unmarshal(responseBz); err != nil {
+		return nil, err
+	}
+	return &relayResponse, nil
+}
+
+func (m *mockFullNode) IsHealthy() bool {
+	return true
+}
+
+func (m *mockFullNode) GetAccountClient() *sdk.AccountClient {
+	return nil // Mock implementation
+}
+
+type mockDataReporter struct {
+	publishCalled   bool
+	lastObservation *observation.RequestResponseObservations
+}
+
+func (m *mockDataReporter) Publish(obs *observation.RequestResponseObservations) {
+	m.publishCalled = true
+	m.lastObservation = obs
+}

--- a/websockets/bridge.go
+++ b/websockets/bridge.go
@@ -3,62 +3,49 @@ package websockets
 import (
 	"context"
 	"fmt"
-	"net/http"
-	"net/url"
-	"strconv"
 
 	"github.com/gorilla/websocket"
 	"github.com/pokt-network/poktroll/pkg/polylog"
-	"github.com/pokt-network/poktroll/pkg/relayer/proxy"
-	apptypes "github.com/pokt-network/poktroll/x/application/types"
-	servicetypes "github.com/pokt-network/poktroll/x/service/types"
-	sessiontypes "github.com/pokt-network/poktroll/x/session/types"
-	sharedtypes "github.com/pokt-network/poktroll/x/shared/types"
-	sdk "github.com/pokt-network/shannon-sdk"
 
 	"github.com/buildwithgrove/path/gateway"
 	"github.com/buildwithgrove/path/observation"
-	protocolobservations "github.com/buildwithgrove/path/observation/protocol"
-	"github.com/buildwithgrove/path/protocol"
-	"github.com/buildwithgrove/path/request"
 )
 
-// TODO_TECHDEBT(@commoddity, @adshmh): The websockets package contains a large amount of Shannon-specific logic.
-// This contradicts the design pattern of keeping all protocol-specific logic in the protocol/shannon package.
-// This should be refactored in one of two different ways:
-// 		1. Move the Shannon-specific logic to the protocol/shannon package but keep websocket-specific logic in the websockets package.
-// 		2. Move all websockets logic to the protocol/shannon package.
+// Message represents a websocket message that can be:
+// - Client request
+// - Endpoint response
+// - Subscription push event (e.g. eth_subscribe)
+type Message struct {
+	// Data is the message payload
+	Data []byte
 
-// websockets.Bridge implements the gateway.WebsocketsBridge interface.
-var _ gateway.WebsocketsBridge = &Bridge{}
-
-// FullNode represents a Shannon FullNode as only Shannon supports websocket connections.
-// It is used only to validate the relay responses returned by the Endpoint.
-type FullNode interface {
-	// ValidateRelayResponse validates the raw bytes returned from an endpoint (in response to a relay request) and returns the parsed response.
-	ValidateRelayResponse(supplierAddr sdk.SupplierAddress, responseBz []byte) (*servicetypes.RelayResponse, error)
+	// MessageType is an int returned by the gorilla/websocket package
+	MessageType int
 }
 
-// RelayRequestSigner is used by the request context to sign the relay request.
-// It takes an unsigned relay request and an application, and returns a relay request signed either by the gateway that has delegation from the app.
-// If/when the Permissionless Gateway Mode is supported by the Shannon integration, the app's own private key may also be used for signing the relay request.
-type RelayRequestSigner interface {
-	SignRelayRequest(req *servicetypes.RelayRequest, app apptypes.Application) (*servicetypes.RelayRequest, error)
+// MessageHandler processes websocket messages.
+// It can transform the message data before forwarding it.
+type MessageHandler interface {
+	// HandleMessage processes a message and returns the data to forward.
+	// If an error is returned, the connection will be closed.
+	HandleMessage(msg Message) ([]byte, error)
 }
 
-// SelectedEndpoint represents a Shannon Endpoint that has been selected to service a persistent websocket connection.
-type SelectedEndpoint interface {
-	Addr() protocol.EndpointAddr
-	PublicURL() string
-	WebsocketURL() (string, error)
-	Supplier() string
-	Session() *sessiontypes.Session
-	IsFallback() bool
+// ObservationPublisher handles publishing observations after processing endpoint messages.
+type ObservationPublisher interface {
+	// PublishObservations publishes protocol-specific observations.
+	PublishObservations()
+	// SetObservationContext sets the gateway observations and data reporter.
+	SetObservationContext(gatewayObservations *observation.GatewayObservations, dataReporter gateway.RequestResponseReporter)
 }
 
 // Bridge routes data between an Endpoint and a Client.
 // One Bridge represents a single WebSocket connection
 // between a Client and a WebSocket Endpoint.
+//
+// This is a generic websocket bridge that handles the websocket protocol
+// and message routing, while delegating protocol-specific logic to the
+// provided message handlers.
 //
 // Full data flow: Client <---clientConn---> PATH Bridge <---endpointConn---> Relay Miner Bridge <------> Endpoint
 type Bridge struct {
@@ -75,60 +62,25 @@ type Bridge struct {
 	// msgChan receives messages from the Client and Endpoint and passes them to the other side of the bridge.
 	msgChan chan message
 
-	// selectedEndpoint is the Endpoint that the bridge is connected to
-	selectedEndpoint SelectedEndpoint
-	// relayRequestSigner is the RelayRequestSigner that the bridge uses to sign relay requests
-	relayRequestSigner RelayRequestSigner
-	// fullNode is the FullNode that the bridge uses to validate relay responses
-	fullNode FullNode
+	// clientMessageHandler processes messages from the client before forwarding to the endpoint
+	clientMessageHandler MessageHandler
+	// endpointMessageHandler processes messages from the endpoint before forwarding to the client
+	endpointMessageHandler MessageHandler
 
-	// serviceID is the service ID that the bridge is connected to
-	serviceID protocol.ServiceID
-
-	// dataReporter is used to export, to the data pipeline, observations made in handling websocket messages.
-	dataReporter gateway.RequestResponseReporter
-
-	// gatewayObservations in the websocket bridge contain values that will be static for the duration
-	// of the specific Bridge's operation.
-	//
-	// For example, the RequestAuth used to authorize the request.
-	//
-	// As a websocket bridge represents a single persistent connection to a single endpoint,
-	// the gatewayObservations will be the same for the duration of the bridge's operation.
-	gatewayObservations *observation.GatewayObservations
-
-	// protocolObservations in the websocket bridge contain values that will be static for the duration
-	// of the specific Bridge's operation.
-	//
-	// For example, the selected endpoint.
-	//
-	// As a websocket bridge represents a single persistent connection to a single endpoint,
-	// the protocolObservations will be the same for the duration of the bridge's operation.
-	protocolObservations *protocolobservations.Observations
+	// observationPublisher handles publishing observations after endpoint message processing
+	observationPublisher ObservationPublisher
 }
 
-// -------------------- Bridge Creation --------------------
-
-// NewBridge creates a new Bridge instance and a new connection to the Endpoint from the Endpoint URL
+// NewBridge creates a new Bridge instance with connections to both client and endpoint.
 func NewBridge(
 	logger polylog.Logger,
 	clientWSSConn *websocket.Conn,
-	selectedEndpoint SelectedEndpoint,
-	relayRequestSigner RelayRequestSigner,
-	fullNode FullNode,
-	serviceID protocol.ServiceID,
-	protocolObservations *protocolobservations.Observations,
+	endpointWSSConn *websocket.Conn,
+	clientMessageHandler MessageHandler,
+	endpointMessageHandler MessageHandler,
+	observationPublisher ObservationPublisher,
 ) (*Bridge, error) {
-	logger = logger.With(
-		"component", "bridge",
-		"endpoint_url", selectedEndpoint.PublicURL(),
-	)
-
-	// Connect to the Endpoint
-	endpointWSSConn, err := connectWebsocketEndpoint(logger, selectedEndpoint)
-	if err != nil {
-		return nil, fmt.Errorf("NewBridge: %s", err.Error())
-	}
+	logger = logger.With("component", "websocket_bridge")
 
 	// Create a context that can be canceled from either connection
 	ctx, cancelCtx := context.WithCancel(context.Background())
@@ -136,19 +88,15 @@ func NewBridge(
 	// Create a channel to pass messages between the Client and Endpoint
 	msgChan := make(chan message)
 
-	// Create bridge instance without connections first
+	// Create bridge instance
 	b := &Bridge{
 		logger: logger,
+		ctx:    ctx,
 
-		ctx: ctx,
-
-		msgChan:            msgChan,
-		selectedEndpoint:   selectedEndpoint,
-		relayRequestSigner: relayRequestSigner,
-		fullNode:           fullNode,
-
-		serviceID:            serviceID,
-		protocolObservations: protocolObservations,
+		msgChan:                msgChan,
+		clientMessageHandler:   clientMessageHandler,
+		endpointMessageHandler: endpointMessageHandler,
+		observationPublisher:   observationPublisher,
 	}
 
 	// Initialize connections with context and cancel function
@@ -172,73 +120,10 @@ func NewBridge(
 	return b, nil
 }
 
-// connectWebsocketEndpoint makes a websocket connection to the websocket Endpoint.
-func connectWebsocketEndpoint(logger polylog.Logger, selectedEndpoint SelectedEndpoint) (*websocket.Conn, error) {
-	// Get the websocket-specific URL from the selected endpoint.
-	websocketURL, err := selectedEndpoint.WebsocketURL()
-	if err != nil {
-		logger.Error().Err(err).Msgf("❌ Selected endpoint does not support websocket RPC type: %s", selectedEndpoint.Addr())
-		return nil, err
-	}
-
-	logger.Info().Msgf("🔗 Connecting to websocket endpoint: %s", websocketURL)
-
-	// Ensure the websocket URL is valid.
-	u, err := url.Parse(websocketURL)
-	if err != nil {
-		logger.Error().Err(err).Msgf("❌ Error parsing endpoint URL: %s", websocketURL)
-		return nil, err
-	}
-
-	// Prepare the headers for the websocket connection.
-	headers := http.Header{}
-
-	// If the selected endpoint is a protocol endpoint, add the headers
-	// that the RelayMiner requires to forward the request to the Endpoint.
-	//
-	// Requests to fallback endpoints bypass the protocol so RelayMiner headers are not needed.
-	if !selectedEndpoint.IsFallback() {
-		headers = getRelayMinerConnectionHeaders(logger, selectedEndpoint.Session().GetHeader())
-	}
-
-	// Connect to the websocket endpoint using the default websocket dialer.
-	conn, _, err := websocket.DefaultDialer.Dial(u.String(), headers)
-	if err != nil {
-		logger.Error().Err(err).Msgf("❌ Error connecting to endpoint: %s", u.String())
-		return nil, err
-	}
-
-	logger.Debug().Msgf("🔗 Connected to websocket endpoint: %s", websocketURL)
-
-	return conn, nil
-}
-
-// TODO_DOCUMENT(@commoddity): Document these headers and how bridge connections work in more detail.
-//
-// getRelayMinerConnectionHeaders returns the headers that should be sent to the RelayMiner
-// when establishing a new websocket connection to the Endpoint.
-//
-// The headers are:
-//   - `Target-Service-Id`: The service ID of the target service.
-//   - `App-Address:` The address of the session's application.
-//   - `Rpc-Type`: The type of RPC request. Always "websocket" for websocket connection requests.
-func getRelayMinerConnectionHeaders(logger polylog.Logger, sessionHeader *sessiontypes.SessionHeader) http.Header {
-	if sessionHeader == nil {
-		logger.Error().Msg("❌ SHOULD NEVER HAPPEN: Error getting relay miner connection headers: session header is nil")
-		return http.Header{}
-	}
-
-	return http.Header{
-		request.HTTPHeaderTargetServiceID: {sessionHeader.ServiceId},
-		request.HTTPHeaderAppAddress:      {sessionHeader.ApplicationAddress},
-		proxy.RPCTypeHeader:               {strconv.Itoa(int(sharedtypes.RPCType_WEBSOCKET))},
-	}
-}
-
-// -------------------- Bridge Operation --------------------
-
 // StartAsync starts the bridge and establishes a bidirectional communication
 // through PATH between the Client and the selected websocket endpoint.
+//
+// This method implements the gateway.WebsocketsBridge interface.
 //
 // Full data flow: Client <---clientConn---> PATH Bridge <---endpointConn---> Relay Miner Bridge <------> Endpoint
 func (b *Bridge) StartAsync(
@@ -247,13 +132,10 @@ func (b *Bridge) StartAsync(
 ) {
 	b.logger.Info().Msg("bridge operation started successfully")
 
-	// If observations are provided, use them to update the bridge's observations.
-	// These values, both gateway and protocol, are static for the duration of
-	// the bridge's operation. New observations will be set when a new Bridge is created.
-	b.gatewayObservations = gatewayObservations
-
-	// If a data reporter is provided, use it to publish observations.
-	b.dataReporter = dataReporter
+	// Set the observation context for protocol-specific observation publishing
+	if b.observationPublisher != nil {
+		b.observationPublisher.SetObservationContext(gatewayObservations, dataReporter)
+	}
 
 	// Listen for the context to be canceled and shut down the bridge
 	go func() {
@@ -303,153 +185,57 @@ func (b *Bridge) Shutdown(err error) {
 	close(b.msgChan)
 }
 
-// -------------------- Client -> Relay Miner Message Handling --------------------
-
-// handleClientMessage processes a message from the Client and sends it to a protocol or fallback endpoint.
+// handleClientMessage processes a message from the Client and sends it to the endpoint.
 func (b *Bridge) handleClientMessage(msg message) {
-	b.logger.Debug().Msgf("received message from client: %s", string(msg.data))
+	b.logger.Debug().Msgf("received message from client")
 
-	// If the selected endpoint is a fallback endpoint, skip protocol-level signing of the request.
-	if b.selectedEndpoint.IsFallback() {
-		b.handleClientFallbackEndpointMessage(msg)
-		return
+	// Create a Message struct for the handler
+	handlerMsg := Message{
+		Data:        msg.data,
+		MessageType: msg.messageType,
 	}
 
-	// If the selected endpoint is a protocol endpoint, sign the request using the RelayRequestSigner.
-	b.handleClientProtocolEndpointMessage(msg)
-}
-
-// handleClientProtocolEndpointMessage processes a message from the Client and sends it to a protocol endpoint.
-// It signs the request using the RelayRequestSigner and sends the signed request to the Endpoint.
-func (b *Bridge) handleClientProtocolEndpointMessage(msg message) {
-	b.logger.Debug().Msgf("received message from protocol endpoint: %s", string(msg.data))
-
-	// Sign the client message before sending it to the Endpoint
-	signedClientMessageBz, err := b.signClientMessage(msg)
+	// Process the message through the client message handler
+	processedData, err := b.clientMessageHandler.HandleMessage(handlerMsg)
 	if err != nil {
-		b.clientConn.handleDisconnect(fmt.Errorf("handleClientMessage: error signing client message: %w", err))
+		b.clientConn.handleDisconnect(fmt.Errorf("handleClientMessage: %w", err))
 		return
 	}
 
-	// Send the signed request to the RelayMiner, which will forward it to the Endpoint
-	if err := b.endpointConn.WriteMessage(msg.messageType, signedClientMessageBz); err != nil {
-		b.endpointConn.handleDisconnect(fmt.Errorf("handleClientMessage: error writing client message to endpoint: %w", err))
-		return
-	}
-}
-
-// signClientMessage signs the client message in order to send it to the Endpoint
-// It uses the RelayRequestSigner to sign the request and returns the signed request
-func (b *Bridge) signClientMessage(msg message) ([]byte, error) {
-	unsignedRelayRequest := &servicetypes.RelayRequest{
-		Meta: servicetypes.RelayRequestMetadata{
-			SessionHeader:           b.selectedEndpoint.Session().GetHeader(),
-			SupplierOperatorAddress: b.selectedEndpoint.Supplier(),
-		},
-		Payload: msg.data,
-	}
-
-	app := b.selectedEndpoint.Session().GetApplication()
-	signedRelayRequest, err := b.relayRequestSigner.SignRelayRequest(unsignedRelayRequest, *app)
-	if err != nil {
-		return nil, fmt.Errorf("error signing client message: %s", err.Error())
-	}
-
-	relayRequestBz, err := signedRelayRequest.Marshal()
-	if err != nil {
-		return nil, fmt.Errorf("error marshalling signed client message: %s", err.Error())
-	}
-
-	return relayRequestBz, nil
-}
-
-// handleClientFallbackEndpointMessage processes a message from the Client and sends it to a fallback endpoint
-// This skips the protocol-level signing of the request and sends the raw message to the Endpoint.
-func (b *Bridge) handleClientFallbackEndpointMessage(msg message) {
-	b.logger.Debug().Msgf("received message from fallback endpoint: %s", string(msg.data))
-
-	// Send the signed request to the RelayMiner, which will forward it to the Endpoint
-	if err := b.endpointConn.WriteMessage(msg.messageType, msg.data); err != nil {
-		b.endpointConn.handleDisconnect(fmt.Errorf("handleClientMessage: error writing client message to endpoint: %w", err))
+	// Send the processed message to the endpoint
+	if err := b.endpointConn.WriteMessage(msg.messageType, processedData); err != nil {
+		b.endpointConn.handleDisconnect(fmt.Errorf("handleClientMessage: error writing to endpoint: %w", err))
 		return
 	}
 }
 
-// -------------------- Relay Miner -> Client Message Handling --------------------
-
-// handleEndpointMessage processes a message from the Endpoint and sends it to the Client
-// It validates the relay response using the Shannon FullNode and sends the relay response to the Client
-// Subscription events pushed from the Endpoint to the Client will be handled here as well.
+// handleEndpointMessage processes a message from the Endpoint and sends it to the Client.
 func (b *Bridge) handleEndpointMessage(msg message) {
-	b.logger.Debug().Msgf("received message from endpoint: %s", string(msg.data))
+	b.logger.Debug().Msgf("received message from endpoint")
 
-	// At the end of each message received from the Endpoint, publish the observations.
-	messageObservations := b.initializeMessageObservations()
-
-	// Publish the observations to the data pipeline after the message is handled.
-	//
-	// If the data reporter is not configured using the `data_reporter_config` field
-	// in the config YAML, then the data reporter will be nil so we need to check for that.
-	// For example, when running the Gateway in a local environment, the data reporter may be nil.
-	if b.dataReporter != nil {
-		defer b.dataReporter.Publish(messageObservations)
+	// Create a Message struct for the handler
+	handlerMsg := Message{
+		Data:        msg.data,
+		MessageType: msg.messageType,
 	}
 
-	// If the selected endpoint is a fallback endpoint, skip protocol-level validation of the relay response.
-	if b.selectedEndpoint.IsFallback() {
-		b.handleEndpointFallbackEndpointMessage(msg)
-		return
-	}
-
-	// If the selected endpoint is a protocol endpoint, validate the relay response using the Shannon FullNode.
-	b.handleEndpointProtocolEndpointMessage(msg)
-}
-
-// handleEndpointProtocolEndpointMessage processes a message from the Endpoint and sends it to the Client
-// It validates the relay response using the Shannon FullNode and sends the relay response to the Client
-func (b *Bridge) handleEndpointProtocolEndpointMessage(msg message) {
-	b.logger.Debug().Msgf("received message from relay miner: %s", string(msg.data))
-
-	// Validate the relay response using the Shannon FullNode
-	relayResponse, err := b.fullNode.ValidateRelayResponse(sdk.SupplierAddress(b.selectedEndpoint.Supplier()), msg.data)
+	// Process the message through the endpoint message handler
+	processedData, err := b.endpointMessageHandler.HandleMessage(handlerMsg)
 	if err != nil {
-		// TODO_TECHDEBT(@commoddity, @adshmh): When the TODO_TECHDEBT at the top of this file is resolved,
-		// add a method to update the protocol observations based on the error in the ValidateRelayResponse method.
-		b.endpointConn.handleDisconnect(fmt.Errorf("handleEndpointMessage: error validating relay response: %w", err))
+		b.endpointConn.handleDisconnect(fmt.Errorf("handleEndpointMessage: %w", err))
 		return
 	}
 
-	// Send the relay response or subscription push event to the Client
-	if err := b.clientConn.WriteMessage(msg.messageType, relayResponse.Payload); err != nil {
-		// TODO_TECHDEBT(@commoddity, @adshmh): When the TODO_TECHDEBT at the top of this file is resolved,
-		// add a method to update the protocol observations based on the error in the WriteMessage method.
+	// Publish observations after successful message processing
+	if b.observationPublisher != nil {
+		defer b.observationPublisher.PublishObservations()
+	}
 
+	// Send the processed message to the client
+	if err := b.clientConn.WriteMessage(msg.messageType, processedData); err != nil {
 		// NOTE: On session rollover, the Endpoint will disconnect the Endpoint connection, which will trigger this
 		// error. This is expected and the Client is expected to handle the reconnection in their connection logic.
-		b.clientConn.handleDisconnect(fmt.Errorf("handleEndpointMessage: error writing endpoint message to client: %w", err))
+		b.clientConn.handleDisconnect(fmt.Errorf("handleEndpointMessage: error writing to client: %w", err))
 		return
-	}
-}
-
-// handleEndpointFallbackEndpointMessage processes a message from the Endpoint and sends it to the Client
-// This skips the protocol-level validation of the relay response and sends the raw message to the Client.
-func (b *Bridge) handleEndpointFallbackEndpointMessage(msg message) {
-	b.logger.Debug().Msgf("received message from relay miner: %s", string(msg.data))
-
-	// Send the relay response or subscription push event to the Client
-	if err := b.clientConn.WriteMessage(msg.messageType, msg.data); err != nil {
-		b.clientConn.handleDisconnect(fmt.Errorf("handleEndpointMessage: error writing endpoint message to client: %w", err))
-		return
-	}
-}
-
-// initializeMessageObservations initializes the observations for a message.
-// It copies the static values from the bridge's observations to the message observations.
-// the observation may be modified based on possible errors, etc. in the websocket request handling.
-func (b *Bridge) initializeMessageObservations() *observation.RequestResponseObservations {
-	return &observation.RequestResponseObservations{
-		ServiceId: string(b.serviceID),
-		Gateway:   b.gatewayObservations,
-		Protocol:  b.protocolObservations,
 	}
 }

--- a/websockets/connection.go
+++ b/websockets/connection.go
@@ -63,7 +63,7 @@ type websocketConnection struct {
 	msgChan chan<- message
 }
 
-// UpgradeWebsocketConnection upgrades an HTTP connection to WebSocket.
+// UpgradeClientWebsocketConnection upgrades an HTTP connection to WebSocket.
 // Used to upgrade a Client's HTTP request to a WebSocket connection.
 //
 // Note: This function uses a permissive CheckOrigin policy (always returns true),
@@ -92,7 +92,7 @@ func UpgradeClientWebsocketConnection(
 	return clientConn, nil
 }
 
-// connectClient initiates a websocket connection to the client.
+// newConnection creates a new websocket connection wrapper.
 func newConnection(
 	ctx context.Context,
 	cancelCtx context.CancelFunc,


### PR DESCRIPTION
## Objective

Refactor the websockets package to remove Shannon-specific protocol logic and properly separate concerns between protocol-agnostic websocket handling and Shannon protocol implementation.

## Origin Document

The TODO_TECHDEBT comment in `path/websockets/bridge.go` (lines 26-30) identifies that the websockets package contains a large amount of Shannon-specific logic, which contradicts the design pattern of keeping all protocol-specific logic in the `protocol/shannon` package. This architectural violation makes the code harder to maintain and extends beyond standard websocket handling.

## Goals

- Establish clear separation of concerns between protocol-agnostic websocket logic and Shannon-specific protocol implementation
- Improve maintainability by consolidating Shannon logic within the `protocol/shannon` package
- Enable future protocol extensibility by removing protocol-specific dependencies from generic websocket infrastructure
- Align codebase architecture with established design patterns used throughout PATH

## Deliverables

- [ ] **Analysis Phase**: Document current Shannon-specific logic embedded in the websockets package, including:
  - Shannon FullNode interface and `ValidateRelayResponse` calls
  - RelayRequestSigner interface and relay request signing logic
  - Shannon-specific endpoint selection and session management
  - RelayMiner connection headers and protocol-specific message handling
- [ ] **Architecture Decision**: Choose and document one of the two refactoring approaches:
  - Option 1: Move Shannon-specific logic to `protocol/shannon` package while keeping websocket-specific logic in `websockets` package
  - Option 2: Move all websockets logic to the `protocol/shannon` package
- [ ] **Interface Design**: Define clean interfaces for protocol-websocket integration that maintain the `gateway.WebsocketsBridge` contract
- [ ] **Refactor Implementation**: Execute the chosen refactoring approach, ensuring:
  - Shannon-specific types (`FullNode`, `RelayRequestSigner`, `SelectedEndpoint`) are moved to appropriate locations
  - Protocol-specific message handling (signing, validation, RelayMiner headers) is consolidated
  - Generic websocket connection management remains protocol-agnostic
- [ ] **Update Integration Points**: Modify `protocol/shannon/context.go`'s `HandleWebsocketRequest` method to work with the new architecture
- [ ] **Resolve Related TODOs**: Address the two additional TODO_TECHDEBT comments in `bridge.go` (lines 416-417, 424-425) that reference this refactoring

## Non-goals / Non-deliverables

- Adding support for additional protocols beyond Shannon (this refactor enables but doesn't implement multi-protocol support)
- Changing the external `gateway.WebsocketsBridge` interface or breaking API compatibility
- Modifying websocket connection lifecycle management or performance characteristics
- Implementing new websocket features or functionality beyond the current scope

## General deliverables

- [ ] **Comments**: Add/update TODOs and comments alongside the source code so it is easier to follow.
- [ ] **Testing**: Add new tests (unit and/or E2E) to the test suite.
- [ ] **Documentation**: Update architectural or development READMEs; use [mermaid](https://mermaid-js.github.io/mermaid/) diagrams where appropriate.

---

**Creator**: @commoddity  
**Co-Owners**: @adshmh