### PR TITLE
[SERVICE][QoS] Renaming `side-protocol` to `bitway`

### DIFF
--- a/config/service_qos_config.go
+++ b/config/service_qos_config.go
@@ -911,8 +911,9 @@ var shannonServices = []ServiceQoSConfig{
 		sharedtypes.RPCType_COMET_BFT: {},
 	}),
 
-	// Side Protocol - https://github.com/cosmos/chain-registry/blob/master/sidechain/chain.json#L9
-	cosmos.NewCosmosSDKServiceQoSConfig("side-protocol", "sidechain-1", "", map[sharedtypes.RPCType]struct{}{
+	// Bitway - https://github.com/cosmos/chain-registry/blob/master/bitway/chain.json
+	// FORMERLY KNOWN AS: Side Protocol - https://github.com/cosmos/chain-registry/blob/master/sidechain/chain.json#L9
+	cosmos.NewCosmosSDKServiceQoSConfig("bitway", "bitway-1", "", map[sharedtypes.RPCType]struct{}{
 		sharedtypes.RPCType_REST:      {}, // CosmosSDK
 		sharedtypes.RPCType_COMET_BFT: {},
 	}),


### PR DESCRIPTION
## Summary

Renaming `side-protocol` to `bitway`

## Type of change

Select one or more from the following:

- [x] New feature, functionality or library
- [ ] Bug fix
- [x] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## QoS Checklist

### E2E Validation & Tests

- [ ] `make path_up`
- [ ] `make test_e2e_evm_shannon`

### Observability

- [ ] 1. `make path_up`
- [ ] 2. Run the following E2E test: `make test_request__shannon_relay_util_100`
- [ ] 3. View results in LocalNet's [PATH Relay Grafana Dashboard](http://localhost:3003/d/relays/path-service-requests)

## Sanity Checklist

- [ ] I have updated the GitHub Issue `assignees`, `reviewers`, `labels`, `project`, `iteration` and `milestone`
- [ ] For docs, I have run `make docusaurus_start`
- [ ] For code, I have run `make test_all`
- [ ] For configurations, I have updated the documentation
- [ ] I added `TODO`s where applicable
