### PR TITLE
[QoS][Solana] Fix QoS Solana: log debug entry on JSONRPC error response

### DIFF
--- a/qos/solana/response.go
+++ b/qos/solana/response.go
@@ -82,5 +82,5 @@ func unmarshalResponse(
 	}
 
 	// Default to a generic response if no method-specific response is found.
-	return responseUnmarshallerGeneric(logger, jsonrpcReq, data)
+	return responseUnmarshallerGeneric(logger, jsonrpcReq, jsonrpcResponse)
 }

--- a/qos/solana/response_generic.go
+++ b/qos/solana/response_generic.go
@@ -1,7 +1,6 @@
 package solana
 
 import (
-	"encoding/json"
 	"time"
 
 	"github.com/pokt-network/poktroll/pkg/polylog"
@@ -34,16 +33,20 @@ const (
 func responseUnmarshallerGeneric(
 	logger polylog.Logger,
 	jsonrpcReq jsonrpc.Request,
-	data []byte,
+	jsonrpcResp jsonrpc.Response,
 ) response {
-	var response jsonrpc.Response
-	if err := json.Unmarshal(data, &response); err != nil {
-		return getGenericJSONRPCErrResponse(logger, jsonrpcReq.ID, data, err)
+	// Log a debug entry if the JSONRPC Response indicates an error.
+	if jsonrpcResp.Error != nil {
+		logger.With(
+			"jsonrpc_request_method", jsonrpcReq.Method,
+			"jsonrpc_response_error_code", jsonrpcResp.Error.Code,
+			"jsonrpc_response_error_message", jsonrpcResp.Error.Message,
+		).Info().Msg("Received JSONRPC error response from endpoint.")
 	}
 
 	return responseGeneric{
 		Logger:          logger,
-		jsonrpcResponse: response,
+		jsonrpcResponse: jsonrpcResp,
 	}
 }
 


### PR DESCRIPTION
## Summary

Log a debug message if Solana endpoint JSONRPC response indicates an error.

### Primary Changes:

- Log a debug message if Solana endpoint JSONRPC response indicates an error.

## Issue

Need to track Solana JSONRPC responses indicating an error.

- Issue or PR: #{ISSUE_OR_PR_NUMBER}

## Type of change

Select one or more from the following:

- [x] New feature, functionality or library
- [ ] Bug fix
- [ ] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## QoS Checklist

### E2E Validation & Tests

- [x] `make path_up`
- [ ] `make test_e2e_evm_shannon`

### Observability

- [ ] 1. `make path_up`
- [ ] 2. Run the following E2E test: `make test_request__shannon_relay_util_100`
- [ ] 3. View results in LocalNet's [PATH Relay Grafana Dashboard](http://localhost:3003/d/relays/path-service-requests)

## Sanity Checklist

- [ ] I have updated the GitHub Issue `assignees`, `reviewers`, `labels`, `project`, `iteration` and `milestone`
- [ ] For docs, I have run `make docusaurus_start`
- [ ] For code, I have run `make test_all`
- [ ] For configurations, I have updated the documentation
- [ ] I added `TODO`s where applicable
