### PR TITLE
[Docs] fix: PATH configs links

### DIFF
--- a/docusaurus/docs/operate/getting_started/1_quickstart.md
+++ b/docusaurus/docs/operate/getting_started/1_quickstart.md
@@ -20,7 +20,7 @@ See [PATH Guard documentation](https://path.grove.city/operate/helm/guard) for d
 
 ## 1. Prepare Your Configuration
 
-First, prepare your configuration file by following [the PATH Config File instructions](https://path.grove.city/develop/path/configurations_path).
+First, prepare your configuration file by following [the PATH Config File instructions](https://path.grove.city/develop/configs/config_intro).
 
 After you have your configuration file, you can proceed with the following steps:
 

--- a/local/Dockerfile.dev
+++ b/local/Dockerfile.dev
@@ -93,7 +93,7 @@ if ! ajv validate -s /tmp/config.schema.json -d ./local/path/.config.yaml --stri
     echo "❌ Error: ./local/path/.config.yaml failed schema validation. Please fix the errors above before continuing."
     echo ""
     echo "  💡 For information about the PATH config YAML file and schema, see the documentation at: "
-    echo "       https://path.grove.city/develop/path/configurations_path "
+    echo "       https://path.grove.city/develop/configs/gateway_config "
     echo ""
     echo "  🌿 Grove employees: you may find a valid .config.yaml file on 1Password in the note called 'PATH Localnet Config' "
     echo ""

--- a/local/scripts/localnet.sh
+++ b/local/scripts/localnet.sh
@@ -328,7 +328,7 @@ check_config_files() {
     if [ ! -f "./local/path/.config.yaml" ]; then
         echo -e "\n${RED}❌ Error: ./local/path/.config.yaml not found. Ensure you have a valid config YAML file at this location.${NC}\n"
         echo -e "  💡 For information about the PATH config YAML file, see the documentation at: "
-        echo -e "       ${CYAN}https://path.grove.city/develop/path/configurations_path${NC} "
+        echo -e "       ${CYAN}https://path.grove.city/develop/configs/gateway_config${NC} "
         echo -e "\n  🌿 Grove employees: you may find a valid ${BLUE}.config.yaml${NC} file on 1Password in the note called ${BLUE}\"PATH Localnet Config\"${NC}\n"
         exit 1
     fi


### PR DESCRIPTION
## Summary

Fix PATH configuration documentation links to point to correct URL path

### Primary Changes:

- Updated PATH Config File documentation link in quickstart guide from `/develop/configs/config_intro` to `/develop/path/configurations_path`
- Updated PATH config documentation references in Docker and shell scripts to use the corrected URL path

### Secondary Changes:

- Ensured consistency across multiple files referencing PATH configuration documentation
- Updated both user-facing documentation and developer tooling references

## Issue

- N/A

## Type of change

Select one or more from the following:

- [ ] New feature, functionality or library
- [ ] Bug fix
- [x] Code health or cleanup
- [x] Documentation
- [ ] Other (specify)

## QoS Checklist

### E2E Validation & Tests

- [ ] `make path_up`
- [ ] `make test_e2e_evm_shannon`

### Observability

- [ ] 1. `make path_up`
- [ ] 2. Run the following E2E test: `make test_request__shannon_relay_util_100`
- [ ] 3. View results in LocalNet's [PATH Relay Grafana Dashboard](http://localhost:3003/d/relays/path-service-requests)

## Sanity Checklist

- [ ] I have updated the GitHub Issue `assignees`, `reviewers`, `labels`, `project`, `iteration` and `milestone`
- [ ] For docs, I have run `make docusaurus_start`
- [ ] For code, I have run `make test_all`
- [ ] For configurations, I have updated the documentation
- [ ] I added `TODO`s where applicable