### PR TITLE
[Metrics] Fix missing `endpoint_domain` when the observation has an error

### DIFF
--- a/metrics/protocol/shannon/metrics.go
+++ b/metrics/protocol/shannon/metrics.go
@@ -446,7 +446,8 @@ func recordRelayTotal(
 				"error_type": requestErrorType,
 				// Relay request failed before reaching out to any endpoints so no fallback was used.
 				// Must be set to avoid inconsistent label cardinality error
-				"used_fallback": "false",
+				"used_fallback":   "false",
+				"endpoint_domain": ErrDomain,
 			},
 		).Inc()
 
@@ -785,10 +786,11 @@ func recordWebsocketConnectionTotal(
 	if requestHasErr, requestErrorType := extractRequestError(observations); requestHasErr {
 		websocketConnectionsTotal.With(
 			prometheus.Labels{
-				"service_id":    serviceID,
-				"success":       "false",
-				"error_type":    requestErrorType,
-				"used_fallback": "false",
+				"service_id":      serviceID,
+				"success":         "false",
+				"error_type":      requestErrorType,
+				"used_fallback":   "false",
+				"endpoint_domain": ErrDomain,
 			},
 		).Inc()
 		return
@@ -837,10 +839,11 @@ func recordWebsocketMessageTotal(
 	if requestHasErr, requestErrorType := extractRequestError(observations); requestHasErr {
 		websocketMessagesTotal.With(
 			prometheus.Labels{
-				"service_id":    serviceID,
-				"success":       "false",
-				"error_type":    requestErrorType,
-				"used_fallback": "false",
+				"service_id":      serviceID,
+				"success":         "false",
+				"error_type":      requestErrorType,
+				"used_fallback":   "false",
+				"endpoint_domain": ErrDomain,
 			},
 		).Inc()
 		return


### PR DESCRIPTION
<img width="918" height="734" alt="Screenshot 2025-09-08 at 5 24 37 PM" src="https://github.com/user-attachments/assets/efd557ff-2af5-4dd5-9536-955abe415339" />
