### PR TITLE
[EVM][Observability] QoS EVM: export JSONRPC error codes metric

### DIFF
--- a/observation/qos/evm.pb.go
+++ b/observation/qos/evm.pb.go
@@ -538,8 +538,10 @@ type EVMEndpointObservation struct {
 	//	*EVMEndpointObservation_EmptyResponse
 	//	*EVMEndpointObservation_NoResponse
 	ResponseObservation isEVMEndpointObservation_ResponseObservation `protobuf_oneof:"response_observation"`
-	unknownFields       protoimpl.UnknownFields
-	sizeCache           protoimpl.SizeCache
+	// Only set if the endpoint returned a valid JSONRPC response.
+	ParsedJsonrpcResponse *JsonRpcResponse `protobuf:"bytes,8,opt,name=parsed_jsonrpc_response,json=parsedJsonrpcResponse,proto3,oneof" json:"parsed_jsonrpc_response,omitempty"`
+	unknownFields         protoimpl.UnknownFields
+	sizeCache             protoimpl.SizeCache
 }
 
 func (x *EVMEndpointObservation) Reset() {
@@ -636,6 +638,13 @@ func (x *EVMEndpointObservation) GetNoResponse() *EVMNoResponse {
 		if x, ok := x.ResponseObservation.(*EVMEndpointObservation_NoResponse); ok {
 			return x.NoResponse
 		}
+	}
+	return nil
+}
+
+func (x *EVMEndpointObservation) GetParsedJsonrpcResponse() *JsonRpcResponse {
+	if x != nil {
+		return x.ParsedJsonrpcResponse
 	}
 	return nil
 }
@@ -1129,7 +1138,7 @@ const file_path_qos_evm_proto_rawDesc = "" +
 	"\x10http_status_code\x18\x01 \x01(\x05R\x0ehttpStatusCode\x12N\n" +
 	"\x10validation_error\x18\x02 \x01(\x0e2#.path.qos.EVMRequestValidationErrorR\x0fvalidationError\x12(\n" +
 	"\rerror_details\x18\x03 \x01(\tH\x00R\ferrorDetails\x88\x01\x01B\x10\n" +
-	"\x0e_error_details\"\xa9\x04\n" +
+	"\x0e_error_details\"\x9d\x05\n" +
 	"\x16EVMEndpointObservation\x12#\n" +
 	"\rendpoint_addr\x18\x01 \x01(\tR\fendpointAddr\x12J\n" +
 	"\x11chain_id_response\x18\x02 \x01(\v2\x1c.path.qos.EVMChainIDResponseH\x00R\x0fchainIdResponse\x12V\n" +
@@ -1138,8 +1147,10 @@ const file_path_qos_evm_proto_rawDesc = "" +
 	"\x15unrecognized_response\x18\x05 \x01(\v2!.path.qos.EVMUnrecognizedResponseH\x00R\x14unrecognizedResponse\x12C\n" +
 	"\x0eempty_response\x18\x06 \x01(\v2\x1a.path.qos.EVMEmptyResponseH\x00R\remptyResponse\x12:\n" +
 	"\vno_response\x18\a \x01(\v2\x17.path.qos.EVMNoResponseH\x00R\n" +
-	"noResponseB\x16\n" +
-	"\x14response_observation\"\x8d\x02\n" +
+	"noResponse\x12V\n" +
+	"\x17parsed_jsonrpc_response\x18\b \x01(\v2\x19.path.qos.JsonRpcResponseH\x01R\x15parsedJsonrpcResponse\x88\x01\x01B\x16\n" +
+	"\x14response_observationB\x1a\n" +
+	"\x18_parsed_jsonrpc_response\"\x8d\x02\n" +
 	"\x12EVMChainIDResponse\x12(\n" +
 	"\x10http_status_code\x18\x01 \x01(\x05R\x0ehttpStatusCode\x12*\n" +
 	"\x11chain_id_response\x18\x02 \x01(\tR\x0fchainIdResponse\x12\x82\x01\n" +
@@ -1229,18 +1240,19 @@ var file_path_qos_evm_proto_depIdxs = []int32{
 	10, // 13: path.qos.EVMEndpointObservation.unrecognized_response:type_name -> path.qos.EVMUnrecognizedResponse
 	11, // 14: path.qos.EVMEndpointObservation.empty_response:type_name -> path.qos.EVMEmptyResponse
 	12, // 15: path.qos.EVMEndpointObservation.no_response:type_name -> path.qos.EVMNoResponse
-	1,  // 16: path.qos.EVMChainIDResponse.response_validation_error:type_name -> path.qos.EVMResponseValidationError
-	1,  // 17: path.qos.EVMBlockNumberResponse.response_validation_error:type_name -> path.qos.EVMResponseValidationError
-	1,  // 18: path.qos.EVMGetBalanceResponse.response_validation_error:type_name -> path.qos.EVMResponseValidationError
-	17, // 19: path.qos.EVMUnrecognizedResponse.jsonrpc_response:type_name -> path.qos.JsonRpcResponse
-	1,  // 20: path.qos.EVMUnrecognizedResponse.response_validation_error:type_name -> path.qos.EVMResponseValidationError
-	1,  // 21: path.qos.EVMEmptyResponse.response_validation_error:type_name -> path.qos.EVMResponseValidationError
-	1,  // 22: path.qos.EVMNoResponse.response_validation_error:type_name -> path.qos.EVMResponseValidationError
-	23, // [23:23] is the sub-list for method output_type
-	23, // [23:23] is the sub-list for method input_type
-	23, // [23:23] is the sub-list for extension type_name
-	23, // [23:23] is the sub-list for extension extendee
-	0,  // [0:23] is the sub-list for field type_name
+	17, // 16: path.qos.EVMEndpointObservation.parsed_jsonrpc_response:type_name -> path.qos.JsonRpcResponse
+	1,  // 17: path.qos.EVMChainIDResponse.response_validation_error:type_name -> path.qos.EVMResponseValidationError
+	1,  // 18: path.qos.EVMBlockNumberResponse.response_validation_error:type_name -> path.qos.EVMResponseValidationError
+	1,  // 19: path.qos.EVMGetBalanceResponse.response_validation_error:type_name -> path.qos.EVMResponseValidationError
+	17, // 20: path.qos.EVMUnrecognizedResponse.jsonrpc_response:type_name -> path.qos.JsonRpcResponse
+	1,  // 21: path.qos.EVMUnrecognizedResponse.response_validation_error:type_name -> path.qos.EVMResponseValidationError
+	1,  // 22: path.qos.EVMEmptyResponse.response_validation_error:type_name -> path.qos.EVMResponseValidationError
+	1,  // 23: path.qos.EVMNoResponse.response_validation_error:type_name -> path.qos.EVMResponseValidationError
+	24, // [24:24] is the sub-list for method output_type
+	24, // [24:24] is the sub-list for method input_type
+	24, // [24:24] is the sub-list for extension type_name
+	24, // [24:24] is the sub-list for extension extendee
+	0,  // [0:24] is the sub-list for field type_name
 }
 
 func init() { file_path_qos_evm_proto_init() }

--- a/observation/qos/evm_interpreter.go
+++ b/observation/qos/evm_interpreter.go
@@ -178,6 +178,39 @@ func (i *EVMObservationInterpreter) GetEndpointObservations() ([]*EVMEndpointObs
 	return allEndpointObservations, true
 }
 
+// GetJSONRPCErrorCode extracts the JSON-RPC error code from the last endpoint observation.
+// Returns (errorCode, true) if a JSON-RPC error is present in the parsed response
+// Returns (0, false) if no error is present or parsed_jsonrpc_response is nil
+func (i *EVMObservationInterpreter) GetJSONRPCErrorCode() (int, bool) {
+	observations, ok := i.GetEndpointObservations()
+	if !ok {
+		return 0, false
+	}
+
+	// No endpoint observations indicates no responses were received
+	if len(observations) == 0 {
+		return 0, false
+	}
+
+	// Use only the last observation (latest response)
+	lastObs := observations[len(observations)-1]
+
+	// Get the parsed JSON-RPC response
+	parsedResponse := lastObs.GetParsedJsonrpcResponse()
+	if parsedResponse == nil {
+		return 0, false
+	}
+
+	// Check if there's an error in the JSON-RPC response
+	jsonrpcError := parsedResponse.GetError()
+	if jsonrpcError == nil {
+		return 0, false
+	}
+
+	// Return the error code
+	return int(jsonrpcError.GetCode()), true
+}
+
 // checkRequestValidationFailures examines observations for request validation failures
 // Returns (httpStatusCode, requestError) where requestError is non-nil if a validation failure was found
 func (i *EVMObservationInterpreter) checkRequestValidationFailures() (int, *EVMRequestError) {

--- a/proto/path/qos/evm.proto
+++ b/proto/path/qos/evm.proto
@@ -201,6 +201,9 @@ message EVMEndpointObservation {
     // This differs from EVMEmptyResponse as no response was reported by the protocol.
     EVMNoResponse no_response = 7;
   }
+
+  // Only set if the endpoint returned a valid JSONRPC response.
+  optional JsonRpcResponse parsed_jsonrpc_response = 8;
 }
 
 // TODO_MVP(@adshmh): Implement a consolidated SanctionObservation message structure that:

--- a/qos/evm/response_blocknumber.go
+++ b/qos/evm/response_blocknumber.go
@@ -87,6 +87,7 @@ type responseToBlockNumber struct {
 // Reference: https://ethereum.org/en/developers/docs/apis/json-rpc/#eth_blocknumber
 func (r responseToBlockNumber) GetObservation() qosobservations.EVMEndpointObservation {
 	return qosobservations.EVMEndpointObservation{
+		ParsedJsonrpcResponse: r.jsonrpcResponse.GetObservation(),
 		ResponseObservation: &qosobservations.EVMEndpointObservation_BlockNumberResponse{
 			BlockNumberResponse: &qosobservations.EVMBlockNumberResponse{
 				HttpStatusCode:          int32(r.getHTTPStatusCode()),

--- a/qos/evm/response_chainid.go
+++ b/qos/evm/response_chainid.go
@@ -84,6 +84,7 @@ type responseToChainID struct {
 // Reference: https://ethereum.org/en/developers/docs/apis/json-rpc/#eth_chainid
 func (r responseToChainID) GetObservation() qosobservations.EVMEndpointObservation {
 	return qosobservations.EVMEndpointObservation{
+		ParsedJsonrpcResponse: r.jsonrpcResponse.GetObservation(),
 		ResponseObservation: &qosobservations.EVMEndpointObservation_ChainIdResponse{
 			ChainIdResponse: &qosobservations.EVMChainIDResponse{
 				HttpStatusCode:          int32(r.getHTTPStatusCode()),

--- a/qos/evm/response_generic.go
+++ b/qos/evm/response_generic.go
@@ -52,7 +52,7 @@ type responseGeneric struct {
 // disqualification when validation errors are present.
 // Implements the response interface.
 func (r responseGeneric) GetObservation() qosobservations.EVMEndpointObservation {
-	return qosobservations.EVMEndpointObservation{
+	observation := qosobservations.EVMEndpointObservation{
 		ResponseObservation: &qosobservations.EVMEndpointObservation_UnrecognizedResponse{
 			UnrecognizedResponse: &qosobservations.EVMUnrecognizedResponse{
 				// Include JSONRPC response's details in the observation.
@@ -62,6 +62,13 @@ func (r responseGeneric) GetObservation() qosobservations.EVMEndpointObservation
 			},
 		},
 	}
+
+	// If validation error was nil, i.e. if the endpoint response was parsed successfully, update the observation.
+	if r.validationError == nil {
+		observation.ParsedJsonrpcResponse = r.jsonrpcResponse.GetObservation()
+	}
+
+	return observation
 }
 
 // GetHTTPResponse builds and returns the httpResponse matching the responseGeneric instance.

--- a/qos/evm/response_getbalance.go
+++ b/qos/evm/response_getbalance.go
@@ -88,6 +88,7 @@ type responseToGetBalance struct {
 // Implements the response interface.
 func (r responseToGetBalance) GetObservation() qosobservations.EVMEndpointObservation {
 	return qosobservations.EVMEndpointObservation{
+		ParsedJsonrpcResponse: r.jsonrpcResponse.GetObservation(),
 		ResponseObservation: &qosobservations.EVMEndpointObservation_GetBalanceResponse{
 			GetBalanceResponse: &qosobservations.EVMGetBalanceResponse{
 				HttpStatusCode:          int32(r.getHTTPStatusCode()),


### PR DESCRIPTION
## Summary

QoS EVM: export JSONRPC error codes metric

### Primary Changes:

- Added jsonrpcErrorsTotal Prometheus counter metric to track JSON-RPC errors by method, endpoint domain, and error code
- Extended EVMEndpointObservation protobuf with optional parsed_jsonrpc_response field for better error analysis
- Implemented GetJSONRPCErrorCode() method in EVMObservationInterpreter to extract error codes from responses

### Secondary Changes:

- Updated all response handlers (responseToBlockNumber, responseToChainID, responseToGetBalance, responseGeneric) to populate the new parsed_jsonrpc_response field
- Added comprehensive documentation for the new metric including usage examples and cardinality considerations

## Issue

No visibility into JSONRPC response error codes via metrics.

- Issue or PR: #{ISSUE_OR_PR_NUMBER}

## Type of change

Select one or more from the following:

- [x] New feature, functionality or library
- [ ] Bug fix
- [ ] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## QoS Checklist

### E2E Validation & Tests

- [ ] `make path_up`
- [ ] `make test_e2e_evm_shannon`

### Observability

- [ ] 1. `make path_up`
- [ ] 2. Run the following E2E test: `make test_request__shannon_relay_util_100`
- [ ] 3. View results in LocalNet's [PATH Relay Grafana Dashboard](http://localhost:3003/d/relays/path-service-requests)

## Sanity Checklist

- [x] I have updated the GitHub Issue `assignees`, `reviewers`, `labels`, `project`, `iteration` and `milestone`
- [ ] For docs, I have run `make docusaurus_start`
- [ ] For code, I have run `make test_all`
- [ ] For configurations, I have updated the documentation
- [x] I added `TODO`s where applicable
