### PR TITLE
[Websockets][QoS] Add websockets QoS checks with separate protocol-level endpoint sanction stores for websockets and HTTP

### DIFF
--- a/config/service_qos_config.go
+++ b/config/service_qos_config.go
@@ -49,350 +49,639 @@ var shannonServices = []ServiceQoSConfig{
 	// *** EVM Services (Archival) ***
 
 	// Arbitrum One
-	evm.NewEVMServiceQoSConfig("arb-one", "0xa4b1", evm.NewEVMArchivalCheckConfig(
-		// https://arbiscan.io/address/0xb38e8c17e38363af6ebdcb3dae12e0243582891d
-		"0xb38e8c17e38363af6ebdcb3dae12e0243582891d",
-		// Contract start block
-		3_057_700,
-	)),
+	evm.NewEVMServiceQoSConfig(
+		"arb-one", "0xa4b1",
+		evm.NewEVMArchivalCheckConfig(
+			// https://arbiscan.io/address/0xb38e8c17e38363af6ebdcb3dae12e0243582891d
+			"0xb38e8c17e38363af6ebdcb3dae12e0243582891d",
+			// Contract start block
+			3_057_700,
+		),
+		map[sharedtypes.RPCType]struct{}{
+			sharedtypes.RPCType_JSON_RPC: {},
+		},
+	),
 
 	// Arbitrum Sepolia Testnet
-	evm.NewEVMServiceQoSConfig("arb-sepolia-testnet", "0x66EEE", evm.NewEVMArchivalCheckConfig(
-		// https://sepolia.arbiscan.io/address/0x22b65d0b9b59af4d3ed59f18b9ad53f5f4908b54
-		"0x22b65d0b9b59af4d3ed59f18b9ad53f5f4908b54",
-		// Contract start block
-		132_000_000,
-	)),
+	evm.NewEVMServiceQoSConfig(
+		"arb-sepolia-testnet",
+		"0x66EEE",
+		evm.NewEVMArchivalCheckConfig(
+			// https://sepolia.arbiscan.io/address/0x22b65d0b9b59af4d3ed59f18b9ad53f5f4908b54
+			"0x22b65d0b9b59af4d3ed59f18b9ad53f5f4908b54",
+			// Contract start block
+			132_000_000,
+		),
+		map[sharedtypes.RPCType]struct{}{
+			sharedtypes.RPCType_JSON_RPC: {},
+		},
+	),
 
 	// Avalanche
-	evm.NewEVMServiceQoSConfig("avax", "0xa86a", evm.NewEVMArchivalCheckConfig(
-		// https://avascan.info/blockchain/c/address/0x9f8c163cBA728e99993ABe7495F06c0A3c8Ac8b9
-		"0x9f8c163cBA728e99993ABe7495F06c0A3c8Ac8b9",
-		// Contract start block
-		5_000_000,
-	)),
+	evm.NewEVMServiceQoSConfig(
+		"avax",
+		"0xa86a",
+		evm.NewEVMArchivalCheckConfig(
+			// https://avascan.info/blockchain/c/address/0x9f8c163cBA728e99993ABe7495F06c0A3c8Ac8b9
+			"0x9f8c163cBA728e99993ABe7495F06c0A3c8Ac8b9",
+			// Contract start block
+			5_000_000,
+		),
+		map[sharedtypes.RPCType]struct{}{
+			sharedtypes.RPCType_JSON_RPC: {},
+		},
+	),
 
 	// Avalanche-DFK
-	evm.NewEVMServiceQoSConfig("avax-dfk", "0xd2af", evm.NewEVMArchivalCheckConfig(
-		// https://avascan.info/blockchain/dfk/address/0xCCb93dABD71c8Dad03Fc4CE5559dC3D89F67a260
-		"0xCCb93dABD71c8Dad03Fc4CE5559dC3D89F67a260",
-		// Contract start block
-		45_000_000,
-	)),
+	evm.NewEVMServiceQoSConfig(
+		"avax-dfk",
+		"0xd2af",
+		evm.NewEVMArchivalCheckConfig(
+			// https://avascan.info/blockchain/dfk/address/0xCCb93dABD71c8Dad03Fc4CE5559dC3D89F67a260
+			"0xCCb93dABD71c8Dad03Fc4CE5559dC3D89F67a260",
+			// Contract start block
+			45_000_000,
+		),
+		map[sharedtypes.RPCType]struct{}{
+			sharedtypes.RPCType_JSON_RPC: {},
+		},
+	),
 
 	// Base
-	evm.NewEVMServiceQoSConfig("base", "0x2105", evm.NewEVMArchivalCheckConfig(
-		// https://basescan.org/address/0x3304e22ddaa22bcdc5fca2269b418046ae7b566a
-		"0x3304E22DDaa22bCdC5fCa2269b418046aE7b566A",
-		// Contract start block
-		4_504_400,
-	)),
+	evm.NewEVMServiceQoSConfig(
+		"base",
+		"0x2105",
+		evm.NewEVMArchivalCheckConfig(
+			// https://basescan.org/address/0x3304e22ddaa22bcdc5fca2269b418046ae7b566a
+			"0x3304E22DDaa22bCdC5fCa2269b418046aE7b566A",
+			// Contract start block
+			4_504_400,
+		),
+		map[sharedtypes.RPCType]struct{}{
+			sharedtypes.RPCType_JSON_RPC:  {},
+			sharedtypes.RPCType_WEBSOCKET: {},
+		},
+	),
 
 	// Base Sepolia Testnet
-	evm.NewEVMServiceQoSConfig("base-sepolia-testnet", "0x14a34", evm.NewEVMArchivalCheckConfig(
-		// https://sepolia.basescan.org/address/0xbab76e4365a2dff89ddb2d3fc9994103b48886c0
-		"0xbab76e4365a2dff89ddb2d3fc9994103b48886c0",
-		// Contract start block
-		13_000_000,
-	)),
+	evm.NewEVMServiceQoSConfig(
+		"base-sepolia-testnet",
+		"0x14a34",
+		evm.NewEVMArchivalCheckConfig(
+			// https://sepolia.basescan.org/address/0xbab76e4365a2dff89ddb2d3fc9994103b48886c0
+			"0xbab76e4365a2dff89ddb2d3fc9994103b48886c0",
+			// Contract start block
+			13_000_000,
+		),
+		map[sharedtypes.RPCType]struct{}{
+			sharedtypes.RPCType_JSON_RPC: {},
+		},
+	),
 
 	// Berachain
-	evm.NewEVMServiceQoSConfig("bera", "0x138de", evm.NewEVMArchivalCheckConfig(
-		// https://berascan.com/address/0x6969696969696969696969696969696969696969
-		"0x6969696969696969696969696969696969696969",
-		// Contract start block
-		2_000_000,
-	)),
+	evm.NewEVMServiceQoSConfig(
+		"bera",
+		"0x138de",
+		evm.NewEVMArchivalCheckConfig(
+			// https://berascan.com/address/0x6969696969696969696969696969696969696969
+			"0x6969696969696969696969696969696969696969",
+			// Contract start block
+			2_000_000,
+		),
+		map[sharedtypes.RPCType]struct{}{
+			sharedtypes.RPCType_JSON_RPC: {},
+		},
+	),
 
 	// Blast
-	evm.NewEVMServiceQoSConfig("blast", "0x13e31", evm.NewEVMArchivalCheckConfig(
-		// https://blastscan.io/address/0x4300000000000000000000000000000000000004
-		"0x4300000000000000000000000000000000000004",
-		// Contract start block
-		1_000_000,
-	)),
+	evm.NewEVMServiceQoSConfig(
+		"blast",
+		"0x13e31",
+		evm.NewEVMArchivalCheckConfig(
+			// https://blastscan.io/address/0x4300000000000000000000000000000000000004
+			"0x4300000000000000000000000000000000000004",
+			// Contract start block
+			1_000_000,
+		),
+		map[sharedtypes.RPCType]struct{}{
+			sharedtypes.RPCType_JSON_RPC: {},
+		},
+	),
 
 	// BNB Smart Chain
-	evm.NewEVMServiceQoSConfig("bsc", "0x38", evm.NewEVMArchivalCheckConfig(
-		// https://bsctrace.com/address/0xfb50526f49894b78541b776f5aaefe43e3bd8590
-		"0xfb50526f49894b78541b776f5aaefe43e3bd8590",
-		// Contract start block
-		33_049_200,
-	)),
+	evm.NewEVMServiceQoSConfig(
+		"bsc",
+		"0x38",
+		evm.NewEVMArchivalCheckConfig(
+			// https://bsctrace.com/address/0xfb50526f49894b78541b776f5aaefe43e3bd8590
+			"0xfb50526f49894b78541b776f5aaefe43e3bd8590",
+			// Contract start block
+			33_049_200,
+		),
+		map[sharedtypes.RPCType]struct{}{
+			sharedtypes.RPCType_JSON_RPC:  {},
+			sharedtypes.RPCType_WEBSOCKET: {},
+		},
+	),
 
 	// Boba
-	evm.NewEVMServiceQoSConfig("boba", "0x120", evm.NewEVMArchivalCheckConfig(
-		// https://bobascan.com/address/0x3A92cA39476fF84Dc579C868D4D7dE125513B034
-		"0x3A92cA39476fF84Dc579C868D4D7dE125513B034",
-		// Contract start block
-		3_060_300,
-	)),
+	evm.NewEVMServiceQoSConfig(
+		"boba",
+		"0x120",
+		evm.NewEVMArchivalCheckConfig(
+			// https://bobascan.com/address/0x3A92cA39476fF84Dc579C868D4D7dE125513B034
+			"0x3A92cA39476fF84Dc579C868D4D7dE125513B034",
+			// Contract start block
+			3_060_300,
+		),
+		map[sharedtypes.RPCType]struct{}{
+			sharedtypes.RPCType_JSON_RPC: {},
+		},
+	),
 
 	// Celo
-	evm.NewEVMServiceQoSConfig("celo", "0xa4ec", evm.NewEVMArchivalCheckConfig(
-		// https://celo.blockscout.com/address/0xf89d7b9c864f589bbF53a82105107622B35EaA40
-		"0xf89d7b9c864f589bbF53a82105107622B35EaA40",
-		// Contract start block
-		20_000_000,
-	)),
+	evm.NewEVMServiceQoSConfig(
+		"celo",
+		"0xa4ec",
+		evm.NewEVMArchivalCheckConfig(
+			// https://celo.blockscout.com/address/0xf89d7b9c864f589bbF53a82105107622B35EaA40
+			"0xf89d7b9c864f589bbF53a82105107622B35EaA40",
+			// Contract start block
+			20_000_000,
+		),
+		map[sharedtypes.RPCType]struct{}{
+			sharedtypes.RPCType_JSON_RPC: {},
+		},
+	),
 
 	// Ethereum
-	evm.NewEVMServiceQoSConfig("eth", defaultEVMChainID, evm.NewEVMArchivalCheckConfig(
-		// https://etherscan.io/address/0x28C6c06298d514Db089934071355E5743bf21d60
-		"0x28C6c06298d514Db089934071355E5743bf21d60",
-		// Contract start block
-		12_300_000,
-	)),
+	evm.NewEVMServiceQoSConfig(
+		"eth",
+		defaultEVMChainID,
+		evm.NewEVMArchivalCheckConfig(
+			// https://etherscan.io/address/0x28C6c06298d514Db089934071355E5743bf21d60
+			"0x28C6c06298d514Db089934071355E5743bf21d60",
+			// Contract start block
+			12_300_000,
+		),
+		map[sharedtypes.RPCType]struct{}{
+			sharedtypes.RPCType_JSON_RPC: {},
+		},
+	),
 
 	// Ethereum Holesky Testnet
-	evm.NewEVMServiceQoSConfig("eth-holesky-testnet", "0x4268", evm.NewEVMArchivalCheckConfig(
-		// https://holesky.etherscan.io/address/0xc6392ad8a14794ea57d237d12017e7295bea2363
-		"0xc6392ad8a14794ea57d237d12017e7295bea2363",
-		// Contract start block
-		1_900_384,
-	)),
+	evm.NewEVMServiceQoSConfig(
+		"eth-holesky-testnet",
+		"0x4268",
+		evm.NewEVMArchivalCheckConfig(
+			// https://holesky.etherscan.io/address/0xc6392ad8a14794ea57d237d12017e7295bea2363
+			"0xc6392ad8a14794ea57d237d12017e7295bea2363",
+			// Contract start block
+			1_900_384,
+		),
+		map[sharedtypes.RPCType]struct{}{
+			sharedtypes.RPCType_JSON_RPC: {},
+		},
+	),
 
 	// Ethereum Sepolia Testnet
-	evm.NewEVMServiceQoSConfig("eth-sepolia-testnet", "0xaa36a7", evm.NewEVMArchivalCheckConfig(
-		// https://sepolia.etherscan.io/address/0xc0f3833b7e7216eecd9f6bc2c7927a7aa36ab58b
-		"0xc0f3833b7e7216eecd9f6bc2c7927a7aa36ab58b",
-		// Contract start block
-		6_412_177,
-	)),
+	evm.NewEVMServiceQoSConfig(
+		"eth-sepolia-testnet",
+		"0xaa36a7",
+		evm.NewEVMArchivalCheckConfig(
+			// https://sepolia.etherscan.io/address/0xc0f3833b7e7216eecd9f6bc2c7927a7aa36ab58b
+			"0xc0f3833b7e7216eecd9f6bc2c7927a7aa36ab58b",
+			// Contract start block
+			6_412_177,
+		),
+		map[sharedtypes.RPCType]struct{}{
+			sharedtypes.RPCType_JSON_RPC: {},
+		},
+	),
 
 	// Fantom
-	evm.NewEVMServiceQoSConfig("fantom", "0xfa", evm.NewEVMArchivalCheckConfig(
-		// https://explorer.fantom.network/address/0xaabf86ab3646a7064aa2f61e5959e39129ca46b6
-		"0xaabf86ab3646a7064aa2f61e5959e39129ca46b6",
-		// Contract start block
-		110_633_000,
-	)),
+	evm.NewEVMServiceQoSConfig(
+		"fantom",
+		"0xfa",
+		evm.NewEVMArchivalCheckConfig(
+			// https://explorer.fantom.network/address/0xaabf86ab3646a7064aa2f61e5959e39129ca46b6
+			"0xaabf86ab3646a7064aa2f61e5959e39129ca46b6",
+			// Contract start block
+			110_633_000,
+		),
+		map[sharedtypes.RPCType]struct{}{
+			sharedtypes.RPCType_JSON_RPC: {},
+		},
+	),
 
 	// Fuse
-	evm.NewEVMServiceQoSConfig("fuse", "0x7a", evm.NewEVMArchivalCheckConfig(
-		// https://explorer.fuse.io/address/0x3014ca10b91cb3D0AD85fEf7A3Cb95BCAc9c0f79
-		"0x3014ca10b91cb3D0AD85fEf7A3Cb95BCAc9c0f79",
-		// Contract start block
-		15_000_000,
-	)),
+	evm.NewEVMServiceQoSConfig(
+		"fuse",
+		"0x7a",
+		evm.NewEVMArchivalCheckConfig(
+			// https://explorer.fuse.io/address/0x3014ca10b91cb3D0AD85fEf7A3Cb95BCAc9c0f79
+			"0x3014ca10b91cb3D0AD85fEf7A3Cb95BCAc9c0f79",
+			// Contract start block
+			15_000_000,
+		),
+		map[sharedtypes.RPCType]struct{}{
+			sharedtypes.RPCType_JSON_RPC: {},
+		},
+	),
 
 	// Giwa
 	// TODO_NEXT(@commoddity): Update to use correct EVM chain ID once `giwa` mainnet is live.
 	// TODO_NEXT(@commoddity): Add archival check config for Giwa once `giwa` mainnet is live.
-	evm.NewEVMServiceQoSConfig("giwa", "0x1", nil),
+	evm.NewEVMServiceQoSConfig("giwa", "0x1", nil, map[sharedtypes.RPCType]struct{}{
+		sharedtypes.RPCType_JSON_RPC: {},
+	}),
 
 	// Giwa Sepolia Testnet
-	evm.NewEVMServiceQoSConfig("giwa-sepolia-testnet", "0x164ce", evm.NewEVMArchivalCheckConfig(
-		// https://sepolia-explorer.giwa.io/address/0xA2a51Cca837B8ebc00dA2810e72F386Ee0dD08a0
-		"0xA2a51Cca837B8ebc00dA2810e72F386Ee0dD08a0",
-		// Contract start block
-		3_456_000,
-	)),
+	evm.NewEVMServiceQoSConfig(
+		"giwa-sepolia-testnet",
+		"0x164ce",
+		evm.NewEVMArchivalCheckConfig(
+			// https://sepolia-explorer.giwa.io/address/0xA2a51Cca837B8ebc00dA2810e72F386Ee0dD08a0
+			"0xA2a51Cca837B8ebc00dA2810e72F386Ee0dD08a0",
+			// Contract start block
+			3_456_000,
+		),
+		map[sharedtypes.RPCType]struct{}{
+			sharedtypes.RPCType_JSON_RPC: {},
+		},
+	),
 
 	// Gnosis
-	evm.NewEVMServiceQoSConfig("gnosis", "0x64", evm.NewEVMArchivalCheckConfig(
-		// https://gnosisscan.io/address/0xe91d153e0b41518a2ce8dd3d7944fa863463a97d
-		"0xe91d153e0b41518a2ce8dd3d7944fa863463a97d",
-		// Contract start block
-		20_000_000,
-	)),
+	evm.NewEVMServiceQoSConfig(
+		"gnosis",
+		"0x64",
+		evm.NewEVMArchivalCheckConfig(
+			// https://gnosisscan.io/address/0xe91d153e0b41518a2ce8dd3d7944fa863463a97d
+			"0xe91d153e0b41518a2ce8dd3d7944fa863463a97d",
+			// Contract start block
+			20_000_000,
+		),
+		map[sharedtypes.RPCType]struct{}{
+			sharedtypes.RPCType_JSON_RPC: {},
+		},
+	),
 
 	// Harmony-0
-	evm.NewEVMServiceQoSConfig("harmony", "0x63564c40", evm.NewEVMArchivalCheckConfig(
-		// https://explorer.harmony.one/address/one19senwle0ezp3he6ed9xkc7zeg5rs94r0ecpp0a?shard=0
-		"one19senwle0ezp3he6ed9xkc7zeg5rs94r0ecpp0a",
-		// Contract start block
-		60_000_000,
-	)),
+	evm.NewEVMServiceQoSConfig(
+		"harmony",
+		"0x63564c40",
+		evm.NewEVMArchivalCheckConfig(
+			// https://explorer.harmony.one/address/one19senwle0ezp3he6ed9xkc7zeg5rs94r0ecpp0a?shard=0
+			"one19senwle0ezp3he6ed9xkc7zeg5rs94r0ecpp0a",
+			// Contract start block
+			60_000_000,
+		),
+		map[sharedtypes.RPCType]struct{}{
+			sharedtypes.RPCType_JSON_RPC: {},
+		},
+	),
 
 	// Ink
-	evm.NewEVMServiceQoSConfig("ink", "0xdef1", evm.NewEVMArchivalCheckConfig(
-		// https://explorer.inkonchain.com/address/0x4200000000000000000000000000000000000006
-		"0x4200000000000000000000000000000000000006",
-		// Contract start block
-		4_500_000,
-	)),
+	evm.NewEVMServiceQoSConfig(
+		"ink",
+		"0xdef1",
+		evm.NewEVMArchivalCheckConfig(
+			// https://explorer.inkonchain.com/address/0x4200000000000000000000000000000000000006
+			"0x4200000000000000000000000000000000000006",
+			// Contract start block
+			4_500_000,
+		),
+		map[sharedtypes.RPCType]struct{}{
+			sharedtypes.RPCType_JSON_RPC: {},
+		},
+	),
 
 	// IoTeX
-	evm.NewEVMServiceQoSConfig("iotex", "0x1251", evm.NewEVMArchivalCheckConfig(
-		// https://iotexscan.io/address/0x0a7f9ea31ca689f346e1661cf73a47c69d4bd883#transactions
-		"0x0a7f9ea31ca689f346e1661cf73a47c69d4bd883",
-		// Contract start block
-		6_440_916,
-	)),
+	evm.NewEVMServiceQoSConfig(
+		"iotex",
+		"0x1251",
+		evm.NewEVMArchivalCheckConfig(
+			// https://iotexscan.io/address/0x0a7f9ea31ca689f346e1661cf73a47c69d4bd883#transactions
+			"0x0a7f9ea31ca689f346e1661cf73a47c69d4bd883",
+			// Contract start block
+			6_440_916,
+		),
+		map[sharedtypes.RPCType]struct{}{
+			sharedtypes.RPCType_JSON_RPC: {},
+		},
+	),
 
 	// Kaia
-	evm.NewEVMServiceQoSConfig("kaia", "0x2019", evm.NewEVMArchivalCheckConfig(
-		// https://www.kaiascan.io/address/0x0051ef9259c7ec0644a80e866ab748a2f30841b3
-		"0x0051ef9259c7ec0644a80e866ab748a2f30841b3",
-		// Contract start block
-		170_000_000,
-	)),
+	evm.NewEVMServiceQoSConfig(
+		"kaia",
+		"0x2019",
+		evm.NewEVMArchivalCheckConfig(
+			// https://www.kaiascan.io/address/0x0051ef9259c7ec0644a80e866ab748a2f30841b3
+			"0x0051ef9259c7ec0644a80e866ab748a2f30841b3",
+			// Contract start block
+			170_000_000,
+		),
+		map[sharedtypes.RPCType]struct{}{
+			sharedtypes.RPCType_JSON_RPC: {},
+		},
+	),
 
 	// Linea
-	evm.NewEVMServiceQoSConfig("linea", "0xe708", evm.NewEVMArchivalCheckConfig(
-		// https://lineascan.build/address/0xf89d7b9c864f589bbf53a82105107622b35eaa40
-		"0xf89d7b9c864f589bbf53a82105107622b35eaa40",
-		// Contract start block
-		10_000_000,
-	)),
+	evm.NewEVMServiceQoSConfig(
+		"linea",
+		"0xe708",
+		evm.NewEVMArchivalCheckConfig(
+			// https://lineascan.build/address/0xf89d7b9c864f589bbf53a82105107622b35eaa40
+			"0xf89d7b9c864f589bbf53a82105107622b35eaa40",
+			// Contract start block
+			10_000_000,
+		),
+		map[sharedtypes.RPCType]struct{}{
+			sharedtypes.RPCType_JSON_RPC: {},
+		},
+	),
 
 	// Mantle
-	evm.NewEVMServiceQoSConfig("mantle", "0x1388", evm.NewEVMArchivalCheckConfig(
-		// https://explorer.mantle.xyz/address/0x588846213A30fd36244e0ae0eBB2374516dA836C
-		"0x588846213A30fd36244e0ae0eBB2374516dA836C",
-		// Contract start block
-		60_000_000,
-	)),
+	evm.NewEVMServiceQoSConfig(
+		"mantle",
+		"0x1388",
+		evm.NewEVMArchivalCheckConfig(
+			// https://explorer.mantle.xyz/address/0x588846213A30fd36244e0ae0eBB2374516dA836C
+			"0x588846213A30fd36244e0ae0eBB2374516dA836C",
+			// Contract start block
+			60_000_000,
+		),
+		map[sharedtypes.RPCType]struct{}{
+			sharedtypes.RPCType_JSON_RPC: {},
+		},
+	),
 
 	// Metis
-	evm.NewEVMServiceQoSConfig("metis", "0x440", evm.NewEVMArchivalCheckConfig(
-		// https://explorer.metis.io/address/0xfad31cd4d45Ac7C4B5aC6A0044AA05Ca7C017e62
-		"0xfad31cd4d45Ac7C4B5aC6A0044AA05Ca7C017e62",
-		// Contract start block
-		15_000_000,
-	)),
+	evm.NewEVMServiceQoSConfig(
+		"metis",
+		"0x440",
+		evm.NewEVMArchivalCheckConfig(
+			// https://explorer.metis.io/address/0xfad31cd4d45Ac7C4B5aC6A0044AA05Ca7C017e62
+			"0xfad31cd4d45Ac7C4B5aC6A0044AA05Ca7C017e62",
+			// Contract start block
+			15_000_000,
+		),
+		map[sharedtypes.RPCType]struct{}{
+			sharedtypes.RPCType_JSON_RPC: {},
+		},
+	),
 
 	// Moonbeam
-	evm.NewEVMServiceQoSConfig("moonbeam", "0x504", evm.NewEVMArchivalCheckConfig(
-		// https://moonscan.io/address/0xf89d7b9c864f589bbf53a82105107622b35eaa40
-		"0xf89d7b9c864f589bbf53a82105107622b35eaa40",
-		// Contract start block
-		677_000,
-	)),
+	evm.NewEVMServiceQoSConfig(
+		"moonbeam",
+		"0x504",
+		evm.NewEVMArchivalCheckConfig(
+			// https://moonscan.io/address/0xf89d7b9c864f589bbf53a82105107622b35eaa40
+			"0xf89d7b9c864f589bbf53a82105107622b35eaa40",
+			// Contract start block
+			677_000,
+		),
+		map[sharedtypes.RPCType]struct{}{
+			sharedtypes.RPCType_JSON_RPC: {},
+		},
+	),
 
 	// Oasys
-	evm.NewEVMServiceQoSConfig("oasys", "0xf8", evm.NewEVMArchivalCheckConfig(
-		// https://explorer.oasys.games/address/0xf89d7b9c864f589bbF53a82105107622B35EaA40
-		"0xf89d7b9c864f589bbF53a82105107622B35EaA40",
-		// Contract start block
-		424_300,
-	)),
+	evm.NewEVMServiceQoSConfig(
+		"oasys",
+		"0xf8",
+		evm.NewEVMArchivalCheckConfig(
+			// https://explorer.oasys.games/address/0xf89d7b9c864f589bbF53a82105107622B35EaA40
+			"0xf89d7b9c864f589bbF53a82105107622B35EaA40",
+			// Contract start block
+			424_300,
+		),
+		map[sharedtypes.RPCType]struct{}{
+			sharedtypes.RPCType_JSON_RPC: {},
+		},
+	),
 
 	// Optimism
-	evm.NewEVMServiceQoSConfig("op", "0xa", evm.NewEVMArchivalCheckConfig(
-		// https://optimistic.etherscan.io/address/0xacd03d601e5bb1b275bb94076ff46ed9d753435a
-		"0xacD03D601e5bB1B275Bb94076fF46ED9D753435A",
-		// Contract start block
-		8_121_800,
-	)),
+	evm.NewEVMServiceQoSConfig(
+		"op",
+		"0xa",
+		evm.NewEVMArchivalCheckConfig(
+			// https://optimistic.etherscan.io/address/0xacd03d601e5bb1b275bb94076ff46ed9d753435a
+			"0xacD03D601e5bB1B275Bb94076fF46ED9D753435A",
+			// Contract start block
+			8_121_800,
+		),
+		map[sharedtypes.RPCType]struct{}{
+			sharedtypes.RPCType_JSON_RPC: {},
+		},
+	),
 
 	// Optimism Sepolia Testnet
-	evm.NewEVMServiceQoSConfig("op-sepolia-testnet", "0xAA37DC", evm.NewEVMArchivalCheckConfig(
-		// https://sepolia-optimism.etherscan.io/address/0x734d539a7efee15714a2755caa4280e12ef3d7e4
-		"0x734d539a7efee15714a2755caa4280e12ef3d7e4",
-		// Contract start block
-		18_241_388,
-	)),
+	evm.NewEVMServiceQoSConfig(
+		"op-sepolia-testnet",
+		"0xAA37DC",
+		evm.NewEVMArchivalCheckConfig(
+			// https://sepolia-optimism.etherscan.io/address/0x734d539a7efee15714a2755caa4280e12ef3d7e4
+			"0x734d539a7efee15714a2755caa4280e12ef3d7e4",
+			// Contract start block
+			18_241_388,
+		),
+		map[sharedtypes.RPCType]struct{}{
+			sharedtypes.RPCType_JSON_RPC: {},
+		},
+	),
 
 	// Polygon
-	evm.NewEVMServiceQoSConfig("poly", "0x89", evm.NewEVMArchivalCheckConfig(
-		// https://polygonscan.com/address/0x0d500B1d8E8eF31E21C99d1Db9A6444d3ADf1270
-		"0x0d500B1d8E8eF31E21C99d1Db9A6444d3ADf1270",
-		// Contract start block
-		5_000_000,
-	)),
+	evm.NewEVMServiceQoSConfig(
+		"poly",
+		"0x89",
+		evm.NewEVMArchivalCheckConfig(
+			// https://polygonscan.com/address/0x0d500B1d8E8eF31E21C99d1Db9A6444d3ADf1270
+			"0x0d500B1d8E8eF31E21C99d1Db9A6444d3ADf1270",
+			// Contract start block
+			5_000_000,
+		),
+		map[sharedtypes.RPCType]struct{}{
+			sharedtypes.RPCType_JSON_RPC: {},
+		},
+	),
 
 	// Polygon Amoy Testnet
-	evm.NewEVMServiceQoSConfig("poly-amoy-testnet", "0x13882", evm.NewEVMArchivalCheckConfig(
-		// https://amoy.polygonscan.com/address/0x54d03ec0c462e9a01f77579c090cde0fc2617817
-		"0x54d03ec0c462e9a01f77579c090cde0fc2617817",
-		// Contract start block
-		10_453_569,
-	)),
+	evm.NewEVMServiceQoSConfig(
+		"poly-amoy-testnet",
+		"0x13882", evm.NewEVMArchivalCheckConfig(
+			// https://amoy.polygonscan.com/address/0x54d03ec0c462e9a01f77579c090cde0fc2617817
+			"0x54d03ec0c462e9a01f77579c090cde0fc2617817",
+			// Contract start block
+			10_453_569,
+		),
+		map[sharedtypes.RPCType]struct{}{
+			sharedtypes.RPCType_JSON_RPC: {},
+		},
+	),
 
 	// Polygon zkEVM
-	evm.NewEVMServiceQoSConfig("poly-zkevm", "0x44d", evm.NewEVMArchivalCheckConfig(
-		// https://zkevm.polygonscan.com/address/0xee1727f5074e747716637e1776b7f7c7133f16b1
-		"0xee1727f5074E747716637e1776B7F7C7133f16b1",
-		// Contract start block
-		111,
-	)),
+	evm.NewEVMServiceQoSConfig(
+		"poly-zkevm",
+		"0x44d",
+		evm.NewEVMArchivalCheckConfig(
+			// https://zkevm.polygonscan.com/address/0xee1727f5074e747716637e1776b7f7c7133f16b1
+			"0xee1727f5074E747716637e1776B7F7C7133f16b1",
+			// Contract start block
+			111,
+		),
+		map[sharedtypes.RPCType]struct{}{
+			sharedtypes.RPCType_JSON_RPC: {},
+		},
+	),
 
 	// Scroll
-	evm.NewEVMServiceQoSConfig("scroll", "0x82750", evm.NewEVMArchivalCheckConfig(
-		// https://scrollscan.com/address/0x5300000000000000000000000000000000000004
-		"0x5300000000000000000000000000000000000004",
-		// Contract start block
-		5_000_000,
-	)),
+	evm.NewEVMServiceQoSConfig(
+		"scroll",
+		"0x82750",
+		evm.NewEVMArchivalCheckConfig(
+			// https://scrollscan.com/address/0x5300000000000000000000000000000000000004
+			"0x5300000000000000000000000000000000000004",
+			// Contract start block
+			5_000_000,
+		),
+		map[sharedtypes.RPCType]struct{}{
+			sharedtypes.RPCType_JSON_RPC: {},
+		},
+	),
 
 	// Sonic
-	evm.NewEVMServiceQoSConfig("sonic", "0x92", evm.NewEVMArchivalCheckConfig(
-		// https://sonicscan.org/address/0xfc00face00000000000000000000000000000000
-		"0xfc00face00000000000000000000000000000000",
-		// Contract start block
-		10_769_279,
-	)),
+	evm.NewEVMServiceQoSConfig(
+		"sonic",
+		"0x92",
+		evm.NewEVMArchivalCheckConfig(
+			// https://sonicscan.org/address/0xfc00face00000000000000000000000000000000
+			"0xfc00face00000000000000000000000000000000",
+			// Contract start block
+			10_769_279,
+		),
+		map[sharedtypes.RPCType]struct{}{
+			sharedtypes.RPCType_JSON_RPC: {},
+		},
+	),
 
 	// Taiko
-	evm.NewEVMServiceQoSConfig("taiko", "0x28c58", evm.NewEVMArchivalCheckConfig(
-		// https://taikoscan.io/address/0x1670000000000000000000000000000000000001
-		"0x1670000000000000000000000000000000000001",
-		// Contract start block
-		170_163,
-	)),
+	evm.NewEVMServiceQoSConfig(
+		"taiko",
+		"0x28c58",
+		evm.NewEVMArchivalCheckConfig(
+			// https://taikoscan.io/address/0x1670000000000000000000000000000000000001
+			"0x1670000000000000000000000000000000000001",
+			// Contract start block
+			170_163,
+		),
+		map[sharedtypes.RPCType]struct{}{
+			sharedtypes.RPCType_JSON_RPC: {},
+		},
+	),
 
 	// Taiko Hekla Testnet
-	evm.NewEVMServiceQoSConfig("taiko-hekla-testnet", "0x28c61", evm.NewEVMArchivalCheckConfig(
-		// https://hekla.taikoscan.io/address/0x1670090000000000000000000000000000010001
-		"0x1670090000000000000000000000000000010001",
-		// Contract start block
-		420_139,
-	)),
+	evm.NewEVMServiceQoSConfig(
+		"taiko-hekla-testnet",
+		"0x28c61",
+		evm.NewEVMArchivalCheckConfig(
+			// https://hekla.taikoscan.io/address/0x1670090000000000000000000000000000010001
+			"0x1670090000000000000000000000000000010001",
+			// Contract start block
+			420_139,
+		),
+		map[sharedtypes.RPCType]struct{}{
+			sharedtypes.RPCType_JSON_RPC: {},
+		},
+	),
 	// zkLink
-	evm.NewEVMServiceQoSConfig("zklink-nova", "0xc5cc4", evm.NewEVMArchivalCheckConfig(
-		// https://explorer.zklink.io/address/0xa3cb8648d12bD36e713af27D92968B370D7A9546
-		"0xa3cb8648d12bD36e713af27D92968B370D7A9546",
-		// Contract start block
-		5_004_627,
-	)),
+	evm.NewEVMServiceQoSConfig(
+		"zklink-nova",
+		"0xc5cc4", evm.NewEVMArchivalCheckConfig(
+			// https://explorer.zklink.io/address/0xa3cb8648d12bD36e713af27D92968B370D7A9546
+			"0xa3cb8648d12bD36e713af27D92968B370D7A9546",
+			// Contract start block
+			5_004_627,
+		),
+		map[sharedtypes.RPCType]struct{}{
+			sharedtypes.RPCType_JSON_RPC: {},
+		},
+	),
 
 	// zkSync
-	evm.NewEVMServiceQoSConfig("zksync-era", "0x144", evm.NewEVMArchivalCheckConfig(
-		// https://explorer.zksync.io/address/0x03AC0b1b952C643d66A4Dc1fBc75118109cC074C
-		"0x03AC0b1b952C643d66A4Dc1fBc75118109cC074C",
-		// Contract start block
-		55_405_668,
-	)),
+	evm.NewEVMServiceQoSConfig(
+		"zksync-era",
+		"0x144",
+		evm.NewEVMArchivalCheckConfig(
+			// https://explorer.zksync.io/address/0x03AC0b1b952C643d66A4Dc1fBc75118109cC074C
+			"0x03AC0b1b952C643d66A4Dc1fBc75118109cC074C",
+			// Contract start block
+			55_405_668,
+		),
+		map[sharedtypes.RPCType]struct{}{
+			sharedtypes.RPCType_JSON_RPC: {},
+		},
+	),
 
 	// *** EVM Services (testing) ***
 
 	// Anvil - Ethereum development/testing
-	evm.NewEVMServiceQoSConfig("anvil", "0x7a69", nil),
+	evm.NewEVMServiceQoSConfig("anvil", "0x7a69", nil, map[sharedtypes.RPCType]struct{}{
+		sharedtypes.RPCType_JSON_RPC: {},
+	}),
 
 	// Anvil WebSockets - Ethereum WebSockets development/testing
-	evm.NewEVMServiceQoSConfig("anvilws", "0x7a69", nil),
+	evm.NewEVMServiceQoSConfig("anvilws", "0x7a69", nil, map[sharedtypes.RPCType]struct{}{
+		sharedtypes.RPCType_JSON_RPC: {},
+	}),
 
 	// *** EVM Services (Non-Archival) ***
 
 	// Evmos
-	evm.NewEVMServiceQoSConfig("evmos", "0x2329", nil),
+	evm.NewEVMServiceQoSConfig("evmos", "0x2329", nil, map[sharedtypes.RPCType]struct{}{
+		sharedtypes.RPCType_JSON_RPC: {},
+	}),
 
 	// Fraxtal
-	evm.NewEVMServiceQoSConfig("fraxtal", "0xfc", nil),
+	evm.NewEVMServiceQoSConfig("fraxtal", "0xfc", nil, map[sharedtypes.RPCType]struct{}{
+		sharedtypes.RPCType_JSON_RPC: {},
+	}),
 
 	// Kava
-	evm.NewEVMServiceQoSConfig("kava", "0x8ae", nil),
+	evm.NewEVMServiceQoSConfig("kava", "0x8ae", nil, map[sharedtypes.RPCType]struct{}{
+		sharedtypes.RPCType_JSON_RPC: {},
+	}),
 
 	// Moonriver
-	evm.NewEVMServiceQoSConfig("moonriver", "0x505", nil),
+	evm.NewEVMServiceQoSConfig("moonriver", "0x505", nil, map[sharedtypes.RPCType]struct{}{
+		sharedtypes.RPCType_JSON_RPC: {},
+	}),
 
 	// opBNB
-	evm.NewEVMServiceQoSConfig("opbnb", "0xcc", nil),
+	evm.NewEVMServiceQoSConfig("opbnb", "0xcc", nil, map[sharedtypes.RPCType]struct{}{
+		sharedtypes.RPCType_JSON_RPC: {},
+	}),
 
 	// Sui
-	evm.NewEVMServiceQoSConfig("sui", "0x101", nil),
+	evm.NewEVMServiceQoSConfig("sui", "0x101", nil, map[sharedtypes.RPCType]struct{}{
+		sharedtypes.RPCType_JSON_RPC: {},
+	}),
 
 	// TRON
-	evm.NewEVMServiceQoSConfig("tron", "0x2b6653dc", nil),
+	evm.NewEVMServiceQoSConfig("tron", "0x2b6653dc", nil, map[sharedtypes.RPCType]struct{}{
+		sharedtypes.RPCType_JSON_RPC: {},
+	}),
 
 	// Sei
-	evm.NewEVMServiceQoSConfig("sei", "0x531", nil),
+	evm.NewEVMServiceQoSConfig("sei", "0x531", nil, map[sharedtypes.RPCType]struct{}{
+		sharedtypes.RPCType_JSON_RPC: {},
+	}),
 
 	// Hey
 	// TODO_TECHDEBT(@olshansk): Either remove or format this correctly
-	evm.NewEVMServiceQoSConfig("hey", defaultEVMChainID, nil),
+	evm.NewEVMServiceQoSConfig("hey", defaultEVMChainID, nil, map[sharedtypes.RPCType]struct{}{
+		sharedtypes.RPCType_JSON_RPC: {},
+	}),
 
 	// TODO_TECHDEBT: Add support for Radix QoS
 	// Radix

--- a/gateway/http_request_context.go
+++ b/gateway/http_request_context.go
@@ -173,7 +173,7 @@ func (rc *requestContext) BuildProtocolContextsFromHTTPRequest(httpReq *http.Req
 	logger := rc.logger.With("method", "BuildProtocolContextsFromHTTPRequest").With("service_id", rc.serviceID)
 
 	// Retrieve the list of available endpoints for the requested service.
-	availableEndpoints, endpointLookupObs, err := rc.protocol.AvailableEndpoints(rc.context, rc.serviceID, httpReq)
+	availableEndpoints, endpointLookupObs, err := rc.protocol.AvailableHTTPEndpoints(rc.context, rc.serviceID, httpReq)
 	if err != nil {
 		// error encountered: use the supplied observations as protocol observations.
 		rc.updateProtocolObservations(&endpointLookupObs)
@@ -299,7 +299,7 @@ func (rc *requestContext) BroadcastAllObservations() {
 		// update protocol-level observations: no errors encountered setting up the protocol context.
 		rc.updateProtocolObservations(nil)
 		if rc.protocolObservations != nil {
-			err := rc.protocol.ApplyObservations(rc.protocolObservations)
+			err := rc.protocol.ApplyHTTPObservations(rc.protocolObservations)
 			if err != nil {
 				rc.logger.Warn().Err(err).Msg("error applying protocol observations.")
 			}

--- a/gateway/hydrator.go
+++ b/gateway/hydrator.go
@@ -3,7 +3,6 @@
 package gateway
 
 import (
-	"context"
 	"errors"
 	"sync"
 	"time"
@@ -51,7 +50,7 @@ type EndpointHydrator struct {
 	// of explicitly defining PATH gateway's components and their interactions.
 	DataReporter RequestResponseReporter
 
-	// RunInterval is the interval at which the Endpoint Hydrator will run in milliseconds.
+	// RunInterval is the interval at which the Endpoint Hydrator will run HTTP checks in milliseconds.
 	RunInterval time.Duration
 	// MaxEndpointCheckWorkers is the maximum number of workers that will be used to concurrently check endpoints.
 	MaxEndpointCheckWorkers int
@@ -70,6 +69,7 @@ type EndpointHydrator struct {
 
 // Start should be called to signal this instance of the hydrator
 // to start generating and sending endpoint check requests.
+// It starts two separate goroutines: one for HTTP checks and one for WebSocket checks.
 func (eph *EndpointHydrator) Start() error {
 	if eph.Protocol == nil {
 		return errors.New("an instance of Protocol must be provided")
@@ -79,162 +79,26 @@ func (eph *EndpointHydrator) Start() error {
 		return errors.New("at least one QoS instance must be provided to the endpoint hydrator to start sending check requests")
 	}
 
+	// Start HTTP checks on the configured interval
 	go func() {
 		ticker := time.NewTicker(eph.RunInterval)
+		defer ticker.Stop()
 		for {
-			eph.run()
+			eph.runHTTPChecks()
 			<-ticker.C
 		}
 	}()
 
-	return nil
-}
+	// Start WebSocket checks on a separate interval
+	go func() {
+		ticker := time.NewTicker(websocketCheckInterval)
+		defer ticker.Stop()
+		for {
+			eph.runWebSocketChecks()
+			<-ticker.C
+		}
+	}()
 
-func (eph *EndpointHydrator) run() {
-	logger := eph.Logger.With("services_count", len(eph.ActiveQoSServices))
-	logger.Info().Msg("Running Endpoint Hydrator")
-
-	// TODO_TECHDEBT: ensure every outgoing request (or the goroutine checking a service ID)
-	// has a timeout set.
-	var wg sync.WaitGroup
-	// A sync.Map is optimized for the use case here,
-	// i.e. each map entry is written only once.
-	var successfulServiceChecks sync.Map
-
-	for svcID, svcQoS := range eph.ActiveQoSServices {
-		wg.Add(1)
-		go func(serviceID protocol.ServiceID, serviceQoS QoSService) {
-			defer wg.Done()
-
-			logger := eph.Logger.With("serviceID", serviceID)
-
-			err := eph.performChecks(serviceID, serviceQoS)
-			if err != nil {
-				logger.Warn().Err(err).Msg("failed to run QoS checks for service")
-				return
-			}
-
-			successfulServiceChecks.Store(svcID, true)
-			logger.Info().Msg("successfully completed QoS checks for service")
-		}(svcID, svcQoS)
-	}
-	wg.Wait()
-
-	eph.healthStatusMutex.Lock()
-	defer eph.healthStatusMutex.Unlock()
-
-	eph.isHealthy = eph.getHealthStatus(&successfulServiceChecks)
-}
-
-func (eph *EndpointHydrator) performChecks(serviceID protocol.ServiceID, serviceQoS QoSService) error {
-	logger := eph.Logger.With(
-		"method", "performChecks",
-		"service_id", string(serviceID),
-	)
-
-	// Passing a nil as the HTTP request, because we assume the hydrator uses "Centralized Operation Mode".
-	// This implies there is no need to specify a specific app.
-	// TODO_TECHDEBT(@adshmh): support specifying the app(s) used for sending/signing synthetic relay requests by the hydrator.
-	// TODO_FUTURE(@adshmh): consider publishing observations if endpoint lookup fails.
-	availableEndpoints, _, err := eph.AvailableEndpoints(context.TODO(), serviceID, nil)
-	if err != nil || len(availableEndpoints) == 0 {
-		// No session found or no endpoints available for service: skip.
-		logger.Warn().Msg("no session found or no endpoints available for service when running hydrator checks.")
-		// do NOT return an error: hydrator and PATH should not report unhealthy status if a single service is unavailable.
-		return nil
-	}
-
-	logger = logger.With("number_of_endpoints", len(availableEndpoints))
-
-	// Prepare a channel that will keep track of all the parallel async job to perform QoS checks on every endpoint.
-	endpointCheckChan := make(chan protocol.EndpointAddr, len(availableEndpoints))
-
-	var wgEndpoints sync.WaitGroup
-	for range eph.MaxEndpointCheckWorkers {
-		wgEndpoints.Add(1)
-
-		go func() {
-			defer wgEndpoints.Done()
-
-			for endpointAddr := range endpointCheckChan {
-				// Creating a new locally scoped logger
-				endpointLogger := logger.With("endpoint_addr", string(endpointAddr))
-				endpointLogger.Info().Msg("About to run QoS checks against the current endpoint and service")
-
-				// Retrieve all the required QoS checks for the endpoint.
-				requiredQoSChecks := serviceQoS.GetRequiredQualityChecks(endpointAddr)
-				if len(requiredQoSChecks) == 0 {
-					endpointLogger.Warn().Msg("No required QoS checks for endpoint and service. Skipping checks...")
-					continue
-				}
-
-				// Iterate over every required QoS check for the endpoint and service.
-				for _, serviceRequestCtx := range requiredQoSChecks {
-					// Create a new protocol request context with a pre-selected endpoint for each request.
-					// IMPORTANT: A new request context MUST be created on each iteration of the loop to
-					// avoid race conditions related to concurrent access issues when running concurrent QoS checks.
-
-					// Passing a nil as the HTTP request, because we assume the Centralized Operation Mode being used by the hydrator,
-					// which means there is no need for specifying a specific app.
-					// TODO_FUTURE(@adshmh): support specifying the app(s) used for sending/signing synthetic relay requests by the hydrator.
-					// TODO_FUTURE(@adshmh): consider publishing observations here.
-					hydratorRequestCtx, _, err := eph.BuildHTTPRequestContextForEndpoint(context.TODO(), serviceID, endpointAddr, nil)
-					if err != nil {
-						logger.Error().Err(err).Msg("Failed to build a protocol request context for the endpoint")
-						continue
-					}
-
-					// Prepare a request context to submit a synthetic relay request to the endpoint on behalf of the gateway for QoS purposes.
-					gatewayRequestCtx := requestContext{
-						logger:  endpointLogger,
-						context: context.TODO(),
-						// TODO_MVP(@adshmh): populate the fields of gatewayObservations struct.
-						// Mark the request as Synthetic using the following steps:
-						// 	1. Define a `gatewayObserver` function as a field in the `requestContext` struct.
-						//	2. Define a `hydratorObserver` function in this file: it should at-least set the request type as `Synthetic`
-						//	3. Set the `hydratorObserver` function in the `gatewayRequestContext` below.
-						gatewayObservations: getSyntheticRequestGatewayObservations(),
-						serviceID:           serviceID,
-						serviceQoS:          serviceQoS,
-						qosCtx:              serviceRequestCtx,
-						protocol:            eph.Protocol,
-						protocolContexts:    []ProtocolRequestContext{hydratorRequestCtx},
-						// metrics reporter for exporting metrics on hydrator service requests.
-						metricsReporter: eph.MetricsReporter,
-						// data reporter for exporting data on hydrator service requests to the data pipeline.
-						dataReporter: eph.DataReporter,
-					}
-
-					err = gatewayRequestCtx.HandleRelayRequest()
-					if err != nil {
-						// TODO_FUTURE: consider skipping the rest of the checks based on the error.
-						// e.g. if the endpoint is refusing connections it may be reasonable to skip it
-						// in this iteration of QoS checks.
-						//
-						// TODO_FUTURE: consider retrying failed service requests
-						// as the failure may not be related to the quality of the endpoint.
-						logger.Warn().Err(err).Msg("Failed to send a relay. Only protocol-level observations will be applied.")
-					}
-
-					// publish all observations gathered through sending the synthetic service requests.
-					// e.g. protocol-level, qos-level observations.
-					gatewayRequestCtx.BroadcastAllObservations()
-				}
-			}
-		}()
-	}
-
-	// Kick off the workers above for every unique endpoint.
-	for _, endpointAddr := range availableEndpoints {
-		endpointCheckChan <- endpointAddr
-	}
-
-	close(endpointCheckChan)
-
-	// Wait for all workers to finish processing the endpoints.
-	wgEndpoints.Wait()
-
-	// TODO_FUTURE: publish aggregated QoS reports (in addition to reports on endpoints of a specific service)
 	return nil
 }
 

--- a/gateway/hydrator_http.go
+++ b/gateway/hydrator_http.go
@@ -60,7 +60,7 @@ func (eph *EndpointHydrator) performHTTPChecks(serviceID protocol.ServiceID, ser
 	// This implies there is no need to specify a specific app.
 	// TODO_TECHDEBT(@adshmh): support specifying the app(s) used for sending/signing synthetic relay requests by the hydrator.
 	// TODO_FUTURE(@adshmh): consider publishing observations if endpoint lookup fails.
-	availableEndpoints, _, err := eph.AvailableEndpoints(context.TODO(), serviceID, nil)
+	availableEndpoints, _, err := eph.AvailableHTTPEndpoints(context.TODO(), serviceID, nil)
 	if err != nil || len(availableEndpoints) == 0 {
 		// No session found or no endpoints available for service: skip.
 		logger.Warn().Msg("no session found or no endpoints available for service when running HTTP hydrator checks.")

--- a/gateway/hydrator_http.go
+++ b/gateway/hydrator_http.go
@@ -1,0 +1,186 @@
+package gateway
+
+import (
+	"context"
+	"sync"
+
+	"github.com/pokt-network/poktroll/pkg/polylog"
+
+	"github.com/buildwithgrove/path/protocol"
+)
+
+// runHTTPChecks performs HTTP-based QoS checks for all services and endpoints.
+func (eph *EndpointHydrator) runHTTPChecks() {
+	logger := eph.Logger.With(
+		"services_count", len(eph.ActiveQoSServices),
+		"check_type", "http",
+	)
+	logger.Info().Msg("Running HTTP Endpoint Hydrator checks")
+
+	// TODO_TECHDEBT: ensure every outgoing request (or the goroutine checking a service ID)
+	// has a timeout set.
+	var wg sync.WaitGroup
+	// A sync.Map is optimized for the use case here,
+	// i.e. each map entry is written only once.
+	var successfulServiceChecks sync.Map
+
+	for svcID, svcQoS := range eph.ActiveQoSServices {
+		wg.Add(1)
+		go func(serviceID protocol.ServiceID, serviceQoS QoSService) {
+			defer wg.Done()
+
+			logger := eph.Logger.With("serviceID", serviceID)
+
+			err := eph.performHTTPChecks(serviceID, serviceQoS)
+			if err != nil {
+				logger.Warn().Err(err).Msg("failed to run HTTP QoS checks for service")
+				return
+			}
+
+			successfulServiceChecks.Store(svcID, true)
+			logger.Info().Msg("successfully completed HTTP QoS checks for service")
+		}(svcID, svcQoS)
+	}
+	wg.Wait()
+
+	eph.healthStatusMutex.Lock()
+	defer eph.healthStatusMutex.Unlock()
+
+	eph.isHealthy = eph.getHealthStatus(&successfulServiceChecks)
+}
+
+// performHTTPChecks performs HTTP-based QoS checks for a specific service.
+func (eph *EndpointHydrator) performHTTPChecks(serviceID protocol.ServiceID, serviceQoS QoSService) error {
+	logger := eph.Logger.With(
+		"method", "performHTTPChecks",
+		"service_id", string(serviceID),
+	)
+
+	// Passing a nil as the HTTP request, because we assume the hydrator uses "Centralized Operation Mode".
+	// This implies there is no need to specify a specific app.
+	// TODO_TECHDEBT(@adshmh): support specifying the app(s) used for sending/signing synthetic relay requests by the hydrator.
+	// TODO_FUTURE(@adshmh): consider publishing observations if endpoint lookup fails.
+	availableEndpoints, _, err := eph.AvailableEndpoints(context.TODO(), serviceID, nil)
+	if err != nil || len(availableEndpoints) == 0 {
+		// No session found or no endpoints available for service: skip.
+		logger.Warn().Msg("no session found or no endpoints available for service when running HTTP hydrator checks.")
+		// do NOT return an error: hydrator and PATH should not report unhealthy status if a single service is unavailable.
+		return nil
+	}
+
+	logger = logger.With("number_of_endpoints", len(availableEndpoints))
+
+	// Prepare a channel that will keep track of all the parallel async job to perform HTTP QoS checks on every endpoint.
+	endpointCheckChan := make(chan protocol.EndpointAddr, len(availableEndpoints))
+
+	var wgEndpoints sync.WaitGroup
+	for range eph.MaxEndpointCheckWorkers {
+		wgEndpoints.Add(1)
+
+		go func() {
+			defer wgEndpoints.Done()
+
+			for endpointAddr := range endpointCheckChan {
+				eph.runHTTPQualityChecks(logger, serviceID, serviceQoS, endpointAddr)
+			}
+		}()
+	}
+
+	// Kick off the workers above for every unique endpoint.
+	for _, endpointAddr := range availableEndpoints {
+		endpointCheckChan <- endpointAddr
+	}
+
+	close(endpointCheckChan)
+
+	// Wait for all workers to finish processing the endpoints.
+	wgEndpoints.Wait()
+
+	// TODO_FUTURE: publish aggregated QoS reports (in addition to reports on endpoints of a specific service)
+	return nil
+}
+
+// runHTTPQualityChecks performs HTTP-based quality checks for a specific endpoint.
+func (eph *EndpointHydrator) runHTTPQualityChecks(
+	endpointLogger polylog.Logger,
+	serviceID protocol.ServiceID,
+	serviceQoS QoSService,
+	endpointAddr protocol.EndpointAddr,
+) {
+	// Retrieve all the required QoS checks for the endpoint.
+	requiredQoSChecks := serviceQoS.GetRequiredQualityChecks(endpointAddr)
+	if len(requiredQoSChecks) == 0 {
+		endpointLogger.Warn().Msg("No required QoS checks for endpoint and service. Skipping checks...")
+		return
+	}
+
+	// Iterate over every required QoS check for the endpoint and service.
+	for _, serviceRequestCtx := range requiredQoSChecks {
+		eph.performSingleQoSCheck(
+			endpointLogger,
+			serviceID,
+			serviceQoS,
+			endpointAddr,
+			serviceRequestCtx,
+		)
+	}
+}
+
+// performSingleQoSCheck performs a single QoS check by sending a synthetic request to the endpoint.
+func (eph *EndpointHydrator) performSingleQoSCheck(
+	endpointLogger polylog.Logger,
+	serviceID protocol.ServiceID,
+	serviceQoS QoSService,
+	endpointAddr protocol.EndpointAddr,
+	serviceRequestCtx RequestQoSContext,
+) {
+	// Create a new protocol request context with a pre-selected endpoint for each request.
+	// IMPORTANT: A new request context MUST be created on each iteration of the loop to
+	// avoid race conditions related to concurrent access issues when running concurrent QoS checks.
+
+	// Passing a nil as the HTTP request, because we assume the Centralized Operation Mode being used by the hydrator,
+	// which means there is no need for specifying a specific app.
+	// TODO_FUTURE(@adshmh): support specifying the app(s) used for sending/signing synthetic relay requests by the hydrator.
+	// TODO_FUTURE(@adshmh): consider publishing observations here.
+	hydratorRequestCtx, _, err := eph.BuildHTTPRequestContextForEndpoint(context.TODO(), serviceID, endpointAddr, nil)
+	if err != nil {
+		endpointLogger.Error().Err(err).Msg("Failed to build a protocol request context for the endpoint")
+		return
+	}
+
+	// Prepare a request context to submit a synthetic relay request to the endpoint on behalf of the gateway for QoS purposes.
+	gatewayRequestCtx := requestContext{
+		logger:  endpointLogger,
+		context: context.TODO(),
+		// TODO_MVP(@adshmh): populate the fields of gatewayObservations struct.
+		// Mark the request as Synthetic using the following steps:
+		// 	1. Define a `gatewayObserver` function as a field in the `requestContext` struct.
+		//	2. Define a `hydratorObserver` function in this file: it should at-least set the request type as `Synthetic`
+		//	3. Set the `hydratorObserver` function in the `gatewayRequestContext` below.
+		gatewayObservations: getSyntheticRequestGatewayObservations(),
+		serviceID:           serviceID,
+		serviceQoS:          serviceQoS,
+		qosCtx:              serviceRequestCtx,
+		protocol:            eph.Protocol,
+		protocolContexts:    []ProtocolRequestContext{hydratorRequestCtx},
+		// metrics reporter for exporting metrics on hydrator service requests.
+		metricsReporter: eph.MetricsReporter,
+		// data reporter for exporting data on hydrator service requests to the data pipeline.
+		dataReporter: eph.DataReporter,
+	}
+
+	err = gatewayRequestCtx.HandleRelayRequest()
+	if err != nil {
+		// TODO_FUTURE: consider skipping the rest of the checks based on the error.
+		// e.g. if the endpoint is refusing connections it may be reasonable to skip it
+		// in this iteration of QoS checks.
+		//
+		// TODO_FUTURE: consider retrying failed service requests
+		// as the failure may not be related to the quality of the endpoint.
+		endpointLogger.Warn().Err(err).Msg("Failed to send a relay. Only protocol-level observations will be applied.")
+	}
+
+	// publish all observations gathered through sending the synthetic service requests.
+	// e.g. protocol-level, qos-level observations.
+	gatewayRequestCtx.BroadcastAllObservations()
+}

--- a/gateway/hydrator_websocket.go
+++ b/gateway/hydrator_websocket.go
@@ -60,7 +60,7 @@ func (eph *EndpointHydrator) performWebSocketChecks(serviceID protocol.ServiceID
 	// Passing a nil as the HTTP request, because we assume the hydrator uses "Centralized Operation Mode".
 	// TODO_TECHDEBT(@adshmh): support specifying the app(s) used for sending/signing synthetic relay requests by the hydrator.
 	// TODO_FUTURE(@adshmh): consider publishing observations if endpoint lookup fails.
-	availableEndpoints, _, err := eph.AvailableEndpoints(context.TODO(), serviceID, nil)
+	availableEndpoints, _, err := eph.AvailableWebsocketEndpoints(context.TODO(), serviceID, nil)
 	if err != nil || len(availableEndpoints) == 0 {
 		// No session found or no endpoints available for service: skip.
 		logger.Warn().Msg("no session found or no endpoints available for service when running WebSocket hydrator checks.")
@@ -122,7 +122,7 @@ func (eph *EndpointHydrator) performWebSocketConnectionCheck(
 
 	obs := eph.Protocol.CheckWebsocketConnection(ctx, serviceID, endpointAddr)
 	if obs != nil {
-		eph.Protocol.ApplyObservations(obs)
+		eph.Protocol.ApplyWebSocketObservations(obs)
 	}
 
 	return nil

--- a/gateway/hydrator_websocket.go
+++ b/gateway/hydrator_websocket.go
@@ -1,0 +1,129 @@
+package gateway
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/buildwithgrove/path/protocol"
+)
+
+// websocketCheckInterval is the interval at which WebSocket connection checks are performed.
+const websocketCheckInterval = 10 * time.Minute
+
+// runWebSocketChecks performs WebSocket connection checks for all services and endpoints.
+func (eph *EndpointHydrator) runWebSocketChecks() {
+	logger := eph.Logger.With(
+		"services_count", len(eph.ActiveQoSServices),
+		"check_type", "websocket",
+	)
+	logger.Info().Msg("Running WebSocket Endpoint Hydrator checks")
+
+	// TODO_TECHDEBT: ensure every outgoing request (or the goroutine checking a service ID)
+	// has a timeout set.
+	var wg sync.WaitGroup
+
+	for svcID, svcQoS := range eph.ActiveQoSServices {
+		logger := logger.With("service_id", string(svcID))
+
+		// Skip if WebSocket checks are not enabled for this service.
+		if !svcQoS.CheckWebsocketConnection() {
+			logger.Debug().Msg("Service is not configured to run WebSocket checks. Skipping.")
+			continue
+		}
+
+		wg.Add(1)
+		go func(serviceID protocol.ServiceID, serviceQoS QoSService) {
+			defer wg.Done()
+
+			logger := eph.Logger.With("serviceID", serviceID)
+
+			err := eph.performWebSocketChecks(serviceID, serviceQoS)
+			if err != nil {
+				logger.Warn().Err(err).Msg("failed to run WebSocket checks for service")
+				return
+			}
+
+			logger.Info().Msg("successfully completed WebSocket checks for service")
+		}(svcID, svcQoS)
+	}
+	wg.Wait()
+}
+
+// performWebSocketChecks performs WebSocket connection checks for a specific service.
+func (eph *EndpointHydrator) performWebSocketChecks(serviceID protocol.ServiceID, serviceQoS QoSService) error {
+	logger := eph.Logger.With(
+		"method", "performWebSocketChecks",
+		"service_id", string(serviceID),
+	)
+
+	// Passing a nil as the HTTP request, because we assume the hydrator uses "Centralized Operation Mode".
+	// TODO_TECHDEBT(@adshmh): support specifying the app(s) used for sending/signing synthetic relay requests by the hydrator.
+	// TODO_FUTURE(@adshmh): consider publishing observations if endpoint lookup fails.
+	availableEndpoints, _, err := eph.AvailableEndpoints(context.TODO(), serviceID, nil)
+	if err != nil || len(availableEndpoints) == 0 {
+		// No session found or no endpoints available for service: skip.
+		logger.Warn().Msg("no session found or no endpoints available for service when running WebSocket hydrator checks.")
+		// do NOT return an error: hydrator and PATH should not report unhealthy status if a single service is unavailable.
+		return nil
+	}
+
+	logger = logger.With("number_of_endpoints", len(availableEndpoints))
+
+	// Prepare a channel that will keep track of all the parallel async job to perform WebSocket checks on every endpoint.
+	endpointCheckChan := make(chan protocol.EndpointAddr, len(availableEndpoints))
+
+	var wgEndpoints sync.WaitGroup
+	for range eph.MaxEndpointCheckWorkers {
+		wgEndpoints.Add(1)
+
+		go func() {
+			defer wgEndpoints.Done()
+
+			for endpointAddr := range endpointCheckChan {
+				endpointLogger := logger.With("endpoint_addr", string(endpointAddr))
+				endpointLogger.Info().Msg("Running WebSocket connection check for endpoint")
+
+				err := eph.performWebSocketConnectionCheck(serviceID, endpointAddr)
+				if err != nil {
+					endpointLogger.Warn().Err(err).Msg("WebSocket connection check failed")
+					// Continue with other endpoints even if one WebSocket check fails
+				}
+			}
+		}()
+	}
+
+	// Kick off the workers above for every unique endpoint.
+	for _, endpointAddr := range availableEndpoints {
+		endpointCheckChan <- endpointAddr
+	}
+
+	close(endpointCheckChan)
+
+	// Wait for all workers to finish processing the endpoints.
+	wgEndpoints.Wait()
+
+	// TODO_FUTURE: publish aggregated WebSocket check reports
+	return nil
+}
+
+// performWebSocketConnectionCheck performs a WebSocket connection establishment check
+// for the given endpoint. It performs a simplified version of the websocket bridge connection process
+// to determine if an endpoint can support websocket connections.
+func (eph *EndpointHydrator) performWebSocketConnectionCheck(
+	serviceID protocol.ServiceID,
+	endpointAddr protocol.EndpointAddr,
+) error {
+	// Create a context with a short timeout for the WebSocket connection check
+	// This ensures we don't wait too long for unresponsive endpoints
+	checkTimeout := 10 * time.Second
+	ctx, cancel := context.WithTimeout(context.Background(), checkTimeout)
+	defer cancel()
+
+	obs := eph.Protocol.CheckWebsocketConnection(ctx, serviceID, endpointAddr)
+	if obs != nil {
+		eph.Protocol.ApplyObservations(obs)
+	}
+
+	return nil
+}

--- a/gateway/protocol.go
+++ b/gateway/protocol.go
@@ -90,6 +90,9 @@ type Protocol interface {
 	// HydrateDisqualifiedEndpointsResponse hydrates the disqualified endpoint response with the protocol-specific data.
 	HydrateDisqualifiedEndpointsResponse(protocol.ServiceID, *devtools.DisqualifiedEndpointResponse)
 
+	// CheckWebsocketConnection checks if the websocket connection to the endpoint is established.
+	CheckWebsocketConnection(context.Context, protocol.ServiceID, protocol.EndpointAddr) *protocolobservations.Observations
+
 	// health.Check interface is used to verify protocol instance's health status.
 	health.Check
 }

--- a/gateway/protocol.go
+++ b/gateway/protocol.go
@@ -15,7 +15,7 @@ import (
 // Protocol defines the core functionality of a protocol from the perspective of a gateway.
 // The gateway expects a protocol to build and return a request context for a particular service ID.
 type Protocol interface {
-	// AvailableEndpoints returns the list of available endpoints matching both the service ID
+	// AvailableHTTPEndpoints returns the list of available HTTP endpoints matching both the service ID
 	//
 	// If the Pocket Network Gateway is in delegated mode, the staked application is passed via
 	// the `App-Address` header. In all other modes, *http.Request will be nil.
@@ -23,7 +23,21 @@ type Protocol interface {
 	// Context may contain a deadline that protocol should respect on best-effort basis.
 	// Return observation if endpoint lookup fails.
 	// Used as protocol observation for the request when no protocol context exists.
-	AvailableEndpoints(
+	AvailableHTTPEndpoints(
+		context.Context,
+		protocol.ServiceID,
+		*http.Request,
+	) (protocol.EndpointAddrList, protocolobservations.Observations, error)
+
+	// AvailableWebsocketEndpoints returns the list of available websocket endpoints matching both the service ID
+	//
+	// If the Pocket Network Gateway is in delegated mode, the staked application is passed via
+	// the `App-Address` header. In all other modes, *http.Request will be nil.
+	//
+	// Context may contain a deadline that protocol should respect on best-effort basis.
+	// Return observation if endpoint lookup fails.
+	// Used as protocol observation for the request when no protocol context exists.
+	AvailableWebsocketEndpoints(
 		context.Context,
 		protocol.ServiceID,
 		*http.Request,
@@ -70,12 +84,19 @@ type Protocol interface {
 	// See protocol/gateway_mode.go for more details.
 	SupportedGatewayModes() []protocol.GatewayMode
 
-	// ApplyObservations applies the supplied observations to the protocol instance's internal state.
+	// ApplyHTTPObservations applies the supplied observations to the protocol instance's internal state.
 	// Hypothetical example (for illustrative purposes only):
 	// 	- protocol: Shannon
 	// 	- observation: "endpoint maxed-out or over-serviced (i.e. onchain rate limiting)"
 	// 	- result: skip the endpoint for a set time period until a new session begins.
-	ApplyObservations(*protocolobservations.Observations) error
+	ApplyHTTPObservations(*protocolobservations.Observations) error
+
+	// ApplyWebSocketObservations applies the supplied observations to the protocol instance's internal state.
+	// Hypothetical example (for illustrative purposes only):
+	// 	- protocol: Shannon
+	// 	- observation: "endpoint maxed-out or over-serviced (i.e. onchain rate limiting)"
+	// 	- result: skip the endpoint for a set time period until a new session begins.
+	ApplyWebSocketObservations(*protocolobservations.Observations) error
 
 	// TODO_FUTURE(@adshmh): support specifying the app(s) used for sending/signing synthetic relay requests by the hydrator.
 	// TODO_TECHDEBT: Enable the hydrator for gateway modes beyond Centralized only.

--- a/gateway/qos.go
+++ b/gateway/qos.go
@@ -90,6 +90,20 @@ type QoSEndpointCheckGenerator interface {
 	// - Returns required quality checks for a QoS instance to assess endpoint validity.
 	// - Example: EVM QoS may skip block height check if chain ID check already failed.
 	GetRequiredQualityChecks(protocol.EndpointAddr) []RequestQoSContext
+
+	// TODO_TECHDEBT(@commoddity): Currently websocket QoS only performs a protocol-level check
+	// which determines if an endpoint connection request is successful or not.
+	//
+	// This only require a simple bool that tells the hydrator if the endpoint should be checked
+	// for WebSocket connection and applies protocol-level sanctions if it fails.
+	//
+	// In the future, we may want to add QoS-level checks that take into account specific endpoint
+	// responses to apply websocket-related filtering at the QoS level.
+	//
+	// CheckWebsocketConnection
+	//  - Checks if the endpoint supports WebSocket connections.
+	//  - Returns a boolean indicating whether the endpoint should be checked for WebSocket connection.
+	CheckWebsocketConnection() bool
 }
 
 // TODO_IMPLEMENT:

--- a/gateway/websocket_request_context.go
+++ b/gateway/websocket_request_context.go
@@ -157,7 +157,7 @@ func (wrc *websocketRequestContext) buildProtocolContextAndStartBridge(
 
 	// Retrieve the list of available endpoints for the requested service.
 	// endpointLookupObs will capture the details of the endpoint lookup, including whether it is an error or success.
-	availableEndpoints, endpointLookupObs, err := wrc.protocol.AvailableEndpoints(wrc.context, wrc.serviceID, httpReq)
+	availableEndpoints, endpointLookupObs, err := wrc.protocol.AvailableWebsocketEndpoints(wrc.context, wrc.serviceID, httpReq)
 	if err != nil {
 		logger.Error().Err(err).Msg("❌ no available endpoints could be found for websocket request")
 		// Send connection failure observation manually since the connection observation channel is not available yet
@@ -355,7 +355,7 @@ func (wrc *websocketRequestContext) BroadcastMessageObservations(
 	// observation-related tasks are called in Goroutines to avoid potentially blocking the handler.
 	go func() {
 		if protocolObservations := messageObservations.GetProtocol(); protocolObservations != nil {
-			err := wrc.protocol.ApplyObservations(protocolObservations)
+			err := wrc.protocol.ApplyWebSocketObservations(protocolObservations)
 			if err != nil {
 				wrc.logger.Warn().Err(err).Msg("error applying protocol observations for websocket.")
 			}

--- a/metrics/devtools/disqualified_endpoint_reporter.go
+++ b/metrics/devtools/disqualified_endpoint_reporter.go
@@ -68,7 +68,6 @@ func (r *DisqualifiedEndpointReporter) ReportEndpointStatus(serviceID protocol.S
 	r.Logger.Info().Msgf("DisqualifiedEndpointReporter.Report: Successfully hydrated disqualified endpoint details for service ID: %s", serviceID)
 
 	details.DisqualifiedServiceEndpointsCount = details.GetDisqualifiedEndpointsCount()
-	details.QualifiedServiceEndpointsCount = details.GetValidServiceEndpointsCount()
 
 	return details, nil
 }

--- a/metrics/devtools/disqualified_endpoint_response.go
+++ b/metrics/devtools/disqualified_endpoint_response.go
@@ -13,11 +13,10 @@ import (
 //
 // It also reports the total number of service endpoints, the number of qualified service endpoints, and the number of disqualified service endpoints.
 type DisqualifiedEndpointResponse struct {
-	ProtocolLevelDisqualifiedEndpoints ProtocolLevelDataResponse `json:"protocol_level_disqualified_endpoints"`
-	QoSLevelDisqualifiedEndpoints      QoSLevelDataResponse      `json:"qos_level_disqualified_endpoints"`
-	TotalServiceEndpointsCount         int                       `json:"total_service_endpoints_count"`
-	QualifiedServiceEndpointsCount     int                       `json:"qualified_service_endpoints_count"`
-	DisqualifiedServiceEndpointsCount  int                       `json:"disqualified_service_endpoints_count"`
+	ProtocolLevelDisqualifiedEndpoints map[string]ProtocolLevelDataResponse `json:"protocol_level_disqualified_endpoints"`
+	QoSLevelDisqualifiedEndpoints      QoSLevelDataResponse                 `json:"qos_level_disqualified_endpoints"`
+	TotalServiceEndpointsCount         int                                  `json:"total_service_endpoints_count"`
+	DisqualifiedServiceEndpointsCount  int                                  `json:"disqualified_service_endpoints_count"`
 }
 
 // GetDisqualifiedEndpointsCount sums:
@@ -25,14 +24,13 @@ type DisqualifiedEndpointResponse struct {
 //   - Protocol-level session sanctioned endpoints
 //   - QoS-level disqualified endpoints
 func (r *DisqualifiedEndpointResponse) GetDisqualifiedEndpointsCount() int {
-	return len(r.ProtocolLevelDisqualifiedEndpoints.PermanentlySanctionedEndpoints) +
-		len(r.ProtocolLevelDisqualifiedEndpoints.SessionSanctionedEndpoints) +
+	protocolLevelDisqualifiedEndpointsCount := 0
+	for _, protocolLevelDisqualifiedEndpoints := range r.ProtocolLevelDisqualifiedEndpoints {
+		protocolLevelDisqualifiedEndpointsCount += len(protocolLevelDisqualifiedEndpoints.PermanentlySanctionedEndpoints) +
+			len(protocolLevelDisqualifiedEndpoints.SessionSanctionedEndpoints)
+	}
+	return protocolLevelDisqualifiedEndpointsCount +
 		len(r.QoSLevelDisqualifiedEndpoints.DisqualifiedEndpoints)
-}
-
-// GetValidServiceEndpointsCount subtracts the number of disqualified endpoints from the total number of service endpoints.
-func (r *DisqualifiedEndpointResponse) GetValidServiceEndpointsCount() int {
-	return r.TotalServiceEndpointsCount - r.GetDisqualifiedEndpointsCount()
 }
 
 type (

--- a/protocol/shannon/observation_websocket.go
+++ b/protocol/shannon/observation_websocket.go
@@ -1,13 +1,170 @@
 package shannon
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/pokt-network/poktroll/pkg/polylog"
+	sessiontypes "github.com/pokt-network/poktroll/x/session/types"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	protocolobservations "github.com/buildwithgrove/path/observation/protocol"
+	"github.com/buildwithgrove/path/protocol"
 )
+
+// ---------- Message-Level Observations ----------
+
+// getWebsocketMessageSuccessObservation updates the observations for the current message
+// if the message handler does not return an error.
+func getWebsocketMessageSuccessObservation(
+	logger polylog.Logger,
+	serviceID protocol.ServiceID,
+	selectedEndpoint endpoint,
+	msgData []byte,
+) protocolobservations.Observations {
+	logger.With("method", "getWebsocketMessageSuccessObservation")
+
+	// Create a new WebSocket message observation for success
+	wsMessageObs := buildWebsocketMessageSuccessObservation(
+		logger,
+		selectedEndpoint,
+		int64(len(msgData)),
+	)
+
+	// Update the observations to use the WebSocket message observation
+	return protocolobservations.Observations{
+		Shannon: &protocolobservations.ShannonObservationsList{
+			Observations: []*protocolobservations.ShannonRequestObservations{
+				{
+					ServiceId:    string(serviceID),
+					RequestError: nil, // WS messages do not have request errors
+					ObservationData: &protocolobservations.ShannonRequestObservations_WebsocketMessageObservation{
+						WebsocketMessageObservation: wsMessageObs,
+					},
+				},
+			},
+		},
+	}
+}
+
+// getWebsocketMessageErrorObservation updates the observations for the current message
+// if the message handler returns an error.
+func getWebsocketMessageErrorObservation(
+	logger polylog.Logger,
+	serviceID protocol.ServiceID,
+	selectedEndpoint endpoint,
+	msgData []byte,
+	messageError error,
+) protocolobservations.Observations {
+	// Error classification based on trusted error sources only
+	endpointErrorType, recommendedSanctionType := classifyRelayError(logger, messageError)
+
+	// Create a new WebSocket message observation for error
+	wsMessageObs := buildWebsocketMessageErrorObservation(
+		selectedEndpoint,
+		int64(len(msgData)),
+		endpointErrorType,
+		fmt.Sprintf("websocket message error: %v", messageError),
+		recommendedSanctionType,
+	)
+
+	return protocolobservations.Observations{
+		Shannon: &protocolobservations.ShannonObservationsList{
+			Observations: []*protocolobservations.ShannonRequestObservations{
+				{
+					ServiceId:    string(serviceID),
+					RequestError: nil, // WS messages do not have request errors
+					ObservationData: &protocolobservations.ShannonRequestObservations_WebsocketMessageObservation{
+						WebsocketMessageObservation: wsMessageObs,
+					},
+				},
+			},
+		},
+	}
+}
+
+// ---------- Connection-Level Observations ----------
+
+// getWebsocketConnectionSuccessObservation builds observations for successful WebSocket connection establishment.
+func getWebsocketConnectionEstablishedObservation(
+	logger polylog.Logger,
+	serviceID protocol.ServiceID,
+	selectedEndpoint endpoint,
+) *protocolobservations.Observations {
+	return &protocolobservations.Observations{
+		Shannon: &protocolobservations.ShannonObservationsList{
+			Observations: []*protocolobservations.ShannonRequestObservations{
+				{
+					ServiceId: string(serviceID),
+					ObservationData: &protocolobservations.ShannonRequestObservations_WebsocketConnectionObservation{
+						WebsocketConnectionObservation: buildWebsocketConnectionObservation(
+							logger,
+							selectedEndpoint,
+							protocolobservations.ShannonWebsocketConnectionObservation_CONNECTION_ESTABLISHED,
+						),
+					},
+				},
+			},
+		},
+	}
+}
+
+func getWebsocketConnectionClosedObservation(
+	logger polylog.Logger,
+	serviceID protocol.ServiceID,
+	selectedEndpoint endpoint,
+) *protocolobservations.Observations {
+	return &protocolobservations.Observations{
+		Shannon: &protocolobservations.ShannonObservationsList{
+			Observations: []*protocolobservations.ShannonRequestObservations{
+				{
+					ServiceId: string(serviceID),
+					ObservationData: &protocolobservations.ShannonRequestObservations_WebsocketConnectionObservation{
+						WebsocketConnectionObservation: buildWebsocketConnectionObservation(
+							logger,
+							selectedEndpoint,
+							protocolobservations.ShannonWebsocketConnectionObservation_CONNECTION_CLOSED,
+						),
+					},
+				},
+			},
+		},
+	}
+}
+
+// getWebsocketConnectionErrorObservation builds observations for failed WebSocket connection establishment.
+func getWebsocketConnectionErrorObservation(
+	logger polylog.Logger,
+	serviceID protocol.ServiceID,
+	selectedEndpoint endpoint,
+	err error,
+) *protocolobservations.Observations {
+	endpointErrorType, recommendedSanctionType := classifyRelayError(logger, err)
+
+	return &protocolobservations.Observations{
+		Shannon: &protocolobservations.ShannonObservationsList{
+			Observations: []*protocolobservations.ShannonRequestObservations{
+				{
+					ServiceId: string(serviceID),
+					RequestError: &protocolobservations.ShannonRequestError{
+						ErrorType:    protocolobservations.ShannonRequestErrorType_SHANNON_REQUEST_ERROR_INTERNAL,
+						ErrorDetails: err.Error(),
+					},
+					ObservationData: &protocolobservations.ShannonRequestObservations_WebsocketConnectionObservation{
+						WebsocketConnectionObservation: buildWebsocketConnectionErrorObservation(
+							logger,
+							selectedEndpoint,
+							endpointErrorType,
+							err.Error(),
+							recommendedSanctionType,
+							protocolobservations.ShannonWebsocketConnectionObservation_CONNECTION_ESTABLISHMENT_FAILED,
+						),
+					},
+				},
+			},
+		},
+	}
+}
 
 // buildWebsocketMessageSuccessObservation creates a Shannon websocket message observation for successful message processing.
 // It includes endpoint details, session information, and message-specific data.
@@ -138,5 +295,32 @@ func buildWebsocketConnectionErrorObservation(
 		// Connection lifecycle
 		ConnectionEstablishedTimestamp: timestamppb.New(time.Now()),
 		EventType:                      eventType,
+	}
+}
+
+// builds a Shannon endpoint from an endpoint observation.
+// Used to identify an endpoint for applying sanctions.
+func buildEndpointFromWebSocketConnectionObservation(
+	observation *protocolobservations.ShannonWebsocketConnectionObservation,
+) endpoint {
+	session := buildSessionFromWebSocketConnectionObservation(observation)
+	return &protocolEndpoint{
+		session:  session,
+		supplier: observation.GetSupplier(),
+		url:      observation.GetEndpointUrl(),
+	}
+}
+
+func buildSessionFromWebSocketConnectionObservation(
+	observation *protocolobservations.ShannonWebsocketConnectionObservation,
+) sessiontypes.Session {
+	return sessiontypes.Session{
+		Header: &sessiontypes.SessionHeader{
+			ApplicationAddress:      observation.GetEndpointAppAddress(),
+			ServiceId:               observation.GetSessionServiceId(),
+			SessionId:               observation.GetSessionId(),
+			SessionStartBlockHeight: observation.GetSessionStartHeight(),
+			SessionEndBlockHeight:   observation.GetSessionEndHeight(),
+		},
 	}
 }

--- a/protocol/shannon/protocol.go
+++ b/protocol/shannon/protocol.go
@@ -285,7 +285,6 @@ func (p *Protocol) ApplyObservations(observations *protocolobservations.Observat
 		p.logger.ProbabilisticDebugInfo(polylog.ProbabilisticDebugInfoProb).Msg("SHOULD RARELY HAPPEN: ApplyObservations called with nil set of Shannon request observations.")
 		return nil
 	}
-
 	// hand over the observations to the sanctioned endpoints store for adding any applicable sanctions.
 	p.sanctionedEndpointsStore.ApplyObservations(shannonObservations)
 

--- a/protocol/shannon/sanction.go
+++ b/protocol/shannon/sanction.go
@@ -42,6 +42,17 @@ func buildSanctionFromObservation(observation *protocolobservations.ShannonEndpo
 	}
 }
 
+// buildSanctionFromWebSocketConnectionObservation creates a sanction struct from a websocket connection observation.
+func buildSanctionFromWebSocketConnectionObservation(observation *protocolobservations.ShannonWebsocketConnectionObservation) sanction {
+	return sanction{
+		reason:             observation.GetErrorDetails(),
+		errorType:          observation.GetErrorType(),
+		createdAt:          time.Now(),
+		sessionServiceID:   observation.GetSessionServiceId(),
+		sessionStartHeight: observation.GetSessionStartHeight(),
+	}
+}
+
 // permanentSanctionToDetails converts a permanent sanction to a devtools.SanctionedEndpoint struct.
 // It does not include the session ID as permanent sanction is not associated with a specific session.
 func (s sanction) permanentSanctionToDetails(

--- a/protocol/shannon/sanctioned_endpoints_store.go
+++ b/protocol/shannon/sanctioned_endpoints_store.go
@@ -85,6 +85,10 @@ func (ses *sanctionedEndpointsStore) ApplyObservations(shannonObservations []*pr
 	}
 }
 
+// TODO_TECHDEBT(@commoddity,@adshmh): sanctioned endpoints stores are categorized on RPC type, but contain HTTP methods.
+// The approach is in the right direction in general, but requires a few refactors to encapsulate observation processing
+// logic specific to each RPC type.
+//
 // processHTTPConnectionObservationForSanctions processes HTTP endpoint observations for sanctions
 func (ses *sanctionedEndpointsStore) processHTTPConnectionObservationForSanctions(
 	logger polylog.Logger,

--- a/protocol/shannon/sanctioned_endpoints_store.go
+++ b/protocol/shannon/sanctioned_endpoints_store.go
@@ -71,52 +71,91 @@ func (ses *sanctionedEndpointsStore) ApplyObservations(shannonObservations []*pr
 
 	// For each observation set:
 	for _, observationSet := range shannonObservations {
+		// Process HTTP observations if present
 		httpObservations := observationSet.GetHttpObservations()
-		if httpObservations == nil {
-			logger.With("observation_set", observationSet).Warn().Msg("❌ SHOULD NEVER HAPPEN: skipping processing: received empty HTTP observations")
+		if httpObservations != nil {
+			ses.processHTTPConnectionObservationForSanctions(logger, httpObservations)
+		}
+
+		// Process WebSocket connection observations
+		websocketConnectionObs := observationSet.GetWebsocketConnectionObservation()
+		if websocketConnectionObs != nil {
+			ses.processWebSocketConnectionObservationForSanctions(logger, websocketConnectionObs)
+		}
+	}
+}
+
+// processHTTPConnectionObservationForSanctions processes HTTP endpoint observations for sanctions
+func (ses *sanctionedEndpointsStore) processHTTPConnectionObservationForSanctions(
+	logger polylog.Logger,
+	httpObservations *protocolobservations.ShannonHTTPEndpointObservations,
+) {
+	// For each endpoint observation in the set:
+	for _, endpointObservation := range httpObservations.GetEndpointObservations() {
+		// Build endpoint from observation
+		endpoint := buildEndpointFromObservation(endpointObservation)
+
+		// Hydrate logger with endpoint context
+		logger := hydrateLoggerWithEndpoint(logger, endpoint).With("method", "processHTTPConnectionObservationForSanctions")
+		logger.Debug().Msg("processing endpoint observation.")
+
+		// Skip if no sanction is recommended
+		recommendedSanction := endpointObservation.GetRecommendedSanction()
+		if recommendedSanction == protocolobservations.ShannonSanctionType_SHANNON_SANCTION_UNSPECIFIED {
 			continue
 		}
 
-		// For each endpoint observation in the set:
-		for _, endpointObservation := range httpObservations.GetEndpointObservations() {
-			// Build endpoint from observation
-			endpoint := buildEndpointFromObservation(endpointObservation)
+		// Build sanction from observation
+		sanctionData := buildSanctionFromObservation(endpointObservation)
 
-			// Hydrate logger with endpoint context
-			logger := hydrateLoggerWithEndpoint(logger, endpoint).With("method", "ApplyObservations")
-			logger.Debug().Msg("processing endpoint observation.")
+		// Apply appropriate type of sanction:
+		switch recommendedSanction {
+		case protocolobservations.ShannonSanctionType_SHANNON_SANCTION_PERMANENT:
+			// Permanent sanction:
+			//   - Persists for process lifetime (not on disk)
+			//   - Lost on PATH restart; not shared
+			logger.Info().Msg("Adding permanent sanction for endpoint")
+			ses.addPermanentSanction(endpoint.Addr(), sanctionData)
 
-			// Skip if no sanction is recommended
-			recommendedSanction := endpointObservation.GetRecommendedSanction()
-			if recommendedSanction == protocolobservations.ShannonSanctionType_SHANNON_SANCTION_UNSPECIFIED {
-				continue
-			}
+		case protocolobservations.ShannonSanctionType_SHANNON_SANCTION_SESSION:
+			// Session-based sanction:
+			//   - Expires after set duration
+			//   - More ephemeral than permanent
+			//   - Lost on PATH restart; not shared
+			logger.Info().Msg("Adding session sanction for endpoint")
+			ses.addSessionSanction(endpoint, sanctionData)
 
-			// Build sanction from observation
-			sanctionData := buildSanctionFromObservation(endpointObservation)
-
-			// Apply appropriate type of sanction:
-			switch recommendedSanction {
-			case protocolobservations.ShannonSanctionType_SHANNON_SANCTION_PERMANENT:
-				// Permanent sanction:
-				//   - Persists for process lifetime (not on disk)
-				//   - Lost on PATH restart; not shared
-				logger.Info().Msg("Adding permanent sanction for endpoint")
-				ses.addPermanentSanction(endpoint.Addr(), sanctionData)
-
-			case protocolobservations.ShannonSanctionType_SHANNON_SANCTION_SESSION:
-				// Session-based sanction:
-				//   - Expires after set duration
-				//   - More ephemeral than permanent
-				//   - Lost on PATH restart; not shared
-				logger.Info().Msg("Adding session sanction for endpoint")
-				ses.addSessionSanction(endpoint, sanctionData)
-
-			default:
-				logger.Warn().Msg("sanction type not supported by the store. skipping.")
-			}
+		default:
+			logger.Warn().Msg("sanction type not supported by the store. skipping.")
 		}
 	}
+}
+
+// processWebSocketConnectionObservationForSanctions processes a WebSocket connection observation for sanctions
+func (ses *sanctionedEndpointsStore) processWebSocketConnectionObservationForSanctions(
+	logger polylog.Logger,
+	websocketConnectionObs *protocolobservations.ShannonWebsocketConnectionObservation,
+) {
+	// Build endpoint from WebSocket connection observation
+	endpoint := buildEndpointFromWebSocketConnectionObservation(websocketConnectionObs)
+
+	// Hydrate logger with endpoint context
+	logger = hydrateLoggerWithEndpoint(logger, endpoint).With("method", "processWebSocketConnectionObservationForSanctions")
+	logger.Debug().
+		Str("recommended_sanction", websocketConnectionObs.GetRecommendedSanction().String()).
+		Msg("processing WebSocket connection observation for sanctions")
+
+	// Skip if no sanction is recommended
+	recommendedSanction := websocketConnectionObs.GetRecommendedSanction()
+	if recommendedSanction == protocolobservations.ShannonSanctionType_SHANNON_SANCTION_UNSPECIFIED {
+		return
+	}
+
+	// Build sanction from WebSocket connection observation
+	sanctionData := buildSanctionFromWebSocketConnectionObservation(websocketConnectionObs)
+
+	// Apply the sanction
+	ses.addSessionSanction(endpoint, sanctionData)
 }
 
 // FilterSanctionedEndpoints:

--- a/protocol/shannon/sanctions.go
+++ b/protocol/shannon/sanctions.go
@@ -75,14 +75,13 @@ func classifyRelayError(logger polylog.Logger, err error) (protocolobservations.
 			protocolobservations.ShannonSanctionType_SHANNON_SANCTION_SESSION
 
 	// TODO_NEXT(@commoddity): Introduce correct error classification for WebSocket errors.
-	//   - Error creating a WebSocket connection.
 	//   - Error signing the relay request.
 	//   - Error validating the relay response.
 
 	// WebSocket connection failed.
 	case errors.Is(err, errCreatingWebSocketConnection):
 		return protocolobservations.ShannonEndpointErrorType_SHANNON_ENDPOINT_ERROR_WEBSOCKET_CONNECTION_FAILED,
-			protocolobservations.ShannonSanctionType_SHANNON_SANCTION_UNSPECIFIED
+			protocolobservations.ShannonSanctionType_SHANNON_SANCTION_SESSION
 
 	// Error signing the relay request.
 	case errors.Is(err, errRelayRequestWebsocketMessageSigningFailed):

--- a/qos/cosmos/request_validator_checks.go
+++ b/qos/cosmos/request_validator_checks.go
@@ -18,6 +18,12 @@ import (
 // It generates requests for both JSONRPC and REST endpoints.
 var _ gateway.QoSEndpointCheckGenerator = &requestValidator{}
 
+// CheckWebsocketConnection returns true if the endpoint supports WebSocket connections.
+func (rv *requestValidator) CheckWebsocketConnection() bool {
+	_, supportsWebsockets := rv.serviceState.serviceQoSConfig.getSupportedAPIs()[sharedtypes.RPCType_WEBSOCKET]
+	return supportsWebsockets
+}
+
 // GetRequiredQualityChecks returns the list of quality checks required for an endpoint.
 // It is called in the `gateway/hydrator.go` file on each run of the hydrator.
 func (rv *requestValidator) GetRequiredQualityChecks(endpointAddr protocol.EndpointAddr) []gateway.RequestQoSContext {

--- a/qos/evm/service_qos_config.go
+++ b/qos/evm/service_qos_config.go
@@ -1,6 +1,10 @@
 package evm
 
-import "github.com/buildwithgrove/path/protocol"
+import (
+	sharedtypes "github.com/pokt-network/poktroll/x/shared/types"
+
+	"github.com/buildwithgrove/path/protocol"
+)
 
 // QoSType is the QoS type for the EVM blockchain.
 const QoSType = "evm"
@@ -29,6 +33,7 @@ type EVMServiceQoSConfig interface {
 	getSyncAllowance() uint64
 	getEVMArchivalCheckConfig() evmArchivalCheckConfig
 	archivalCheckEnabled() bool
+	getSupportedAPIs() map[sharedtypes.RPCType]struct{}
 }
 
 // evmArchivalCheckConfig is the configuration for the archival check.
@@ -54,11 +59,13 @@ func NewEVMServiceQoSConfig(
 	serviceID protocol.ServiceID,
 	evmChainID string,
 	archivalCheckConfig *evmArchivalCheckConfig,
+	supportedAPIs map[sharedtypes.RPCType]struct{},
 ) EVMServiceQoSConfig {
 	return evmServiceQoSConfig{
 		serviceID:           serviceID,
 		evmChainID:          evmChainID,
 		archivalCheckConfig: archivalCheckConfig,
+		supportedAPIs:       supportedAPIs,
 	}
 }
 
@@ -81,6 +88,7 @@ type evmServiceQoSConfig struct {
 	evmChainID          string
 	syncAllowance       uint64
 	archivalCheckConfig *evmArchivalCheckConfig
+	supportedAPIs       map[sharedtypes.RPCType]struct{}
 }
 
 // GetServiceID returns the ID of the service.
@@ -120,4 +128,10 @@ func (c evmServiceQoSConfig) archivalCheckEnabled() bool {
 // Implements the EVMServiceQoSConfig interface.
 func (c evmServiceQoSConfig) getEVMArchivalCheckConfig() evmArchivalCheckConfig {
 	return *c.archivalCheckConfig
+}
+
+// getSupportedAPIs returns the RPC types supported by the service.
+// Implements the EVMServiceQoSConfig interface.
+func (c evmServiceQoSConfig) getSupportedAPIs() map[sharedtypes.RPCType]struct{} {
+	return c.supportedAPIs
 }

--- a/qos/evm/service_state.go
+++ b/qos/evm/service_state.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/pokt-network/poktroll/pkg/polylog"
+	sharedtypes "github.com/pokt-network/poktroll/x/shared/types"
 
 	"github.com/buildwithgrove/path/gateway"
 	"github.com/buildwithgrove/path/metrics/devtools"
@@ -58,6 +59,12 @@ type serviceState struct {
 // the gateway package to augment endpoints' quality data,
 // using synthetic service requests.
 var _ gateway.QoSEndpointCheckGenerator = &serviceState{}
+
+// CheckWebsocketConnection returns true if the endpoint supports WebSocket connections.
+func (ss *serviceState) CheckWebsocketConnection() bool {
+	_, supportsWebsockets := ss.serviceQoSConfig.getSupportedAPIs()[sharedtypes.RPCType_WEBSOCKET]
+	return supportsWebsockets
+}
 
 // GetRequiredQualityChecks returns the list of quality checks required for an endpoint.
 // It is called in the `gateway/hydrator.go` file on each run of the hydrator.

--- a/qos/noop/noop.go
+++ b/qos/noop/noop.go
@@ -46,6 +46,12 @@ func (NoOpQoS) ApplyObservations(_ *qosobservations.Observations) error {
 	return nil
 }
 
+// CheckWebsocketConnection returns true if the endpoint supports WebSocket connections.
+// NoOp QoS does not support WebSocket connections.
+func (NoOpQoS) CheckWebsocketConnection() bool {
+	return false
+}
+
 // GetRequiredQualityChecks on noop QoS only fulfills the interface requirements and does not perform any actions.
 // Implements the gateway.QoSService interface.
 func (NoOpQoS) GetRequiredQualityChecks(_ protocol.EndpointAddr) []gateway.RequestQoSContext {

--- a/qos/solana/check.go
+++ b/qos/solana/check.go
@@ -23,6 +23,12 @@ const (
 // using synthetic service requests.
 var _ gateway.QoSEndpointCheckGenerator = &EndpointStore{}
 
+// TODO_TECHDEBT(@commoddity): Update Solana QoS to support WebSocket connection checks.
+// CheckWebsocketConnection returns true if the endpoint supports WebSocket connections.
+func (es *EndpointStore) CheckWebsocketConnection() bool {
+	return false
+}
+
 // TODO_IMPROVE(@commoddity): implement QoS check expiry functionality and use protocol.EndpointAddr
 // to filter out checks for any endpoint which has acurrently valid QoS data point.
 func (es *EndpointStore) GetRequiredQualityChecks(_ protocol.EndpointAddr) []gateway.RequestQoSContext {

--- a/websockets/bridge.go
+++ b/websockets/bridge.go
@@ -101,7 +101,7 @@ func StartBridge(
 	}
 
 	// Connect to the Relay Miner endpoint
-	endpointConn, err := connectWebsocketEndpoint(logger, websocketURL, headers)
+	endpointConn, err := ConnectWebsocketEndpoint(logger, websocketURL, headers)
 	if err != nil {
 		logger.Error().Err(err).Msg("❌ error connecting to websocket endpoint")
 		cancelCtx() // Clean up context on error

--- a/websockets/connection.go
+++ b/websockets/connection.go
@@ -98,8 +98,8 @@ func upgradeClientWebsocketConnection(
 	return clientConn, nil
 }
 
-// connectWebsocketEndpoint makes a websocket connection to the websocket Endpoint.
-func connectWebsocketEndpoint(
+// ConnectWebsocketEndpoint makes a websocket connection to the websocket Endpoint.
+func ConnectWebsocketEndpoint(
 	wsLogger polylog.Logger,
 	websocketURL string,
 	headers http.Header,

--- a/websockets/connection_test.go
+++ b/websockets/connection_test.go
@@ -213,7 +213,7 @@ func Test_ConnectWebsocketEndpoint(t *testing.T) {
 				test.websocketURL = "ws" + strings.TrimPrefix(server.URL, "http")
 			}
 
-			conn, err := connectWebsocketEndpoint(polyzero.NewLogger(), test.websocketURL, test.headers)
+			conn, err := ConnectWebsocketEndpoint(polyzero.NewLogger(), test.websocketURL, test.headers)
 
 			if test.shouldFail {
 				c.Error(err)


### PR DESCRIPTION
## 🌿 Summary

Add WebSocket QoS checks with separate protocol-level endpoint sanction stores for WebSocket and HTTP RPC types.

### 🌱 Primary Changes:
- Add WebSocket-specific endpoint sanction store to maintain separate sanctions for WebSocket and HTTP RPC types
- Implement WebSocket connection checks in the endpoint hydrator with separate intervals for HTTP and WebSocket checks
- Extend protocol interface with WebSocket-specific methods for endpoint availability, observation application, and connection checking
- Add WebSocket support configuration to EVM service QoS configs (enabled for base and bsc chains)

### 🍃 Secondary changes:
- Refactor endpoint hydrator into separate HTTP and WebSocket check implementations for better maintainability
- Update metrics reporting to handle protocol-level disqualified endpoints per RPC type
- Add WebSocket connection check support to EVM, Cosmos, and NoOp QoS implementations
- Extend WebSocket observation handling with connection and message-level observations for better monitoring


## 💡 New TODOs 

New TODOs introduced in this PR:
- TODO_TECHDEBT(@commoddity): Currently websocket QoS only performs a protocol-level check which determines if an endpoint connection request is successful or not.  In the future, we may want to add QoS-level checks that take into account specific endpoint responses to apply websocket-related filtering at the QoS level. - gateway/qos.go
- TODO_TECHDEBT(@adshmh,@commoddity,@olshansk): JSON_RPC RPC type should more correctly be called HTTP when used in this context. Add an HTTP RPC-type to the enum in poktroll and update this map when it is done.  sanctionedEndpointsStores tracks sanctioned endpoints per RPC type currently only JSON_RPC (stand-in for HTTP) and WEBSOCKET are supported - protocol/shannon/protocol.go

## 🛠️ Type of change

Select one or more from the following:

- [x] New feature, functionality or library
