### PR TITLE
perf: reduce GC pressure on hot paths (~30% CPU on busy gateway pods)

### DIFF
--- a/protocol/shannon/protocol.go
+++ b/protocol/shannon/protocol.go
@@ -994,8 +994,8 @@ func (p *Protocol) getSessionsUniqueEndpoints(
 
 		// Using a single iteration scope for this logger.
 		// Avoids adding all apps in the loop to the logger's fields.
-		// Hydrate the logger with session details.
-		logger := logger.With("valid_app_address", app.Address).With("method", "getSessionsUniqueEndpoints")
+		// "method" is already set on the outer logger above; don't re-add it.
+		logger := logger.With("valid_app_address", app.Address)
 		logger = hydrateLoggerWithSession(logger, &session)
 		logger.ProbabilisticDebugInfo(polylog.ProbabilisticDebugInfoProb).Msgf("Finding unique endpoints for session %s for app %s for service %s.", session.SessionId, app.Address, serviceID)
 

--- a/protocol/shannon/reputation.go
+++ b/protocol/shannon/reputation.go
@@ -36,10 +36,21 @@ func (p *Protocol) filterByReputation(
 
 	keyBuilder := p.reputationService.KeyBuilderForService(serviceID)
 
-	// Build endpoint keys for batch lookup
+	// Build keys + remember each endpoint in a single pass. The second loop
+	// walks this slice instead of re-iterating the map and re-calling BuildKey
+	// (which allocates for non-default key granularities — domain mode parses
+	// URLs and extracts hostnames).
+	type addrKey struct {
+		addr protocol.EndpointAddr
+		ep   endpoint
+		key  reputation.EndpointKey
+	}
+	cached := make([]addrKey, 0, len(endpoints))
 	keys := make([]reputation.EndpointKey, 0, len(endpoints))
-	for addr := range endpoints {
-		keys = append(keys, keyBuilder.BuildKey(serviceID, addr, rpcType))
+	for addr, ep := range endpoints {
+		k := keyBuilder.BuildKey(serviceID, addr, rpcType)
+		cached = append(cached, addrKey{addr: addr, ep: ep, key: k})
+		keys = append(keys, k)
 	}
 
 	// Get scores for all endpoints in a single call
@@ -49,15 +60,17 @@ func (p *Protocol) filterByReputation(
 		return endpoints
 	}
 
+	// Hoist out of the loop; the threshold doesn't change per endpoint.
+	minThreshold := p.getMinThresholdForService(serviceID)
+
 	// Filter endpoints below threshold or in cooldown
 	filtered := make(map[protocol.EndpointAddr]endpoint, len(endpoints))
-	for addr, ep := range endpoints {
-		key := keyBuilder.BuildKey(serviceID, addr, rpcType)
-		score, exists := scores[key]
+	for _, ak := range cached {
+		score, exists := scores[ak.key]
 
 		// If score doesn't exist, the endpoint is new and gets initial score (which is above threshold)
 		if !exists {
-			filtered[addr] = ep
+			filtered[ak.addr] = ak.ep
 			continue
 		}
 
@@ -66,10 +79,10 @@ func (p *Protocol) filterByReputation(
 			// CRITICAL: If this is the pre-selected endpoint, we MUST include it to avoid
 			// the "Selected endpoint is not available" error. This handles the race condition
 			// where an endpoint was selected but then entered cooldown.
-			if addr == requestedEndpointAddr {
-				filtered[addr] = ep
+			if ak.addr == requestedEndpointAddr {
+				filtered[ak.addr] = ak.ep
 				logger.Debug().
-					Str("endpoint", string(addr)).
+					Str("endpoint", string(ak.addr)).
 					Int("strikes", score.CriticalStrikes).
 					Dur("cooldown_remaining", score.CooldownRemaining()).
 					Msg("Including requested endpoint even though it is in cooldown")
@@ -77,7 +90,7 @@ func (p *Protocol) filterByReputation(
 			}
 
 			logger.Debug().
-				Str("endpoint", string(addr)).
+				Str("endpoint", string(ak.addr)).
 				Int("strikes", score.CriticalStrikes).
 				Dur("cooldown_remaining", score.CooldownRemaining()).
 				Msg("Filtering out endpoint in cooldown (strike system)")
@@ -85,19 +98,18 @@ func (p *Protocol) filterByReputation(
 		}
 
 		// Check if score is above the configured minimum threshold (use per-service threshold)
-		minThreshold := p.getMinThresholdForService(serviceID)
-		if score.Value >= minThreshold || addr == requestedEndpointAddr {
-			filtered[addr] = ep
-			if score.Value < minThreshold && addr == requestedEndpointAddr {
+		if score.Value >= minThreshold || ak.addr == requestedEndpointAddr {
+			filtered[ak.addr] = ak.ep
+			if score.Value < minThreshold && ak.addr == requestedEndpointAddr {
 				logger.Debug().
-					Str("endpoint", string(addr)).
+					Str("endpoint", string(ak.addr)).
 					Float64("score", score.Value).
 					Float64("threshold", minThreshold).
 					Msg("Including requested endpoint even though it is below threshold")
 			}
 		} else {
 			logger.Debug().
-				Str("endpoint", string(addr)).
+				Str("endpoint", string(ak.addr)).
 				Float64("score", score.Value).
 				Float64("threshold", minThreshold).
 				Msg("Filtering out low-reputation endpoint")
@@ -131,10 +143,11 @@ func (p *Protocol) getEndpointScores(
 		return nil, err
 	}
 
-	// Convert to score values map
+	// Convert to score values map. Iterate the keys slice we just built so we
+	// don't have to call keyBuilder.BuildKey a second time per endpoint —
+	// that's a non-trivial allocation under domain/supplier granularity.
 	result := make(map[reputation.EndpointKey]float64, len(endpoints))
-	for addr := range endpoints {
-		key := keyBuilder.BuildKey(serviceID, addr, rpcType)
+	for _, key := range keys {
 		if score, exists := scores[key]; exists {
 			result[key] = score.Value
 		} else {

--- a/protocol/shannon/reputation_filter_bench_test.go
+++ b/protocol/shannon/reputation_filter_bench_test.go
@@ -1,0 +1,135 @@
+package shannon
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/pokt-network/poktroll/pkg/polylog"
+	sharedtypes "github.com/pokt-network/poktroll/x/shared/types"
+
+	"github.com/pokt-network/path/protocol"
+	"github.com/pokt-network/path/reputation"
+	reputationstorage "github.com/pokt-network/path/reputation/storage"
+)
+
+// BenchmarkFilterByReputation measures the per-call cost of filterByReputation
+// across the two key-builder granularities that allocate inside BuildKey, and
+// compares the current implementation against the legacy one that called
+// keyBuilder.BuildKey twice per endpoint.
+//
+// Run with:
+//
+//	go test -run='^$' -bench=BenchmarkFilterByReputation -benchmem ./protocol/shannon/
+func BenchmarkFilterByReputation(b *testing.B) {
+	for _, granularity := range []string{
+		reputation.KeyGranularityEndpoint,
+		reputation.KeyGranularityDomain,
+	} {
+		for _, n := range []int{8, 32} {
+			b.Run(fmt.Sprintf("legacy/granularity=%s/endpoints=%d", granularity, n), func(b *testing.B) {
+				benchFilterByReputation(b, granularity, n, true)
+			})
+			b.Run(fmt.Sprintf("fixed/granularity=%s/endpoints=%d", granularity, n), func(b *testing.B) {
+				benchFilterByReputation(b, granularity, n, false)
+			})
+		}
+	}
+}
+
+func benchFilterByReputation(b *testing.B, granularity string, n int, legacy bool) {
+	ctx := context.Background()
+
+	cfg := reputation.Config{
+		Enabled:        true,
+		InitialScore:   80,
+		MinThreshold:   30,
+		StorageType:    "memory",
+		KeyGranularity: granularity,
+	}
+	cfg.HydrateDefaults()
+
+	svc := reputation.NewService(cfg, reputationstorage.NewMemoryStorage(5*time.Minute))
+	if err := svc.Start(ctx); err != nil {
+		b.Fatalf("svc.Start: %v", err)
+	}
+	b.Cleanup(func() { _ = svc.Stop() })
+
+	p := &Protocol{
+		logger:            newSilentLogger(),
+		reputationService: svc,
+	}
+	const serviceID = protocol.ServiceID("eth")
+
+	endpoints := make(map[protocol.EndpointAddr]endpoint, n)
+	for i := 0; i < n; i++ {
+		addr := protocol.EndpointAddr(fmt.Sprintf("pokt1supplier%d-https://relay-%d.example.com:443/json-rpc", i, i))
+		endpoints[addr] = &mockEndpoint{addr: addr}
+	}
+
+	logger := newSilentLogger()
+	rpcType := sharedtypes.RPCType_JSON_RPC
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if legacy {
+			_ = legacyFilterByReputation(p, ctx, serviceID, endpoints, rpcType, logger, "")
+		} else {
+			_ = p.filterByReputation(ctx, serviceID, endpoints, rpcType, logger, "")
+		}
+	}
+}
+
+// legacyFilterByReputation is the pre-fix implementation, kept locally so the
+// benchmark above can compare old vs new. Do NOT call from production code.
+// (It calls keyBuilder.BuildKey twice per endpoint and re-evaluates
+// minThreshold inside the loop.)
+func legacyFilterByReputation(
+	p *Protocol,
+	ctx context.Context,
+	serviceID protocol.ServiceID,
+	endpoints map[protocol.EndpointAddr]endpoint,
+	rpcType sharedtypes.RPCType,
+	logger polylog.Logger,
+	requestedEndpointAddr protocol.EndpointAddr,
+) map[protocol.EndpointAddr]endpoint {
+	if p.reputationService == nil {
+		return endpoints
+	}
+
+	keyBuilder := p.reputationService.KeyBuilderForService(serviceID)
+
+	keys := make([]reputation.EndpointKey, 0, len(endpoints))
+	for addr := range endpoints {
+		keys = append(keys, keyBuilder.BuildKey(serviceID, addr, rpcType))
+	}
+
+	scores, err := p.reputationService.GetScores(ctx, keys)
+	if err != nil {
+		return endpoints
+	}
+
+	filtered := make(map[protocol.EndpointAddr]endpoint, len(endpoints))
+	for addr, ep := range endpoints {
+		key := keyBuilder.BuildKey(serviceID, addr, rpcType)
+		score, exists := scores[key]
+		if !exists {
+			filtered[addr] = ep
+			continue
+		}
+		if score.IsInCooldown() {
+			if addr == requestedEndpointAddr {
+				filtered[addr] = ep
+			}
+			continue
+		}
+		minThreshold := p.getMinThresholdForService(serviceID)
+		if score.Value >= minThreshold || addr == requestedEndpointAddr {
+			filtered[addr] = ep
+		}
+	}
+
+	return filtered
+}

--- a/protocol/shannon/session_exhaustion.go
+++ b/protocol/shannon/session_exhaustion.go
@@ -19,6 +19,16 @@ const sessionExhaustionTTL = 30 * time.Minute
 // size to keep the steady-state Mark cost ~O(1).
 const sessionExhaustionEvictThreshold = 1024
 
+// sessionExhaustionKey identifies a flagged (service, session, supplier)
+// tuple. Used directly as a map key so we don't allocate a string on every
+// Mark/IsExhausted — pprof showed the previous string-concat key as ~90 GB
+// cumulative on a busy gateway pod.
+type sessionExhaustionKey struct {
+	ServiceID string
+	SessionID string
+	Supplier  string
+}
+
 // sessionExhaustionTracker records (serviceID, sessionID, supplier) tuples
 // where the supplier's relay-miner has signaled the application's per-session
 // stake budget is exhausted ("over-servicing"). Once flagged, PATH must skip
@@ -34,7 +44,7 @@ const sessionExhaustionEvictThreshold = 1024
 // reaped lazily.
 type sessionExhaustionTracker struct {
 	mu      sync.RWMutex
-	entries map[string]time.Time
+	entries map[sessionExhaustionKey]time.Time
 
 	// markCount is incremented on every Mark and gates the opportunistic GC
 	// frequency without taking the write lock just to bump a counter.
@@ -43,14 +53,8 @@ type sessionExhaustionTracker struct {
 
 func newSessionExhaustionTracker() *sessionExhaustionTracker {
 	return &sessionExhaustionTracker{
-		entries: make(map[string]time.Time),
+		entries: make(map[sessionExhaustionKey]time.Time),
 	}
-}
-
-// sessionExhaustionKey builds the map key. Service ID is included so two
-// services that happen to share a session ID prefix don't cross-contaminate.
-func sessionExhaustionKey(serviceID, sessionID, supplier string) string {
-	return serviceID + "|" + sessionID + "|" + supplier
 }
 
 // Mark flags the (service, session, supplier) tuple as over-serviced for the
@@ -60,7 +64,7 @@ func (t *sessionExhaustionTracker) Mark(serviceID, sessionID, supplier string) {
 	if t == nil || serviceID == "" || sessionID == "" || supplier == "" {
 		return
 	}
-	key := sessionExhaustionKey(serviceID, sessionID, supplier)
+	key := sessionExhaustionKey{ServiceID: serviceID, SessionID: sessionID, Supplier: supplier}
 
 	t.mu.Lock()
 	t.entries[key] = time.Now()
@@ -77,7 +81,7 @@ func (t *sessionExhaustionTracker) IsExhausted(serviceID, sessionID, supplier st
 	if t == nil || serviceID == "" || sessionID == "" || supplier == "" {
 		return false
 	}
-	key := sessionExhaustionKey(serviceID, sessionID, supplier)
+	key := sessionExhaustionKey{ServiceID: serviceID, SessionID: sessionID, Supplier: supplier}
 
 	t.mu.RLock()
 	markedAt, ok := t.entries[key]

--- a/protocol/shannon/session_exhaustion_test.go
+++ b/protocol/shannon/session_exhaustion_test.go
@@ -48,14 +48,14 @@ func TestSessionExhaustionTracker_TTLExpiry(t *testing.T) {
 
 	// Fudge the stored timestamp to simulate TTL expiry without sleeping.
 	tr.mu.Lock()
-	tr.entries[sessionExhaustionKey("eth", "session-1", "pokt1abc")] = time.Now().Add(-2 * sessionExhaustionTTL)
+	tr.entries[sessionExhaustionKey{ServiceID: "eth", SessionID: "session-1", Supplier: "pokt1abc"}] = time.Now().Add(-2 * sessionExhaustionTTL)
 	tr.mu.Unlock()
 
 	require.False(t, tr.IsExhausted("eth", "session-1", "pokt1abc"))
 
 	// Lazy reap should have dropped the entry.
 	tr.mu.RLock()
-	_, present := tr.entries[sessionExhaustionKey("eth", "session-1", "pokt1abc")]
+	_, present := tr.entries[sessionExhaustionKey{ServiceID: "eth", SessionID: "session-1", Supplier: "pokt1abc"}]
 	tr.mu.RUnlock()
 	require.False(t, present, "expired entry should be lazily reaped on IsExhausted")
 }

--- a/protocol/shannon/websocket_context.go
+++ b/protocol/shannon/websocket_context.go
@@ -99,9 +99,12 @@ func (p *Protocol) BuildWebsocketRequestContextForEndpoint(
 		return nil, nil, err
 	}
 
-	// Create Websocket request context for the pre-selected endpoint
+	// Create Websocket request context for the pre-selected endpoint.
+	// The logger is hydrated once with all connection-level fields (supplier,
+	// URL, app, etc.) — these are immutable for the connection's lifetime, so
+	// re-adding them per message would just churn allocations.
 	wrc := &websocketRequestContext{
-		logger:             logger,
+		logger:             buildWebsocketConnectionLogger(p.logger, serviceID, selectedEndpoint),
 		context:            ctx,
 		fullNode:           p.FullNode,
 		selectedEndpoint:   selectedEndpoint,
@@ -332,33 +335,37 @@ func (wrc *websocketRequestContext) startWebSocketBridge(
 	messageObservationsChan chan *observation.RequestResponseObservations,
 	connectionObservationChan chan *protocolobservations.Observations,
 ) error {
-	wrc.hydratedLogger("StartWebSocketBridge")
+	logger := wrc.methodLogger("StartWebSocketBridge")
 
 	// Get the websocket-specific URL from the selected endpoint.
-	websocketEndpointURL, err := getWebsocketEndpointURL(wrc.logger, wrc.selectedEndpoint)
+	websocketEndpointURL, err := getWebsocketEndpointURL(logger, wrc.selectedEndpoint)
 	if err != nil {
 		err = fmt.Errorf("%w: selected endpoint does not support websocket RPC type: %s", errCreatingWebSocketConnection, err.Error())
-		wrc.logger.Error().Err(err).Msg("❌ Selected endpoint does not support websocket RPC type")
+		logger.Error().Err(err).Msg("❌ Selected endpoint does not support websocket RPC type")
 
 		// Record critical error signal - endpoint doesn't support required RPC type.
 		// Latency=0 indicates this is a setup/configuration error, not a response time measurement.
 		wrc.recordWebsocketSignal(reputation.NewCriticalErrorSignal("ws_url_not_supported", 0))
-		connectionObservationChan <- getWebsocketConnectionErrorObservation(wrc.logger, wrc.serviceID, wrc.selectedEndpoint, err)
+		connectionObservationChan <- getWebsocketConnectionErrorObservation(logger, wrc.serviceID, wrc.selectedEndpoint, err)
 
 		return fmt.Errorf("selected endpoint does not support websocket RPC type: %w", err)
 	}
+	// One-shot mutation: bake the resolved websocket URL into the connection
+	// logger so the long-lived bridge goroutine and per-message methods all
+	// inherit it. Per-connection only — never per-message.
 	wrc.logger = wrc.logger.With("websocket_url", websocketEndpointURL)
+	logger = logger.With("websocket_url", websocketEndpointURL)
 
 	// Get the headers for the websocket connection that will be sent to the endpoint.
-	endpointConnectionHeaders, err := getWebsocketConnectionHeaders(wrc.logger, wrc.selectedEndpoint)
+	endpointConnectionHeaders, err := getWebsocketConnectionHeaders(logger, wrc.selectedEndpoint)
 	if err != nil {
 		err = fmt.Errorf("%w: failed to get websocket connection headers: %s", errCreatingWebSocketConnection, err.Error())
-		wrc.logger.Error().Err(err).Msg("❌ Failed to get websocket connection headers")
+		logger.Error().Err(err).Msg("❌ Failed to get websocket connection headers")
 
 		// Record major error signal - header construction failed.
 		// Latency=0 indicates this is a setup error, not a response time measurement.
 		wrc.recordWebsocketSignal(reputation.NewMajorErrorSignal("ws_headers_failed", 0))
-		connectionObservationChan <- getWebsocketConnectionErrorObservation(wrc.logger, wrc.serviceID, wrc.selectedEndpoint, err)
+		connectionObservationChan <- getWebsocketConnectionErrorObservation(logger, wrc.serviceID, wrc.selectedEndpoint, err)
 
 		return fmt.Errorf("failed to get websocket connection headers: %w", err)
 	}
@@ -369,10 +376,10 @@ func (wrc *websocketRequestContext) startWebSocketBridge(
 		signature, err := wrc.generateHandshakeSignature()
 		if err != nil {
 			err = fmt.Errorf("%w: failed to generate handshake signature: %s", errCreatingWebSocketConnection, err.Error())
-			wrc.logger.Error().Err(err).Msg("❌ Failed to generate handshake signature")
+			logger.Error().Err(err).Msg("❌ Failed to generate handshake signature")
 
 			wrc.recordWebsocketSignal(reputation.NewMajorErrorSignal("ws_signature_failed", 0))
-			connectionObservationChan <- getWebsocketConnectionErrorObservation(wrc.logger, wrc.serviceID, wrc.selectedEndpoint, err)
+			connectionObservationChan <- getWebsocketConnectionErrorObservation(logger, wrc.serviceID, wrc.selectedEndpoint, err)
 
 			return fmt.Errorf("failed to generate handshake signature: %w", err)
 		}
@@ -393,12 +400,12 @@ func (wrc *websocketRequestContext) startWebSocketBridge(
 	)
 	if err != nil {
 		err = fmt.Errorf("%w: failed to start websocket bridge: %s", errCreatingWebSocketConnection, err.Error())
-		wrc.logger.Error().Err(err).Msg("❌ Failed to start Websocket bridge")
+		logger.Error().Err(err).Msg("❌ Failed to start Websocket bridge")
 
 		// Record major error signal - connection establishment failed.
 		// Latency=0 indicates this is a connection setup error, not a response time measurement.
 		wrc.recordWebsocketSignal(reputation.NewMajorErrorSignal("ws_connection_failed", 0))
-		connectionObservationChan <- getWebsocketConnectionErrorObservation(wrc.logger, wrc.serviceID, wrc.selectedEndpoint, err)
+		connectionObservationChan <- getWebsocketConnectionErrorObservation(logger, wrc.serviceID, wrc.selectedEndpoint, err)
 
 		return fmt.Errorf("failed to start websocket bridge: %w", err)
 	}
@@ -486,7 +493,7 @@ func getWebsocketEndpointURL(logger polylog.Logger, selectedEndpoint endpoint) (
 // to validate the connection upfront (eager validation) before accepting WebSocket messages.
 // The signature is over the same data that would be in a RelayRequest.Meta with empty payload.
 func (wrc *websocketRequestContext) generateHandshakeSignature() (string, error) {
-	wrc.hydratedLogger("generateHandshakeSignature")
+	logger := wrc.methodLogger("generateHandshakeSignature")
 
 	// Create a relay request with empty payload for signing.
 	// The signature covers the session metadata (same as for regular relay requests).
@@ -500,7 +507,7 @@ func (wrc *websocketRequestContext) generateHandshakeSignature() (string, error)
 
 	app := wrc.selectedEndpoint.Session().GetApplication()
 	if app == nil {
-		wrc.logger.Error().Msg("❌ SHOULD NEVER HAPPEN: session application is nil")
+		logger.Error().Msg("❌ SHOULD NEVER HAPPEN: session application is nil")
 		return "", fmt.Errorf("session application is nil")
 	}
 
@@ -517,7 +524,7 @@ func (wrc *websocketRequestContext) generateHandshakeSignature() (string, error)
 	// Encode as base64 for transport in HTTP header.
 	signatureBase64 := base64.StdEncoding.EncodeToString(signatureBytes)
 
-	wrc.logger.Debug().
+	logger.Debug().
 		Str("session_id", signedHandshake.Meta.SessionHeader.SessionId).
 		Int("signature_length", len(signatureBytes)).
 		Msg("Generated handshake signature")
@@ -530,9 +537,9 @@ func (wrc *websocketRequestContext) generateHandshakeSignature() (string, error)
 // ProcessProtocolClientWebsocketMessage processes a message from the client.
 // Implements gateway.ProtocolRequestContextWebsocket interface.
 func (wrc *websocketRequestContext) ProcessProtocolClientWebsocketMessage(msgData []byte) ([]byte, error) {
-	wrc.hydratedLogger("ProcessClientWebsocketMessage")
+	logger := wrc.methodLogger("ProcessClientWebsocketMessage")
 
-	wrc.logger.Debug().Msgf("received message from client: %s", string(msgData))
+	logger.Debug().Msgf("received message from client: %s", string(msgData))
 
 	// Extract domain for message metrics
 	domain, domainErr := shannonmetrics.ExtractDomainOrHost(wrc.selectedEndpoint.PublicURL())
@@ -553,7 +560,7 @@ func (wrc *websocketRequestContext) ProcessProtocolClientWebsocketMessage(msgDat
 	// If the selected endpoint is a protocol endpoint, we need to sign the message.
 	signedRelayRequest, err := wrc.signClientWebsocketMessage(msgData)
 	if err != nil {
-		wrc.logger.Error().Err(err).Msg("❌ failed to sign request")
+		logger.Error().Err(err).Msg("❌ failed to sign request")
 		// Record message metric for client→endpoint direction with error
 		// Note: signing errors are PATH-side, not endpoint quality issues, but we track for observability
 		metrics.RecordWebsocketMessage(domain, serviceID, metrics.WSDirectionClientToEndpoint, metrics.SignalMinorError)
@@ -567,7 +574,7 @@ func (wrc *websocketRequestContext) ProcessProtocolClientWebsocketMessage(msgDat
 
 // signClientWebsocketMessage signs a message from the client using the Relay Request Signer.
 func (wrc *websocketRequestContext) signClientWebsocketMessage(msgData []byte) ([]byte, error) {
-	wrc.hydratedLogger("signClientWebsocketMessage")
+	logger := wrc.methodLogger("signClientWebsocketMessage")
 
 	unsignedRelayRequest := &servicetypes.RelayRequest{
 		Meta: servicetypes.RelayRequestMetadata{
@@ -579,7 +586,7 @@ func (wrc *websocketRequestContext) signClientWebsocketMessage(msgData []byte) (
 
 	app := wrc.selectedEndpoint.Session().GetApplication()
 	if app == nil {
-		wrc.logger.Error().Msg("❌ SHOULD NEVER HAPPEN: session application is nil")
+		logger.Error().Msg("❌ SHOULD NEVER HAPPEN: session application is nil")
 		return nil, fmt.Errorf("session application is nil")
 	}
 
@@ -602,10 +609,10 @@ func (wrc *websocketRequestContext) signClientWebsocketMessage(msgData []byte) (
 func (wrc *websocketRequestContext) ProcessProtocolEndpointWebsocketMessage(
 	msgData []byte,
 ) ([]byte, protocolobservations.Observations, error) {
-	wrc.hydratedLogger("ProcessEndpointWebsocketMessage")
+	logger := wrc.methodLogger("ProcessEndpointWebsocketMessage")
 	startTime := time.Now()
 
-	wrc.logger.Debug().Msgf("received message from endpoint: %s", string(msgData))
+	logger.Debug().Msgf("received message from endpoint: %s", string(msgData))
 
 	// Extract domain for message metrics
 	domain, domainErr := shannonmetrics.ExtractDomainOrHost(wrc.selectedEndpoint.PublicURL())
@@ -622,84 +629,82 @@ func (wrc *websocketRequestContext) ProcessProtocolEndpointWebsocketMessage(
 		wrc.recordWebsocketSignal(reputation.NewSuccessSignal(time.Since(startTime)))
 		// Record message metric for endpoint→client direction
 		metrics.RecordWebsocketMessage(domain, serviceID, metrics.WSDirectionEndpointToClient, metrics.SignalOK)
-		return msgData, getWebsocketMessageSuccessObservation(wrc.logger, wrc.serviceID, wrc.selectedEndpoint, msgData), nil
+		return msgData, getWebsocketMessageSuccessObservation(logger, wrc.serviceID, wrc.selectedEndpoint, msgData), nil
 	}
 
 	// If the selected endpoint is a protocol endpoint, we need to validate the message.
 	validatedRelayResponse, err := wrc.validateEndpointWebsocketMessage(msgData)
 	if err != nil {
-		wrc.logger.Error().Err(err).Msg("❌ failed to validate relay response")
+		logger.Error().Err(err).Msg("❌ failed to validate relay response")
 		// Record error signal for message validation failure
 		wrc.recordWebsocketSignal(reputation.NewMajorErrorSignal("ws_message_validation_failed", time.Since(startTime)))
 		// Record message metric for endpoint→client direction with error
 		metrics.RecordWebsocketMessage(domain, serviceID, metrics.WSDirectionEndpointToClient, metrics.SignalMajorError)
-		return nil, getWebsocketMessageErrorObservation(wrc.logger, wrc.serviceID, wrc.selectedEndpoint, msgData, err), err
+		return nil, getWebsocketMessageErrorObservation(logger, wrc.serviceID, wrc.selectedEndpoint, msgData, err), err
 	}
 
 	// Record success signal for validated message
 	wrc.recordWebsocketSignal(reputation.NewSuccessSignal(time.Since(startTime)))
 	// Record message metric for endpoint→client direction
 	metrics.RecordWebsocketMessage(domain, serviceID, metrics.WSDirectionEndpointToClient, metrics.SignalOK)
-	return validatedRelayResponse, getWebsocketMessageSuccessObservation(wrc.logger, wrc.serviceID, wrc.selectedEndpoint, msgData), nil
+	return validatedRelayResponse, getWebsocketMessageSuccessObservation(logger, wrc.serviceID, wrc.selectedEndpoint, msgData), nil
 }
 
 // validateEndpointWebsocketMessage validates a message from the endpoint using the Shannon FullNode.
 // TODO_IMPROVE(@adshmh): Compare this to 'validateAndProcessResponse' and align the two implementations
 // w.r.t design, error handling, etc...
 func (wrc *websocketRequestContext) validateEndpointWebsocketMessage(msgData []byte) ([]byte, error) {
-	wrc.hydratedLogger("validateEndpointWebsocketMessage")
+	logger := wrc.methodLogger("validateEndpointWebsocketMessage")
 
 	// Validate the relay response using the Shannon FullNode
 	relayResponse, err := wrc.fullNode.ValidateRelayResponse(sdk.SupplierAddress(wrc.selectedEndpoint.Supplier()), msgData)
 	if err != nil {
-		wrc.logger.Error().Err(err).Msg("❌ failed to validate relay response in websocket message")
+		logger.Error().Err(err).Msg("❌ failed to validate relay response in websocket message")
 		return nil, fmt.Errorf("%w: %s", errRelayResponseInWebsocketMessageValidationFailed, err.Error())
 	}
-	wrc.logger.Debug().Msgf("received message from protocol endpoint: %s", string(relayResponse.Payload))
+	logger.Debug().Msgf("received message from protocol endpoint: %s", string(relayResponse.Payload))
 
 	return relayResponse.Payload, nil
 }
 
 // ---------- Logger Helpers ----------
 
-// hydratedLogger:
-// - Enhances the base logger with information from the request context.
-// - Includes:
-//   - Method name
-//   - Service ID
-//   - Selected endpoint supplier
-//   - Selected endpoint URL
-func (wrc *websocketRequestContext) hydratedLogger(methodName string) {
-	logger := wrc.logger.With(
+// buildWebsocketConnectionLogger constructs the per-connection logger ONCE,
+// at request-context setup. The supplier, URL, and session app are immutable
+// for the connection's lifetime so adding them here avoids re-allocating the
+// same context on every message.
+//
+// Background: this used to be done per-message inside hydratedLogger, which
+// also reassigned wrc.logger and so accumulated fields over the connection
+// lifetime — pprof showed it as ~36% of all heap allocations on a busy pod.
+func buildWebsocketConnectionLogger(
+	base polylog.Logger,
+	serviceID protocol.ServiceID,
+	selectedEndpoint endpoint,
+) polylog.Logger {
+	logger := base.With(
 		"request_type", "websocket",
-		"method", methodName,
-		"service_id", wrc.serviceID,
+		"service_id", serviceID,
 	)
-
-	defer func() {
-		wrc.logger = logger
-	}()
-
-	// No endpoint specified on request context.
-	// - This should never happen.
-	selectedEndpoint := wrc.selectedEndpoint
 	if selectedEndpoint == nil {
-		return
+		return logger
 	}
-
 	logger = logger.With(
 		"selected_endpoint_supplier", selectedEndpoint.Supplier(),
 		"selected_endpoint_url", selectedEndpoint.PublicURL(),
+		"endpoint_addr", selectedEndpoint.Addr(),
 	)
-
-	sessionHeader := selectedEndpoint.Session().Header
-	if sessionHeader == nil {
-		return
+	if header := selectedEndpoint.Session().GetHeader(); header != nil {
+		logger = logger.With("selected_endpoint_app", header.ApplicationAddress)
 	}
+	return logger
+}
 
-	logger = logger.With(
-		"selected_endpoint_app", sessionHeader.ApplicationAddress,
-	)
+// methodLogger returns a per-method logger derived from the connection logger.
+// Single allocation per call; does NOT mutate wrc.logger (so the connection
+// logger never grows unbounded across messages).
+func (wrc *websocketRequestContext) methodLogger(methodName string) polylog.Logger {
+	return wrc.logger.With("method", methodName)
 }
 
 // ---------- Reputation Signal Recording ----------

--- a/protocol/shannon/websocket_logger_bench_test.go
+++ b/protocol/shannon/websocket_logger_bench_test.go
@@ -1,0 +1,164 @@
+package shannon
+
+import (
+	"io"
+	"testing"
+
+	"github.com/pokt-network/poktroll/pkg/polylog"
+	"github.com/pokt-network/poktroll/pkg/polylog/polyzero"
+
+	"github.com/pokt-network/path/protocol"
+)
+
+// BenchmarkWebsocketLogger_PerMessage compares the legacy per-message
+// `hydratedLogger` (which mutated wrc.logger and re-added 5–6 fields per call,
+// growing the logger context over the lifetime of a connection) against the
+// current `methodLogger` pattern (one .With("method", ...) call over a
+// connection-level logger that's built once at setup).
+//
+// The logger is set to InfoLevel and discards output, so .Debug() short-circuits
+// — this isolates the cost of the logger-construction pattern itself, which
+// is what the production hot path (websocket message handling) is doing.
+//
+// Run with:
+//
+//	go test -run='^$' -bench=BenchmarkWebsocketLogger -benchmem ./protocol/shannon/
+func BenchmarkWebsocketLogger_PerMessage(b *testing.B) {
+	base := newSilentLogger()
+	ep := &mockEndpoint{addr: "supplier1-https://relay.example.com:443/json-rpc"}
+	const serviceID = protocol.ServiceID("eth")
+
+	b.Run("legacy_hydratedLogger_mutating", func(b *testing.B) {
+		wrc := &websocketRequestContext{
+			logger: base.With(
+				"method", "BuildWebsocketRequestContextForEndpoint",
+				"service_id", serviceID,
+				"endpoint_addr", ep.Addr(),
+			),
+			serviceID:        serviceID,
+			selectedEndpoint: ep,
+		}
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			legacyHydratedLogger(wrc, "ProcessEndpointWebsocketMessage")
+			wrc.logger.Debug().Msg("received message from endpoint")
+		}
+	})
+
+	b.Run("fixed_methodLogger", func(b *testing.B) {
+		wrc := &websocketRequestContext{
+			logger:           buildWebsocketConnectionLogger(base, serviceID, ep),
+			serviceID:        serviceID,
+			selectedEndpoint: ep,
+		}
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			logger := wrc.methodLogger("ProcessEndpointWebsocketMessage")
+			logger.Debug().Msg("received message from endpoint")
+		}
+	})
+}
+
+// BenchmarkWebsocketLogger_LongLivedConnection demonstrates the unbounded
+// logger-context growth in the legacy pattern: by re-adding fields and
+// reassigning wrc.logger every message, the underlying zerolog context buffer
+// grows in size with each call. After many messages on the same connection,
+// every subsequent .With() copies a much larger buffer.
+//
+// In the fixed pattern, the connection logger is hydrated once and never
+// mutated, so per-message cost is constant regardless of connection age.
+func BenchmarkWebsocketLogger_LongLivedConnection(b *testing.B) {
+	base := newSilentLogger()
+	ep := &mockEndpoint{addr: "supplier1-https://relay.example.com:443/json-rpc"}
+	const serviceID = protocol.ServiceID("eth")
+
+	// "Aged" = simulate 10k messages already processed on this connection
+	// before measurement begins. The legacy logger should be much fatter at
+	// this point; the fixed logger should be unchanged.
+	const ageMessages = 10_000
+
+	b.Run("legacy_after_10k_messages", func(b *testing.B) {
+		wrc := &websocketRequestContext{
+			logger: base.With(
+				"method", "BuildWebsocketRequestContextForEndpoint",
+				"service_id", serviceID,
+				"endpoint_addr", ep.Addr(),
+			),
+			serviceID:        serviceID,
+			selectedEndpoint: ep,
+		}
+		for i := 0; i < ageMessages; i++ {
+			legacyHydratedLogger(wrc, "ProcessEndpointWebsocketMessage")
+		}
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			legacyHydratedLogger(wrc, "ProcessEndpointWebsocketMessage")
+			wrc.logger.Debug().Msg("received message from endpoint")
+		}
+	})
+
+	b.Run("fixed_after_10k_messages", func(b *testing.B) {
+		wrc := &websocketRequestContext{
+			logger:           buildWebsocketConnectionLogger(base, serviceID, ep),
+			serviceID:        serviceID,
+			selectedEndpoint: ep,
+		}
+		for i := 0; i < ageMessages; i++ {
+			logger := wrc.methodLogger("ProcessEndpointWebsocketMessage")
+			_ = logger
+		}
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			logger := wrc.methodLogger("ProcessEndpointWebsocketMessage")
+			logger.Debug().Msg("received message from endpoint")
+		}
+	})
+}
+
+// newSilentLogger returns a logger that discards output and only emits at
+// InfoLevel or above — so .Debug() in the benchmark loops short-circuits and
+// we measure the logger-construction cost, not output formatting.
+func newSilentLogger() polylog.Logger {
+	return polyzero.NewLogger(
+		polyzero.WithLevel(polyzero.InfoLevel),
+		polyzero.WithOutput(io.Discard),
+	)
+}
+
+// legacyHydratedLogger is a verbatim copy of the pre-fix `hydratedLogger`
+// implementation — kept here only so the benchmark can compare the old
+// behavior against the new one. Do NOT call from production code.
+func legacyHydratedLogger(wrc *websocketRequestContext, methodName string) {
+	logger := wrc.logger.With(
+		"request_type", "websocket",
+		"method", methodName,
+		"service_id", wrc.serviceID,
+	)
+
+	defer func() {
+		wrc.logger = logger
+	}()
+
+	selectedEndpoint := wrc.selectedEndpoint
+	if selectedEndpoint == nil {
+		return
+	}
+
+	logger = logger.With(
+		"selected_endpoint_supplier", selectedEndpoint.Supplier(),
+		"selected_endpoint_url", selectedEndpoint.PublicURL(),
+	)
+
+	sessionHeader := selectedEndpoint.Session().Header
+	if sessionHeader == nil {
+		return
+	}
+
+	logger = logger.With(
+		"selected_endpoint_app", sessionHeader.ApplicationAddress,
+	)
+}

--- a/reputation/service.go
+++ b/reputation/service.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/pokt-network/poktroll/pkg/polylog"
-	sharedtypes "github.com/pokt-network/poktroll/x/shared/types"
 
 	"github.com/pokt-network/path/metrics"
 	"github.com/pokt-network/path/protocol"
@@ -35,9 +34,11 @@ type service struct {
 	serviceLatencyProfiles   map[string]LatencyConfig
 	serviceLatencyProfilesMu sync.RWMutex
 
-	// Local cache for fast reads
+	// Local cache for fast reads. Keyed by the EndpointKey struct directly so
+	// every read/write avoids allocating an EndpointKey.String() per call —
+	// pprof showed key.String() at ~100 GB cumulative on a busy gateway pod.
 	mu    sync.RWMutex
-	cache map[string]Score
+	cache map[EndpointKey]Score
 
 	// Async write handling
 	writeCh   chan writeRequest
@@ -74,7 +75,7 @@ func NewService(config Config, store Storage) ReputationService {
 		serviceKeyBuilders:     serviceKeyBuilders,
 		serviceConfigs:         make(map[string]ServiceConfig),
 		serviceLatencyProfiles: make(map[string]LatencyConfig),
-		cache:                  make(map[string]Score),
+		cache:                  make(map[EndpointKey]Score),
 		writeCh:                make(chan writeRequest, config.SyncConfig.WriteBufferSize),
 		stopCh:                 make(chan struct{}),
 		stoppedCh:              make(chan struct{}),
@@ -93,7 +94,7 @@ func (s *service) RecordSignal(ctx context.Context, key EndpointKey, signal Sign
 	impact := s.calculateImpact(key.ServiceID, signal)
 
 	s.mu.Lock()
-	score, exists := s.cache[key.String()]
+	score, exists := s.cache[key]
 	if !exists {
 		// Use per-service InitialScore if configured, otherwise global default
 		initialScore := s.GetInitialScoreForService(key.ServiceID)
@@ -157,7 +158,7 @@ func (s *service) RecordSignal(ctx context.Context, key EndpointKey, signal Sign
 		score.LatencyMetrics.UpdateLatency(signal.Latency)
 	}
 
-	s.cache[key.String()] = score
+	s.cache[key] = score
 	s.mu.Unlock()
 
 	// Queue async write (non-blocking if buffer is full)
@@ -204,7 +205,7 @@ func (s *service) GetScore(ctx context.Context, key EndpointKey) (Score, error) 
 	}
 
 	s.mu.RLock()
-	score, exists := s.cache[key.String()]
+	score, exists := s.cache[key]
 	s.mu.RUnlock()
 
 	if !exists {
@@ -262,7 +263,7 @@ func (s *service) recoverScore(ctx context.Context, key EndpointKey) Score {
 	}
 
 	s.mu.Lock()
-	s.cache[key.String()] = score
+	s.cache[key] = score
 	s.mu.Unlock()
 
 	// Queue async write
@@ -292,7 +293,7 @@ func (s *service) GetScores(ctx context.Context, keys []EndpointKey) (map[Endpoi
 
 	result := make(map[EndpointKey]Score, len(keys))
 	for _, key := range keys {
-		if score, exists := s.cache[key.String()]; exists {
+		if score, exists := s.cache[key]; exists {
 			result[key] = score
 		}
 	}
@@ -319,7 +320,7 @@ func (s *service) RankEndpointsByScore(ctx context.Context, keys []EndpointKey) 
 
 	s.mu.RLock()
 	for i, key := range keys {
-		if cachedScore, exists := s.cache[key.String()]; exists {
+		if cachedScore, exists := s.cache[key]; exists {
 			scored[i] = scoredEndpoint{key: key, score: cachedScore.Value}
 		} else {
 			// Endpoints not in cache get initial score (benefit of the doubt)
@@ -365,7 +366,7 @@ func (s *service) FilterByScore(ctx context.Context, keys []EndpointKey, minThre
 	}
 	keyScores := make([]keyScore, len(keys))
 	for i, key := range keys {
-		score, exists := s.cache[key.String()]
+		score, exists := s.cache[key]
 		keyScores[i] = keyScore{
 			key:          key,
 			score:        score,
@@ -414,7 +415,7 @@ func (s *service) ResetScore(ctx context.Context, key EndpointKey) error {
 	}
 
 	s.mu.Lock()
-	s.cache[key.String()] = score
+	s.cache[key] = score
 	s.mu.Unlock()
 
 	// Queue async write
@@ -735,7 +736,7 @@ func (s *service) refreshFromStorage(ctx context.Context) error {
 
 	s.mu.Lock()
 	for key, score := range scores {
-		s.cache[key.String()] = score
+		s.cache[key] = score
 	}
 	s.mu.Unlock()
 
@@ -746,11 +747,9 @@ func (s *service) refreshFromStorage(ctx context.Context) error {
 // This is called by health checks when an endpoint passes archival validation.
 // The status is shared across all replicas via Redis storage.
 func (s *service) SetArchivalStatus(ctx context.Context, key EndpointKey, isArchival bool, archivalTTL time.Duration) error {
-	cacheKey := key.String()
-
 	// Get existing score or create new one
 	s.mu.Lock()
-	score, exists := s.cache[cacheKey]
+	score, exists := s.cache[key]
 	if !exists {
 		// Create a new score with initial values
 		score = Score{
@@ -769,7 +768,7 @@ func (s *service) SetArchivalStatus(ctx context.Context, key EndpointKey, isArch
 	score.LastUpdated = time.Now()
 
 	// Update cache
-	s.cache[cacheKey] = score
+	s.cache[key] = score
 	s.mu.Unlock()
 
 	// Queue async write to storage
@@ -780,7 +779,7 @@ func (s *service) SetArchivalStatus(ctx context.Context, key EndpointKey, isArch
 		if err := s.storage.Set(ctx, key, score); err != nil {
 			if s.logger != nil {
 				s.logger.Error().Err(err).
-					Str("key", cacheKey).
+					Str("key", key.String()).
 					Bool("is_archival", isArchival).
 					Msg("Failed to persist archival status to storage")
 			}
@@ -790,7 +789,7 @@ func (s *service) SetArchivalStatus(ctx context.Context, key EndpointKey, isArch
 
 	if s.logger != nil {
 		s.logger.Debug().
-			Str("key", cacheKey).
+			Str("key", key.String()).
 			Bool("is_archival", isArchival).
 			Time("expires_at", score.ArchivalExpiresAt).
 			Msg("📜 Set archival status in reputation service")
@@ -806,11 +805,9 @@ func (s *service) SetArchivalStatus(ctx context.Context, key EndpointKey, isArch
 // the local cache, ensuring non-leader replicas can access archival status
 // set by health checks running on the leader replica.
 func (s *service) IsArchivalCapable(ctx context.Context, key EndpointKey) bool {
-	cacheKey := key.String()
-
 	// Check local cache first
 	s.mu.RLock()
-	score, exists := s.cache[cacheKey]
+	score, exists := s.cache[key]
 	s.mu.RUnlock()
 
 	if exists {
@@ -824,7 +821,7 @@ func (s *service) IsArchivalCapable(ctx context.Context, key EndpointKey) bool {
 		if err == nil {
 			// Update local cache with fetched score
 			s.mu.Lock()
-			s.cache[cacheKey] = storedScore
+			s.cache[key] = storedScore
 			s.mu.Unlock()
 
 			return storedScore.IsArchivalCapable()
@@ -833,7 +830,7 @@ func (s *service) IsArchivalCapable(ctx context.Context, key EndpointKey) bool {
 		if s.logger != nil {
 			s.logger.Debug().
 				Err(err).
-				Str("key", cacheKey).
+				Str("key", key.String()).
 				Msg("Failed to fetch archival status from storage")
 		}
 	}
@@ -916,41 +913,18 @@ func (s *service) RemoveEndpointBlockHeights(ctx context.Context, serviceID prot
 // This enables bootstrapping the EVM archival cache at startup when the
 // endpoint store is empty but the reputation cache has been populated from Redis.
 func (s *service) GetArchivalEndpoints(ctx context.Context, serviceID protocol.ServiceID) []EndpointKey {
-	prefix := string(serviceID) + ":"
-
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
 	var result []EndpointKey
-	for cacheKey, score := range s.cache {
-		// Quick prefix check to filter by service
-		if !strings.HasPrefix(cacheKey, prefix) {
+	for key, score := range s.cache {
+		if key.ServiceID != serviceID {
 			continue
 		}
-
 		if !score.IsArchivalCapable() {
 			continue
 		}
-
-		// Parse "serviceID:endpointAddr:rpcType" back to EndpointKey.
-		// EndpointAddr may contain colons (e.g., URLs with ports),
-		// so split and take: first part = serviceID, last part = rpcType, middle = endpointAddr.
-		parts := strings.Split(cacheKey, ":")
-		if len(parts) < 3 {
-			continue
-		}
-
-		rpcTypeStr := parts[len(parts)-1]
-		endpointAddr := strings.Join(parts[1:len(parts)-1], ":")
-
-		rpcTypeUpper := strings.ToUpper(rpcTypeStr)
-		rpcType := sharedtypes.RPCType(sharedtypes.RPCType_value[rpcTypeUpper])
-
-		result = append(result, NewEndpointKey(
-			serviceID,
-			protocol.EndpointAddr(endpointAddr),
-			rpcType,
-		))
+		result = append(result, key)
 	}
 
 	return result

--- a/reputation/service_test.go
+++ b/reputation/service_test.go
@@ -1113,7 +1113,7 @@ func TestService_GetArchivalEndpoints_ExpiredEntries(t *testing.T) {
 
 	// Manually set an expired archival entry in the cache
 	svc.mu.Lock()
-	svc.cache[key.String()] = Score{
+	svc.cache[key] = Score{
 		Value:             80,
 		IsArchival:        true,
 		ArchivalExpiresAt: time.Now().Add(-1 * time.Hour), // expired


### PR DESCRIPTION
## Summary

CPU profile from a mainnet gateway pod under ~9.2K rps showed ~30% of CPU spent in `runtime.gcBgMarkWorker` / `scanobject`, driven by ~669 MB/s of heap allocations. This branch addresses the three highest-leverage allocators identified in the profile.

- **Stop per-message logger growth on the WebSocket path.** `websocketRequestContext.hydratedLogger` was reassigning `wrc.logger` on every message and re-adding ~5 fields, so the logger's underlying zerolog buffer grew unboundedly over the connection's lifetime. Profile: ~36% of all heap allocations (~1.9 TB cumulative on a busy pod). Replaced with a one-shot connection-level hydration plus a non-mutating `methodLogger`.
- **Key the reputation cache and session-exhaustion tracker by structs instead of derived strings.** `reputation.service.cache` was `map[string]Score` indexed by `EndpointKey.String()` (~100 GB cumulative). `sessionExhaustionTracker.entries` was `map[string]time.Time` indexed by `serviceID + "|" + sessionID + "|" + supplier` (~90 GB cumulative). Both use struct keys directly now.
- **De-duplicate `BuildKey` calls in `filterByReputation` / `getEndpointScores`.** Both functions iterated the endpoints map twice and called `keyBuilder.BuildKey(...)` once per endpoint per pass. For per-domain granularity this allocates inside `URL.Parse` + hostname extraction. Cached the (addr, ep, key) triples in a single pass; also dropped a redundant `.With(\"method\", ...)` in the per-session loop in `getSessionsUniqueEndpoints` and hoisted the per-iteration `getMinThresholdForService` call out of the filter loop.

### Microbenchmarks (Apple M1, polyzero info-level discard logger)

WebSocket per-message logger:

```
legacy_hydratedLogger_mutating-8       312,775 ns/op  3,554,957 B/op  22 allocs/op
fixed_methodLogger-8                       205.8 ns/op       680 B/op   4 allocs/op

legacy_after_10k_messages-8            746,165 ns/op  8,347,279 B/op  23 allocs/op
fixed_after_10k_messages-8                 202.0 ns/op       680 B/op   4 allocs/op
```

The fixed pattern's per-message cost is constant; the legacy pattern grew linearly because each `.With` cloned the accumulating zerolog context buffer (after 10k messages, every additional `.With` was copying ~8 MB).

`filterByReputation` (per-domain granularity, the case where `BuildKey` allocates):

```
              endpoints=8        endpoints=32
legacy   :    ~48,000 ns/op       ~193,000 ns/op
                5,056 B/68 allocs   24,496 B/265 allocs
fixed    :    ~23,000 ns/op       ~123,000 ns/op
                3,520 B/37 allocs   18,480 B/138 allocs
                (-46% allocs)       (-48% allocs)
```

For per-endpoint granularity (default) wall-clock is comparable; the cached-triple slice is +1 small allocation per call (~1-3 KB) but is offset by the saved second map iteration.

### Expected production impact

The CPU profile on the affected pod attributed:
- ~36% of heap allocations to the WS `hydratedLogger` (commit 1)
- ~4% combined to `EndpointKey.String` + `sessionExhaustionKey` string concat (commit 2)
- A smaller share to duplicate `BuildKey` calls under per-domain granularity (commit 3)

GC CPU on that pod was ~30% of total. With ~40% of the alloc rate gone, expect roughly 10-15% raw CPU back per pod, plus more consistent hedge timing (the hedge rate was suppressed under load because GC pauses were starving the hedge timer).

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test -short ./...` passes (all 30 packages)
- [x] `go test -count=1 ./reputation/storage/...` passes (testcontainer-backed Redis tests)
- [x] Microbenchmarks added: `BenchmarkWebsocketLogger_PerMessage`, `BenchmarkWebsocketLogger_LongLivedConnection`, `BenchmarkFilterByReputation` (legacy vs fixed under per-endpoint and per-domain)
- [ ] Deploy to canary, watch CPU / RPS / 5xx-rate / hedge-rate before promoting
- [ ] Compare follow-up CPU profile against the 2026-05-09 baseline; expect `gcBgMarkWorker` and `runtime.scanobject` to shrink substantially and `hydratedLogger` to disappear from top allocators

🤖 Generated with [Claude Code](https://claude.com/claude-code)