### PR TITLE
Add automated version bumping and release workflow

### DIFF
--- a/.github/workflows/auto-version-bump.yml
+++ b/.github/workflows/auto-version-bump.yml
@@ -1,0 +1,38 @@
+name: Auto Version and Release
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  version-and-release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Bump version and push tag
+        id: tag_version
+        uses: anothrNick/github-tag-action@1.67.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DEFAULT_BUMP: patch
+          WITH_V: true
+          RELEASE_BRANCHES: main
+          INITIAL_VERSION: 0.4.0
+
+      - name: Create GitHub Release
+        uses: ncipollo/release-action@v1
+        with:
+          tag: ${{ steps.tag_version.outputs.new_tag }}
+          name: Release ${{ steps.tag_version.outputs.new_tag }}
+          generateReleaseNotes: true
+          body: |
+            ## Changes in this release
+
+            **Full Changelog**: https://github.com/${{ github.repository }}/compare/${{ steps.tag_version.outputs.tag }}...${{ steps.tag_version.outputs.new_tag }}

--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -4,8 +4,6 @@ on:
   push:
     tags:
       - "v*.*.*"
-    branches:
-      - "main"
   workflow_dispatch:
     inputs:
       custom_tag:
@@ -22,7 +20,7 @@ jobs:
     runs-on: ubuntu-22.04
     env:
       GITHUB_TOKEN: ${{ github.token }}
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    if: startsWith(github.ref, 'refs/tags/v')
     steps:
       - uses: rymndhng/release-on-push-action@master
         with:


### PR DESCRIPTION
## Summary
- Adds `auto-version-bump.yml` workflow that automatically creates version tags and GitHub releases on every push to `main`
- Updates `release-artifacts.yml` to only trigger on tag pushes (removed conflicting `main` branch trigger)
- Fixes broken conditional in `release-artifacts.yml` that was checking for `workflow_run` event on push triggers

## How it works
1. Push to `main` → `auto-version-bump.yml` auto-creates tag + GitHub release with release notes
2. Tag created → `release-artifacts.yml` runs to build/publish artifacts

## Test plan
- [x] Created v0.4.0 tag manually as baseline
- [ ] Merge this PR and verify next push to main creates v0.4.1 automatically
- [ ] Verify release notes are generated correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)