### PR TITLE
[QoS][Solana][Observability] Fix: qos solana endpoint 500 status observations

### DIFF
--- a/observation/qos/solana.pb.go
+++ b/observation/qos/solana.pb.go
@@ -137,6 +137,11 @@ type SolanaEndpointObservation struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Address of the endpoint handling the request
 	EndpointAddr string `protobuf:"bytes,1,opt,name=endpoint_addr,json=endpointAddr,proto3" json:"endpoint_addr,omitempty"`
+	// HTTP status code returned to the user.
+	// It is derived from either:
+	//   - The endpoint payload parsed as a JSONRPC response.
+	//   - A generic JSONRPC error response if the endpoint payload fails to parse.
+	HttpStatusCode int32 `protobuf:"varint,2,opt,name=http_status_code,json=httpStatusCode,proto3" json:"http_status_code,omitempty"`
 	// Types that are valid to be assigned to ResponseObservation:
 	//
 	//	*SolanaEndpointObservation_GetEpochInfoResponse
@@ -184,6 +189,13 @@ func (x *SolanaEndpointObservation) GetEndpointAddr() string {
 	return ""
 }
 
+func (x *SolanaEndpointObservation) GetHttpStatusCode() int32 {
+	if x != nil {
+		return x.HttpStatusCode
+	}
+	return 0
+}
+
 func (x *SolanaEndpointObservation) GetResponseObservation() isSolanaEndpointObservation_ResponseObservation {
 	if x != nil {
 		return x.ResponseObservation
@@ -225,18 +237,18 @@ type isSolanaEndpointObservation_ResponseObservation interface {
 type SolanaEndpointObservation_GetEpochInfoResponse struct {
 	// Response from getEpochInfo
 	// Docs: https://solana.com/docs/rpc/http/getepochinfo
-	GetEpochInfoResponse *SolanaGetEpochInfoResponse `protobuf:"bytes,2,opt,name=get_epoch_info_response,json=getEpochInfoResponse,proto3,oneof"`
+	GetEpochInfoResponse *SolanaGetEpochInfoResponse `protobuf:"bytes,3,opt,name=get_epoch_info_response,json=getEpochInfoResponse,proto3,oneof"`
 }
 
 type SolanaEndpointObservation_GetHealthResponse struct {
 	// Response from getHealth
 	// Docs: https://solana.com/docs/rpc/http/gethealth
-	GetHealthResponse *SolanaGetHealthResponse `protobuf:"bytes,3,opt,name=get_health_response,json=getHealthResponse,proto3,oneof"`
+	GetHealthResponse *SolanaGetHealthResponse `protobuf:"bytes,4,opt,name=get_health_response,json=getHealthResponse,proto3,oneof"`
 }
 
 type SolanaEndpointObservation_UnrecognizedResponse struct {
 	// Responses not used in endpoint validation (e.g., getAccountInfo)
-	UnrecognizedResponse *SolanaUnrecognizedResponse `protobuf:"bytes,4,opt,name=unrecognized_response,json=unrecognizedResponse,proto3,oneof"`
+	UnrecognizedResponse *SolanaUnrecognizedResponse `protobuf:"bytes,5,opt,name=unrecognized_response,json=unrecognizedResponse,proto3,oneof"`
 }
 
 func (*SolanaEndpointObservation_GetEpochInfoResponse) isSolanaEndpointObservation_ResponseObservation() {
@@ -419,12 +431,13 @@ const file_path_qos_solana_proto_rawDesc = "" +
 	"\x0fjsonrpc_request\x18\x06 \x01(\v2\x18.path.qos.JsonRpcRequestH\x01R\x0ejsonrpcRequest\x88\x01\x01\x12X\n" +
 	"\x15endpoint_observations\x18\a \x03(\v2#.path.qos.SolanaEndpointObservationR\x14endpointObservationsB\x10\n" +
 	"\x0e_request_errorB\x12\n" +
-	"\x10_jsonrpc_request\"\xe9\x02\n" +
+	"\x10_jsonrpc_request\"\x93\x03\n" +
 	"\x19SolanaEndpointObservation\x12#\n" +
-	"\rendpoint_addr\x18\x01 \x01(\tR\fendpointAddr\x12]\n" +
-	"\x17get_epoch_info_response\x18\x02 \x01(\v2$.path.qos.SolanaGetEpochInfoResponseH\x00R\x14getEpochInfoResponse\x12S\n" +
-	"\x13get_health_response\x18\x03 \x01(\v2!.path.qos.SolanaGetHealthResponseH\x00R\x11getHealthResponse\x12[\n" +
-	"\x15unrecognized_response\x18\x04 \x01(\v2$.path.qos.SolanaUnrecognizedResponseH\x00R\x14unrecognizedResponseB\x16\n" +
+	"\rendpoint_addr\x18\x01 \x01(\tR\fendpointAddr\x12(\n" +
+	"\x10http_status_code\x18\x02 \x01(\x05R\x0ehttpStatusCode\x12]\n" +
+	"\x17get_epoch_info_response\x18\x03 \x01(\v2$.path.qos.SolanaGetEpochInfoResponseH\x00R\x14getEpochInfoResponse\x12S\n" +
+	"\x13get_health_response\x18\x04 \x01(\v2!.path.qos.SolanaGetHealthResponseH\x00R\x11getHealthResponse\x12[\n" +
+	"\x15unrecognized_response\x18\x05 \x01(\v2$.path.qos.SolanaUnrecognizedResponseH\x00R\x14unrecognizedResponseB\x16\n" +
 	"\x14response_observation\"U\n" +
 	"\x1aSolanaGetEpochInfoResponse\x12!\n" +
 	"\fblock_height\x18\x01 \x01(\x04R\vblockHeight\x12\x14\n" +

--- a/proto/path/qos/solana.proto
+++ b/proto/path/qos/solana.proto
@@ -48,17 +48,23 @@ message SolanaEndpointObservation {
   // Address of the endpoint handling the request
   string endpoint_addr = 1;
 
+  // HTTP status code returned to the user.
+  // It is derived from either:
+  //   - The endpoint payload parsed as a JSONRPC response.
+  //   - A generic JSONRPC error response if the endpoint payload fails to parse.
+  int32 http_status_code = 2;
+
   oneof response_observation {
     // Response from getEpochInfo
     // Docs: https://solana.com/docs/rpc/http/getepochinfo
-    SolanaGetEpochInfoResponse get_epoch_info_response = 2;
+    SolanaGetEpochInfoResponse get_epoch_info_response = 3;
 
     // Response from getHealth
     // Docs: https://solana.com/docs/rpc/http/gethealth
-    SolanaGetHealthResponse get_health_response = 3;
+    SolanaGetHealthResponse get_health_response = 4;
 
     // Responses not used in endpoint validation (e.g., getAccountInfo)
-    SolanaUnrecognizedResponse unrecognized_response = 4;
+    SolanaUnrecognizedResponse unrecognized_response = 5;
   }
 }
 

--- a/qos/solana/response_generic.go
+++ b/qos/solana/response_generic.go
@@ -72,7 +72,7 @@ func (r responseGeneric) GetObservation() qosobservations.SolanaEndpointObservat
 
 	return qosobservations.SolanaEndpointObservation{
 		// Set the HTTP status code using the JSONRPC Response
-		HttpStatusCode: r.Response.GetRecommendedHTTPStatusCode(),
+		HttpStatusCode: int32(r.Response.GetRecommendedHTTPStatusCode()),
 		ResponseObservation: &qosobservations.SolanaEndpointObservation_UnrecognizedResponse{
 			UnrecognizedResponse: unrecognizedResponse,
 		},

--- a/qos/solana/response_generic.go
+++ b/qos/solana/response_generic.go
@@ -71,6 +71,8 @@ func (r responseGeneric) GetObservation() qosobservations.SolanaEndpointObservat
 	}
 
 	return qosobservations.SolanaEndpointObservation{
+		// Set the HTTP status code using the JSONRPC Response
+		HttpStatusCode: r.Response.GetRecommendedHTTPStatusCode(),
 		ResponseObservation: &qosobservations.SolanaEndpointObservation_UnrecognizedResponse{
 			UnrecognizedResponse: unrecognizedResponse,
 		},

--- a/qos/solana/response_getepochinfo.go
+++ b/qos/solana/response_getepochinfo.go
@@ -71,6 +71,8 @@ type responseToGetEpochInfo struct {
 // Implements the response interface used by the requestContext struct.
 func (r responseToGetEpochInfo) GetObservation() qosobservations.SolanaEndpointObservation {
 	return qosobservations.SolanaEndpointObservation{
+		// Set the HTTP status code using the JSONRPC Response
+		HttpStatusCode: r.Response.GetRecommendedHTTPStatusCode(),
 		ResponseObservation: &qosobservations.SolanaEndpointObservation_GetEpochInfoResponse{
 			GetEpochInfoResponse: &qosobservations.SolanaGetEpochInfoResponse{
 				BlockHeight: r.epochInfo.BlockHeight,

--- a/qos/solana/response_getepochinfo.go
+++ b/qos/solana/response_getepochinfo.go
@@ -72,7 +72,7 @@ type responseToGetEpochInfo struct {
 func (r responseToGetEpochInfo) GetObservation() qosobservations.SolanaEndpointObservation {
 	return qosobservations.SolanaEndpointObservation{
 		// Set the HTTP status code using the JSONRPC Response
-		HttpStatusCode: r.Response.GetRecommendedHTTPStatusCode(),
+		HttpStatusCode: int32(r.Response.GetRecommendedHTTPStatusCode()),
 		ResponseObservation: &qosobservations.SolanaEndpointObservation_GetEpochInfoResponse{
 			GetEpochInfoResponse: &qosobservations.SolanaGetEpochInfoResponse{
 				BlockHeight: r.epochInfo.BlockHeight,

--- a/qos/solana/response_getepochinfo.go
+++ b/qos/solana/response_getepochinfo.go
@@ -19,8 +19,8 @@ func responseUnmarshallerGetEpochInfo(
 	logger = logger.With("response_processor", "getEpochInfo")
 
 	getEpochInfoResponse := responseToGetEpochInfo{
-		Logger:   logger,
-		Response: jsonrpcResp,
+		Logger:          logger,
+		jsonrpcResponse: jsonrpcResp,
 	}
 
 	// The endpoint returned an error: no need to do further processing of the response.
@@ -60,8 +60,9 @@ type epochInfo struct {
 // response to a `getEpochInfo` request.
 type responseToGetEpochInfo struct {
 	Logger polylog.Logger
+
 	// Response stores the JSONRPC response parsed from an endpoint's response bytes.
-	jsonrpc.Response
+	jsonrpcResponse jsonrpc.Response
 
 	// epochInfo stores the epochInfo struct that is parsed from the response to a `getEpochInfo` request.
 	epochInfo epochInfo
@@ -72,7 +73,7 @@ type responseToGetEpochInfo struct {
 func (r responseToGetEpochInfo) GetObservation() qosobservations.SolanaEndpointObservation {
 	return qosobservations.SolanaEndpointObservation{
 		// Set the HTTP status code using the JSONRPC Response
-		HttpStatusCode: int32(r.Response.GetRecommendedHTTPStatusCode()),
+		HttpStatusCode: int32(r.jsonrpcResponse.GetRecommendedHTTPStatusCode()),
 		ResponseObservation: &qosobservations.SolanaEndpointObservation_GetEpochInfoResponse{
 			GetEpochInfoResponse: &qosobservations.SolanaGetEpochInfoResponse{
 				BlockHeight: r.epochInfo.BlockHeight,
@@ -90,5 +91,5 @@ func (r responseToGetEpochInfo) GetObservation() qosobservations.SolanaEndpointO
 //  3. An endpoint returns a valid JSONRPC response to a valid user request:
 //     This should be returned to the user as-is.
 func (r responseToGetEpochInfo) GetJSONRPCResponse() jsonrpc.Response {
-	return r.Response
+	return r.jsonrpcResponse
 }

--- a/qos/solana/response_gethealth.go
+++ b/qos/solana/response_gethealth.go
@@ -16,8 +16,8 @@ func responseUnmarshallerGetHealth(logger polylog.Logger, jsonrpcReq jsonrpc.Req
 	logger = logger.With("response_processor", "getHealth")
 
 	getHealthResponse := responseToGetHealth{
-		Logger:   logger,
-		Response: jsonrpcResp,
+		Logger:          logger,
+		jsonrpcResponse: jsonrpcResp,
 	}
 
 	// TODO_MVP(@adshmh): validate a `getHealth` request before sending it out to an endpoint.
@@ -58,7 +58,7 @@ type responseToGetHealth struct {
 	Logger polylog.Logger
 
 	// Response stores the JSONRPC response parsed from an endpoint's response bytes.
-	jsonrpc.Response
+	jsonrpcResponse jsonrpc.Response
 
 	// HealthResult stores the result field of a response to a `getHealth` request.
 	HealthResult string
@@ -69,7 +69,7 @@ type responseToGetHealth struct {
 func (r responseToGetHealth) GetObservation() qosobservations.SolanaEndpointObservation {
 	return qosobservations.SolanaEndpointObservation{
 		// Set the HTTP status code using the JSONRPC Response
-		HttpStatusCode: int32(r.Response.GetRecommendedHTTPStatusCode()),
+		HttpStatusCode: int32(r.jsonrpcResponse.GetRecommendedHTTPStatusCode()),
 		ResponseObservation: &qosobservations.SolanaEndpointObservation_GetHealthResponse{
 			GetHealthResponse: &qosobservations.SolanaGetHealthResponse{
 				Result: r.HealthResult,
@@ -86,5 +86,5 @@ func (r responseToGetHealth) GetObservation() qosobservations.SolanaEndpointObse
 //  3. An endpoint returns a valid JSONRPC response to a valid user request:
 //     This should be returned to the user as-is.
 func (r responseToGetHealth) GetJSONRPCResponse() jsonrpc.Response {
-	return r.Response
+	return r.jsonrpcResponse
 }

--- a/qos/solana/response_gethealth.go
+++ b/qos/solana/response_gethealth.go
@@ -68,6 +68,8 @@ type responseToGetHealth struct {
 // Implements the response interface used by the requestContext struct.
 func (r responseToGetHealth) GetObservation() qosobservations.SolanaEndpointObservation {
 	return qosobservations.SolanaEndpointObservation{
+		// Set the HTTP status code using the JSONRPC Response
+		HttpStatusCode: r.Response.GetRecommendedHTTPStatusCode(),
 		ResponseObservation: &qosobservations.SolanaEndpointObservation_GetHealthResponse{
 			GetHealthResponse: &qosobservations.SolanaGetHealthResponse{
 				Result: r.HealthResult,

--- a/qos/solana/response_gethealth.go
+++ b/qos/solana/response_gethealth.go
@@ -69,7 +69,7 @@ type responseToGetHealth struct {
 func (r responseToGetHealth) GetObservation() qosobservations.SolanaEndpointObservation {
 	return qosobservations.SolanaEndpointObservation{
 		// Set the HTTP status code using the JSONRPC Response
-		HttpStatusCode: r.Response.GetRecommendedHTTPStatusCode(),
+		HttpStatusCode: int32(r.Response.GetRecommendedHTTPStatusCode()),
 		ResponseObservation: &qosobservations.SolanaEndpointObservation_GetHealthResponse{
 			GetHealthResponse: &qosobservations.SolanaGetHealthResponse{
 				Result: r.HealthResult,


### PR DESCRIPTION
## Summary

Add http_status_code field to SolanaEndpointObservation protobuf and update HTTP status retrieval logic

### Primary Changes:

- Add HttpStatusCode field to SolanaEndpointObservation protobuf message with documentation
- Update GetRequestHTTPStatus() method to prioritize endpoint observation HTTP status over request error status
- Populate HttpStatusCode field in all Solana response handlers (responseGeneric, responseToGetEpochInfo, responseToGetHealth)

### Secondary Changes:

- Renumber protobuf field indices for response_observation oneof fields (2→3, 3→4, 4→5) to accommodate new http_status_code field
- Regenerate protobuf Go code with updated field definitions and getter methods

## Issue

Solana metrics need to track endpoint 500 status codes

- Issue or PR: #{ISSUE_OR_PR_NUMBER}

## Type of change

Select one or more from the following:

- [ ] New feature, functionality or library
- [x] Bug fix
- [ ] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## QoS Checklist

### E2E Validation & Tests

- [x] `make path_up`
- [ ] `make test_e2e_evm_shannon`

### Observability

- [ ] 1. `make path_up`
- [ ] 2. Run the following E2E test: `make test_request__shannon_relay_util_100`
- [ ] 3. View results in LocalNet's [PATH Relay Grafana Dashboard](http://localhost:3003/d/relays/path-service-requests)

## Sanity Checklist

- [x] I have updated the GitHub Issue `assignees`, `reviewers`, `labels`, `project`, `iteration` and `milestone`
- [ ] For docs, I have run `make docusaurus_start`
- [ ] For code, I have run `make test_all`
- [ ] For configurations, I have updated the documentation
- [ ] I added `TODO`s where applicable
