### PR TITLE
Per-operator concentration cap + reputation hardening (URL granularity, rate cooldown, HC dedup, WS rebind)

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -330,6 +330,11 @@ func main() {
 		QoSLevelReporters:     qosLevelReporters,
 	}
 
+	// Admin handler to reset per-service chain state (perceived block height) via
+	// POST /admin/chain-state/clear/{serviceId}. Recovers a stuck/too-high perceived
+	// height that the max-only consensus and external floor cannot self-correct.
+	chainStateAdmin := gateway.NewChainStateAdmin(qosInstances)
+
 	// Initialize the API router to serve requests to the PATH API.
 	apiRouter := router.NewRouter(
 		logger,
@@ -338,6 +343,7 @@ func main() {
 		healthChecker,
 		config.GetRouterConfig(),
 		gtw.DomainCircuitBreaker,
+		chainStateAdmin,
 	)
 
 	// -------------------- Start PATH API Router --------------------

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -344,6 +344,7 @@ func main() {
 		config.GetRouterConfig(),
 		gtw.DomainCircuitBreaker,
 		chainStateAdmin,
+		unifiedServicesConfig,
 	)
 
 	// -------------------- Start PATH API Router --------------------

--- a/cmd/qos.go
+++ b/cmd/qos.go
@@ -2,8 +2,6 @@ package main
 
 import (
 	"fmt"
-	"os"
-	"strconv"
 	"strings"
 
 	"github.com/pokt-network/poktroll/pkg/polylog"
@@ -17,26 +15,6 @@ import (
 	"github.com/pokt-network/path/qos/noop"
 	"github.com/pokt-network/path/qos/solana"
 )
-
-// evmMaxOperatorShareEnvVar gates the per-operator (eTLD+1) concentration cap for EVM
-// endpoint selection. A value in (0, 1) enables the cap at that share; unset, <= 0, or
-// >= 1 disables it (flat random pick). Env-gated so it can be A/B tested on canary
-// without a redeploy, matching the WebSocket-rebind rollout pattern.
-const evmMaxOperatorShareEnvVar = "PATH_EVM_MAX_OPERATOR_SHARE"
-
-// parseMaxOperatorShareEnv reads and validates evmMaxOperatorShareEnvVar. Returns 0
-// (disabled) for an unset, unparseable, or out-of-range value.
-func parseMaxOperatorShareEnv() float64 {
-	raw := os.Getenv(evmMaxOperatorShareEnvVar)
-	if raw == "" {
-		return 0
-	}
-	v, err := strconv.ParseFloat(raw, 64)
-	if err != nil || v <= 0 || v >= 1 {
-		return 0
-	}
-	return v
-}
 
 // getServiceQoSInstances returns all QoS instances to be used by the Gateway and the EndpointHydrator.
 // Service types are determined from the unified YAML configuration (gateway_config.services[]).
@@ -62,9 +40,6 @@ func getServiceQoSInstances(
 	// Get configured service IDs from the protocol instance.
 	gatewayServiceIDs := protocolInstance.ConfiguredServiceIDs()
 	logGatewayServiceIDs(hydratedLogger, gatewayServiceIDs)
-
-	// Per-operator concentration cap for EVM endpoint selection (canary A/B off-switch).
-	maxOperatorShare := parseMaxOperatorShareEnv()
 
 	// Remove any service IDs that are manually disabled by the user.
 	for _, disabledQoSServiceIDForGateway := range gatewayConfig.HydratorConfig.QoSDisabledServiceIDs {
@@ -92,15 +67,21 @@ func getServiceQoSInstances(
 		switch serviceType {
 		case gateway.ServiceTypeEVM:
 			evmQoS := evm.NewSimpleQoSInstanceWithSyncAllowance(qosLogger, serviceID, syncAllowance)
-			evmQoS.SetMaxOperatorShare(maxOperatorShare)
 			qosServices[serviceID] = evmQoS
 			if syncAllowance > 0 {
 				svcLogger.Info().Uint64("sync_allowance", syncAllowance).Msg("✅ EVM QoS: sync allowance ENABLED")
 			} else {
 				svcLogger.Info().Msg("⚠️ EVM QoS: sync allowance DISABLED (set sync_allowance > 0 to enable)")
 			}
-			if maxOperatorShare > 0 {
-				svcLogger.Info().Float64("max_operator_share", maxOperatorShare).Msg("✅ EVM QoS: per-operator concentration cap ENABLED")
+			// Per-operator concentration cap: bounds any single operator's share of endpoint
+			// selection (config-driven, shipped ON by default). Covers both HTTP and WebSocket
+			// initial selection via requestContext.Select.
+			if unifiedConfig != nil {
+				maxOperatorShare := unifiedConfig.GetMaxOperatorShareForService(serviceID)
+				evmQoS.SetMaxOperatorShare(maxOperatorShare)
+				if maxOperatorShare > 0 && maxOperatorShare < 1 {
+					svcLogger.Info().Float64("max_operator_share", maxOperatorShare).Msg("✅ EVM QoS: per-operator concentration cap ENABLED")
+				}
 			}
 
 		case gateway.ServiceTypeCosmos:

--- a/cmd/qos.go
+++ b/cmd/qos.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"fmt"
+	"os"
+	"strconv"
 	"strings"
 
 	"github.com/pokt-network/poktroll/pkg/polylog"
@@ -15,6 +17,26 @@ import (
 	"github.com/pokt-network/path/qos/noop"
 	"github.com/pokt-network/path/qos/solana"
 )
+
+// evmMaxOperatorShareEnvVar gates the per-operator (eTLD+1) concentration cap for EVM
+// endpoint selection. A value in (0, 1) enables the cap at that share; unset, <= 0, or
+// >= 1 disables it (flat random pick). Env-gated so it can be A/B tested on canary
+// without a redeploy, matching the WebSocket-rebind rollout pattern.
+const evmMaxOperatorShareEnvVar = "PATH_EVM_MAX_OPERATOR_SHARE"
+
+// parseMaxOperatorShareEnv reads and validates evmMaxOperatorShareEnvVar. Returns 0
+// (disabled) for an unset, unparseable, or out-of-range value.
+func parseMaxOperatorShareEnv() float64 {
+	raw := os.Getenv(evmMaxOperatorShareEnvVar)
+	if raw == "" {
+		return 0
+	}
+	v, err := strconv.ParseFloat(raw, 64)
+	if err != nil || v <= 0 || v >= 1 {
+		return 0
+	}
+	return v
+}
 
 // getServiceQoSInstances returns all QoS instances to be used by the Gateway and the EndpointHydrator.
 // Service types are determined from the unified YAML configuration (gateway_config.services[]).
@@ -40,6 +62,9 @@ func getServiceQoSInstances(
 	// Get configured service IDs from the protocol instance.
 	gatewayServiceIDs := protocolInstance.ConfiguredServiceIDs()
 	logGatewayServiceIDs(hydratedLogger, gatewayServiceIDs)
+
+	// Per-operator concentration cap for EVM endpoint selection (canary A/B off-switch).
+	maxOperatorShare := parseMaxOperatorShareEnv()
 
 	// Remove any service IDs that are manually disabled by the user.
 	for _, disabledQoSServiceIDForGateway := range gatewayConfig.HydratorConfig.QoSDisabledServiceIDs {
@@ -67,11 +92,15 @@ func getServiceQoSInstances(
 		switch serviceType {
 		case gateway.ServiceTypeEVM:
 			evmQoS := evm.NewSimpleQoSInstanceWithSyncAllowance(qosLogger, serviceID, syncAllowance)
+			evmQoS.SetMaxOperatorShare(maxOperatorShare)
 			qosServices[serviceID] = evmQoS
 			if syncAllowance > 0 {
 				svcLogger.Info().Uint64("sync_allowance", syncAllowance).Msg("✅ EVM QoS: sync allowance ENABLED")
 			} else {
 				svcLogger.Info().Msg("⚠️ EVM QoS: sync allowance DISABLED (set sync_allowance > 0 to enable)")
+			}
+			if maxOperatorShare > 0 {
+				svcLogger.Info().Float64("max_operator_share", maxOperatorShare).Msg("✅ EVM QoS: per-operator concentration cap ENABLED")
 			}
 
 		case gateway.ServiceTypeCosmos:

--- a/cmd/qos.go
+++ b/cmd/qos.go
@@ -73,16 +73,6 @@ func getServiceQoSInstances(
 			} else {
 				svcLogger.Info().Msg("⚠️ EVM QoS: sync allowance DISABLED (set sync_allowance > 0 to enable)")
 			}
-			// Per-operator concentration cap: bounds any single operator's share of endpoint
-			// selection (config-driven, shipped ON by default). Covers both HTTP and WebSocket
-			// initial selection via requestContext.Select.
-			if unifiedConfig != nil {
-				maxOperatorShare := unifiedConfig.GetMaxOperatorShareForService(serviceID)
-				evmQoS.SetMaxOperatorShare(maxOperatorShare)
-				if maxOperatorShare > 0 && maxOperatorShare < 1 {
-					svcLogger.Info().Float64("max_operator_share", maxOperatorShare).Msg("✅ EVM QoS: per-operator concentration cap ENABLED")
-				}
-			}
 
 		case gateway.ServiceTypeCosmos:
 			// Convert string RPC types to sharedtypes.RPCType
@@ -118,6 +108,21 @@ func getServiceQoSInstances(
 			svcLogger.Warn().Msg("Unknown service type, using noop QoS")
 			noopQoS := noop.NewNoOpQoSService(qosLogger, serviceID)
 			qosServices[serviceID] = noopQoS
+		}
+
+		// Per-operator concentration cap: bounds any single operator's (eTLD+1) share of
+		// endpoint selection (config-driven, shipped ON by default). Applied uniformly to
+		// every QoS type that supports it — EVM/Cosmos/Solana/NoOp — covering both HTTP and
+		// WebSocket initial selection via requestContext.Select. Disabled (>= 1 or <= 0)
+		// leaves selection as a flat random pick.
+		if unifiedConfig != nil {
+			if setter, ok := qosServices[serviceID].(interface{ SetMaxOperatorShare(float64) }); ok {
+				maxOperatorShare := unifiedConfig.GetMaxOperatorShareForService(serviceID)
+				setter.SetMaxOperatorShare(maxOperatorShare)
+				if maxOperatorShare > 0 && maxOperatorShare < 1 {
+					svcLogger.Info().Float64("max_operator_share", maxOperatorShare).Msg("✅ QoS: per-operator concentration cap ENABLED")
+				}
+			}
 		}
 	}
 

--- a/cmd/qos.go
+++ b/cmd/qos.go
@@ -122,6 +122,10 @@ func getServiceQoSInstances(
 				if maxOperatorShare > 0 && maxOperatorShare < 1 {
 					svcLogger.Info().Float64("max_operator_share", maxOperatorShare).Msg("✅ QoS: per-operator concentration cap ENABLED")
 				}
+			} else {
+				// Every current QoS type implements SetMaxOperatorShare; a new type that
+				// forgets it would silently run uncapped despite the shipped-on default.
+				svcLogger.Warn().Msg("⚠️ QoS type does not support the per-operator concentration cap; selection runs uncapped")
 			}
 		}
 	}

--- a/config/config.schema.yaml
+++ b/config/config.schema.yaml
@@ -627,7 +627,7 @@ properties:
             health_checks:
               $ref: "#/definitions/service_health_check_override"
             max_operator_share:
-              description: "Per-operator (registrable domain / eTLD+1) concentration cap for endpoint selection. Caps the fraction of this service's selections any single operator may receive; excess is spread across the other valid operators. Bounds the blast radius of one operator failing when it holds most of the valid pool. Range (0, 1); a value <= 0 or >= 1 disables the cap. If unset, the global default (0.75) applies."
+              description: "Per-operator (registrable domain / eTLD+1) concentration cap for endpoint selection. Caps the fraction of this service's selections any single operator may receive; excess is spread across the other valid operators. Bounds the blast radius of one operator failing when it holds most of the valid pool. Range (0, 1); a value <= 0 or >= 1 disables the cap. If unset, the global default (0.65) applies."
               type: number
 
   # Logger Configuration (optional)

--- a/config/config.schema.yaml
+++ b/config/config.schema.yaml
@@ -626,6 +626,9 @@ properties:
                   enum: ["json_rpc", "rest", "comet_bft", "websocket", "grpc"]
             health_checks:
               $ref: "#/definitions/service_health_check_override"
+            max_operator_share:
+              description: "Per-operator (registrable domain / eTLD+1) concentration cap for endpoint selection. Caps the fraction of this service's selections any single operator may receive; excess is spread across the other valid operators. Bounds the blast radius of one operator failing when it holds most of the valid pool. Range (0, 1); a value <= 0 or >= 1 disables the cap. If unset, the global default (0.75) applies."
+              type: number
 
   # Logger Configuration (optional)
   logger_config:

--- a/config/examples/config.shannon_example.yaml
+++ b/config/examples/config.shannon_example.yaml
@@ -286,6 +286,13 @@ gateway_config:
       # Ships ON by default at 0.65 for every service — set a value here to override, or
       # 1.0 (or 0) to disable it for this service.
       # max_operator_share: 0.6
+      # WebSocket rebind strategy (optional). When true (the default), a session-rollover
+      # rebind spreads the target uniformly across operators (each provider equally likely),
+      # then picks an endpoint within it — maximizing per-provider spread. When false, the
+      # rebind uses the endpoint-count-weighted max_operator_share cap instead. Note:
+      # operator-uniform gives a single-endpoint operator the same share as a large one, so
+      # disable it per-service if that overloads a small provider.
+      # websocket_rebind_operator_uniform: true
       # External block sources for ground-truth validation (optional)
       # Multiple sources provide redundancy — the max height across all is used.
       # If all session endpoints are behind the real chain tip, these correct it.

--- a/config/examples/config.shannon_example.yaml
+++ b/config/examples/config.shannon_example.yaml
@@ -259,6 +259,8 @@ gateway_config:
   # - fallback: Fallback endpoints (no defaults - must be explicitly configured)
   # - health_checks: Per-service health check rules
   # - external_block_sources: External RPC endpoints for ground-truth block height validation
+  # - static_routes: Fixed responses served by the gateway for a given path, without
+  #   relaying to a backend (e.g. a small service metadata/identity endpoint)
 
   services:
     # -------------------------------------------------------------------------
@@ -295,6 +297,19 @@ gateway_config:
       #   - url: "https://rpc.ankr.com/eth"
       #     interval: 30s
       #     timeout: 5s
+      # Static routes (optional): serve a fixed response for a path directly from the
+      # gateway, bypassing endpoint selection and the relay. Matching is exact on `path`
+      # (evaluated after the /v1 and portal-app-id prefixes are stripped) and, when set,
+      # on the request method. A per-service route overrides a global default on the same
+      # path. `path: "/"` is rejected (it would shadow all relay traffic).
+      # static_routes:
+      #   - path: /identity
+      #     # methods: ["GET"]              # optional; empty = any method
+      #     # status_code: 200              # optional; default 200
+      #     # content_type: text/plain      # optional; default text/plain
+      #     body: "<value-served-at-this-path>"
+      #     # headers:                       # optional extra response headers
+      #     #   Cache-Control: "public, max-age=3600"
 
     - id: poly
       type: "evm"

--- a/config/examples/config.shannon_example.yaml
+++ b/config/examples/config.shannon_example.yaml
@@ -260,7 +260,7 @@ gateway_config:
   # - health_checks: Per-service health check rules
   # - external_block_sources: External RPC endpoints for ground-truth block height validation
   # - static_routes: Fixed responses served by the gateway for a given path, without
-  #   relaying to a backend (e.g. a small service metadata/identity endpoint)
+  #   relaying to a backend (e.g. a small service metadata/version endpoint)
 
   services:
     # -------------------------------------------------------------------------
@@ -310,7 +310,7 @@ gateway_config:
       # on the request method. A per-service route overrides a global default on the same
       # path. `path: "/"` is rejected (it would shadow all relay traffic).
       # static_routes:
-      #   - path: /identity
+      #   - path: /example
       #     # methods: ["GET"]              # optional; empty = any method
       #     # status_code: 200              # optional; default 200
       #     # content_type: text/plain      # optional; default text/plain

--- a/config/examples/config.shannon_example.yaml
+++ b/config/examples/config.shannon_example.yaml
@@ -347,10 +347,14 @@ gateway_config:
       latency_profile: "standard"
       timeout_config:
         relay_timeout: 15s
-      # Solana external block source — uses "getBlockHeight" method (numeric result)
+      # Solana external block source — use "getEpochInfo" and read its blockHeight field.
+      # Do NOT use "getBlockHeight": it returns a bare number that some providers mislabel
+      # with the SLOT (~5% higher than block height), which poisons the max-based perceived
+      # height and makes honest endpoints look "behind". getEpochInfo.blockHeight is explicit
+      # and unambiguous. (The external floor is also plausibility-guarded as defense in depth.)
       # external_block_sources:
-      #   - url: "https://api.mainnet-beta.solana.com"
-      #     method: "getBlockHeight"
+      #   - url: "https://solana-rpc.publicnode.com"
+      #     method: "getEpochInfo"
       #     interval: 15s
       #     timeout: 5s
 

--- a/config/examples/config.shannon_example.yaml
+++ b/config/examples/config.shannon_example.yaml
@@ -277,6 +277,13 @@ gateway_config:
       retry_config:
         max_retries: 2
         hedge_delay: 300ms
+      # Per-operator concentration cap (optional). Bounds the fraction of this service's
+      # endpoint selections that any single operator (registrable domain / eTLD+1) may
+      # receive; the excess is spread across the other valid operators. This limits the
+      # blast radius when one operator holds most of the valid pool and then degrades.
+      # Ships ON by default at 0.75 for every service — set a value here to override, or
+      # 1.0 (or 0) to disable it for this service.
+      # max_operator_share: 0.6
       # External block sources for ground-truth validation (optional)
       # Multiple sources provide redundancy — the max height across all is used.
       # If all session endpoints are behind the real chain tip, these correct it.

--- a/config/examples/config.shannon_example.yaml
+++ b/config/examples/config.shannon_example.yaml
@@ -281,7 +281,7 @@ gateway_config:
       # endpoint selections that any single operator (registrable domain / eTLD+1) may
       # receive; the excess is spread across the other valid operators. This limits the
       # blast radius when one operator holds most of the valid pool and then degrades.
-      # Ships ON by default at 0.75 for every service — set a value here to override, or
+      # Ships ON by default at 0.65 for every service — set a value here to override, or
       # 1.0 (or 0) to disable it for this service.
       # max_operator_share: 0.6
       # External block sources for ground-truth validation (optional)

--- a/gateway/chain_state_admin.go
+++ b/gateway/chain_state_admin.go
@@ -1,0 +1,50 @@
+package gateway
+
+import (
+	"context"
+
+	"github.com/pokt-network/path/protocol"
+)
+
+// perceivedBlockResetter is implemented by QoS instances that track a perceived block
+// height and can reset it (in-memory + Redis). EVM, Cosmos, Solana, and NoOp QoS
+// implement it; QoS types without a perceived height (e.g. generic JSON-RPC) do not.
+type perceivedBlockResetter interface {
+	ResetPerceivedBlockHeight(ctx context.Context) error
+}
+
+// ChainStateAdmin resets per-service chain state (perceived block height) via admin
+// endpoints. It backs POST /admin/chain-state/clear/{serviceId}.
+//
+// Perceived block height is a monotonic max floor held in per-pod memory and mirrored to
+// Redis; neither the max-based consensus nor the external floor can LOWER it, so a
+// too-high value (e.g. a slot-poisoned Solana height, or a value raised by a mislabeled
+// external source) cannot self-correct. This admin path deletes it so it rebuilds from
+// fresh endpoint observations. Like the circuit-breaker clear, it must be called on each
+// pod because the in-memory floor is per-pod.
+type ChainStateAdmin struct {
+	qosInstances map[protocol.ServiceID]QoSService
+}
+
+// NewChainStateAdmin builds a ChainStateAdmin over the given QoS instances.
+func NewChainStateAdmin(qosInstances map[protocol.ServiceID]QoSService) *ChainStateAdmin {
+	return &ChainStateAdmin{qosInstances: qosInstances}
+}
+
+// ResetChainState clears the perceived block height (in-memory + Redis) for a service.
+// Returns found=false if there is no such service or its QoS does not track a perceived
+// block height; err is non-nil only if the reset itself failed.
+func (a *ChainStateAdmin) ResetChainState(ctx context.Context, serviceID string) (found bool, err error) {
+	qos, ok := a.qosInstances[protocol.ServiceID(serviceID)]
+	if !ok {
+		return false, nil
+	}
+	resetter, ok := qos.(perceivedBlockResetter)
+	if !ok {
+		return false, nil
+	}
+	if err := resetter.ResetPerceivedBlockHeight(ctx); err != nil {
+		return true, err
+	}
+	return true, nil
+}

--- a/gateway/concentration_cap_config_test.go
+++ b/gateway/concentration_cap_config_test.go
@@ -32,7 +32,7 @@ func TestGetMaxOperatorShareForService(t *testing.T) {
 		{
 			name: "defaults set, no per-service → defaults",
 			cfg: &UnifiedServicesConfig{
-				Defaults: ServiceDefaults{MaxOperatorTrafficShare: f(0.6)},
+				Defaults: ServiceDefaults{MaxOperatorShare: f(0.6)},
 				Services: []ServiceConfig{{ID: "eth"}},
 			},
 			service: "eth",
@@ -41,8 +41,8 @@ func TestGetMaxOperatorShareForService(t *testing.T) {
 		{
 			name: "per-service overrides defaults",
 			cfg: &UnifiedServicesConfig{
-				Defaults: ServiceDefaults{MaxOperatorTrafficShare: f(0.6)},
-				Services: []ServiceConfig{{ID: "eth", MaxOperatorTrafficShare: f(0.5)}},
+				Defaults: ServiceDefaults{MaxOperatorShare: f(0.6)},
+				Services: []ServiceConfig{{ID: "eth", MaxOperatorShare: f(0.5)}},
 			},
 			service: "eth",
 			want:    0.5,
@@ -50,7 +50,7 @@ func TestGetMaxOperatorShareForService(t *testing.T) {
 		{
 			name: "per-service disable (1.0) is honored",
 			cfg: &UnifiedServicesConfig{
-				Services: []ServiceConfig{{ID: "eth", MaxOperatorTrafficShare: f(1.0)}},
+				Services: []ServiceConfig{{ID: "eth", MaxOperatorShare: f(1.0)}},
 			},
 			service: "eth",
 			want:    1.0,
@@ -58,7 +58,7 @@ func TestGetMaxOperatorShareForService(t *testing.T) {
 		{
 			name: "per-service disable (0) is honored",
 			cfg: &UnifiedServicesConfig{
-				Services: []ServiceConfig{{ID: "eth", MaxOperatorTrafficShare: f(0)}},
+				Services: []ServiceConfig{{ID: "eth", MaxOperatorShare: f(0)}},
 			},
 			service: "eth",
 			want:    0,

--- a/gateway/concentration_cap_config_test.go
+++ b/gateway/concentration_cap_config_test.go
@@ -1,0 +1,80 @@
+package gateway
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/pokt-network/path/protocol"
+)
+
+func TestGetMaxOperatorShareForService(t *testing.T) {
+	f := func(v float64) *float64 { return &v }
+
+	tests := []struct {
+		name    string
+		cfg     *UnifiedServicesConfig
+		service protocol.ServiceID
+		want    float64
+	}{
+		{
+			name:    "unset anywhere → global default",
+			cfg:     &UnifiedServicesConfig{Services: []ServiceConfig{{ID: "eth"}}},
+			service: "eth",
+			want:    DefaultMaxOperatorShare,
+		},
+		{
+			name:    "unknown service → global default",
+			cfg:     &UnifiedServicesConfig{},
+			service: "missing",
+			want:    DefaultMaxOperatorShare,
+		},
+		{
+			name: "defaults set, no per-service → defaults",
+			cfg: &UnifiedServicesConfig{
+				Defaults: ServiceDefaults{MaxOperatorTrafficShare: f(0.6)},
+				Services: []ServiceConfig{{ID: "eth"}},
+			},
+			service: "eth",
+			want:    0.6,
+		},
+		{
+			name: "per-service overrides defaults",
+			cfg: &UnifiedServicesConfig{
+				Defaults: ServiceDefaults{MaxOperatorTrafficShare: f(0.6)},
+				Services: []ServiceConfig{{ID: "eth", MaxOperatorTrafficShare: f(0.5)}},
+			},
+			service: "eth",
+			want:    0.5,
+		},
+		{
+			name: "per-service disable (1.0) is honored",
+			cfg: &UnifiedServicesConfig{
+				Services: []ServiceConfig{{ID: "eth", MaxOperatorTrafficShare: f(1.0)}},
+			},
+			service: "eth",
+			want:    1.0,
+		},
+		{
+			name: "per-service disable (0) is honored",
+			cfg: &UnifiedServicesConfig{
+				Services: []ServiceConfig{{ID: "eth", MaxOperatorTrafficShare: f(0)}},
+			},
+			service: "eth",
+			want:    0,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, tc.cfg.GetMaxOperatorShareForService(tc.service))
+		})
+	}
+}
+
+// TestDefaultMaxOperatorShare_ShippedOn documents that the cap is ON by default and set to
+// a sane in-range value (a change here is a deliberate rollout decision).
+func TestDefaultMaxOperatorShare_ShippedOn(t *testing.T) {
+	require.Greater(t, DefaultMaxOperatorShare, 0.0, "default must be enabled (> 0)")
+	require.Less(t, DefaultMaxOperatorShare, 1.0, "default must be an actual cap (< 1)")
+}

--- a/gateway/extract_block_height_test.go
+++ b/gateway/extract_block_height_test.go
@@ -1,0 +1,59 @@
+package gateway
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestExtractBlockHeight_GetEpochInfo verifies the external block fetcher can parse a
+// Solana getEpochInfo response by its explicit blockHeight field, and that it NEVER
+// substitutes absoluteSlot (the slot, ~5% higher, which poisons the max-based perceived
+// height). getEpochInfo is the preferred Solana external-source method precisely because
+// getBlockHeight returns a bare number some providers mislabel with the slot.
+func TestExtractBlockHeight_GetEpochInfo(t *testing.T) {
+	tests := []struct {
+		name     string
+		body     string
+		want     int64
+		wantErr  bool
+	}{
+		{
+			name: "getEpochInfo uses blockHeight, not absoluteSlot",
+			body: `{"jsonrpc":"2.0","id":1,"result":{"absoluteSlot":434344678,"blockHeight":412405238,"epoch":1005}}`,
+			want: 412405238,
+		},
+		{
+			name:    "getEpochInfo with only absoluteSlot (no blockHeight) must error, not return the slot",
+			body:    `{"jsonrpc":"2.0","id":1,"result":{"absoluteSlot":434344678,"epoch":1005}}`,
+			wantErr: true,
+		},
+		{
+			name: "getBlockHeight bare number still works",
+			body: `{"jsonrpc":"2.0","id":1,"result":412405238}`,
+			want: 412405238,
+		},
+		{
+			name: "EVM hex still works",
+			body: `{"jsonrpc":"2.0","id":1,"result":"0x1940c6f5"}`,
+			want: 0x1940c6f5,
+		},
+		{
+			name: "Cosmos sync_info still works",
+			body: `{"jsonrpc":"2.0","id":1,"result":{"sync_info":{"latest_block_height":"12345"}}}`,
+			want: 12345,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := extractBlockHeight([]byte(tc.body))
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}

--- a/gateway/health_check_config.go
+++ b/gateway/health_check_config.go
@@ -271,6 +271,14 @@ type (
 		// Local defines health checks in the local config.
 		// These override any checks from External with the same service_id + name.
 		Local []ServiceHealthCheckConfig `yaml:"local,omitempty"`
+		// BackendDedup enables backend-URL deduplication of health check relays.
+		// Many staked suppliers front the SAME backend URL (measured: 2-4x redundancy
+		// per service, up to 10 suppliers per URL). When enabled, each cycle fires ONE
+		// relay per unique backend URL (a rotating representative supplier) and fans the
+		// backend-derived result (reputation signal, block height, archival status) to the
+		// other suppliers on that URL — cutting HC relay volume by the redundancy factor.
+		// WebSocket checks are never deduped (connectivity is per-endpoint). Default: true.
+		BackendDedup *bool `yaml:"backend_dedup,omitempty"`
 	}
 
 	// RetryConfig configures automatic retry behavior for failed requests.
@@ -343,6 +351,12 @@ func (hc *ActiveHealthChecksConfig) HydrateDefaults(hasRedis bool) {
 	// Set default sync allowance
 	if hc.SyncAllowance == 0 {
 		hc.SyncAllowance = DefaultSyncAllowance
+	}
+
+	// Backend-URL dedup defaults to enabled.
+	if hc.BackendDedup == nil {
+		enabled := true
+		hc.BackendDedup = &enabled
 	}
 
 	// Hydrate coordination defaults

--- a/gateway/health_check_executor.go
+++ b/gateway/health_check_executor.go
@@ -802,6 +802,7 @@ func (e *HealthCheckExecutor) recordCheckResult(
 		// than regular SuccessSignal (+1) used by client requests, but requires
 		// sustained good behavior to fully recover from critical errors.
 		signal := reputation.NewRecoverySuccessSignal(latency)
+		signal.IsHealthCheck = true // probe, not user traffic — excluded from the rate-cooldown detector
 		if err := e.reputationSvc.RecordSignal(ctx, key, signal); err != nil {
 			e.logger.Warn().
 				Err(err).
@@ -835,6 +836,7 @@ func (e *HealthCheckExecutor) recordCheckResult(
 
 	// Check failed - record error signal based on configured severity
 	signal := e.mapSignalType(check.ReputationSignal, checkErr.Error(), latency)
+	signal.IsHealthCheck = true // probe, not user traffic — excluded from the rate-cooldown detector
 	if err := e.reputationSvc.RecordSignal(ctx, key, signal); err != nil {
 		e.logger.Warn().
 			Err(err).

--- a/gateway/health_check_executor.go
+++ b/gateway/health_check_executor.go
@@ -1854,7 +1854,15 @@ func extractBlockHeight(responseBody []byte) (int64, error) {
 				return int64(heightNum), nil
 			}
 		}
-		return 0, fmt.Errorf("unsupported response format: object without sync_info")
+		// Solana getEpochInfo format: {"blockHeight": 412345678, "epoch": ..., "absoluteSlot": ...}
+		// Prefer getEpochInfo over getBlockHeight for a Solana external source: getBlockHeight
+		// returns a bare number that some providers mislabel with the SLOT (~5% higher), whereas
+		// blockHeight is an explicit, unambiguous field. NEVER fall back to absoluteSlot — the
+		// slot poisons the max-based perceived height.
+		if bh, ok := v["blockHeight"].(float64); ok {
+			return int64(bh), nil
+		}
+		return 0, fmt.Errorf("unsupported response format: object without sync_info or blockHeight")
 
 	default:
 		return 0, fmt.Errorf("unsupported result type: %T", v)

--- a/gateway/health_check_executor.go
+++ b/gateway/health_check_executor.go
@@ -1009,6 +1009,12 @@ func (e *HealthCheckExecutor) ExecuteCheckViaProtocol(
 		return time.Since(startTime), fmt.Errorf("failed to build protocol context: %w", err)
 	}
 
+	// Tag the relay as a health check so the protocol layer skips its own relays_total
+	// recording. The executor records each outcome below as request_type="health_check";
+	// without this the same relay would ALSO be recorded as request_type="normal",
+	// double-counting it (see requestContext.isHealthCheck).
+	protocolCtx.MarkAsHealthCheck()
+
 	// Execute the relay request through the protocol - this sends the actual relay to the supplier
 	responses, relayErr := protocolCtx.HandleServiceRequest(hcQoSCtx.GetServicePayloads())
 	latency := time.Since(startTime)

--- a/gateway/health_check_executor.go
+++ b/gateway/health_check_executor.go
@@ -20,9 +20,11 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/alitto/pond/v2"
@@ -93,6 +95,11 @@ type HealthCheckExecutor struct {
 	// unifiedServicesConfig provides per-service health check overrides from unified config.
 	// Health checks defined here are merged with local/external configs.
 	unifiedServicesConfig *UnifiedServicesConfig
+
+	// cycleCounter increments once per health check cycle. Used to rotate which
+	// supplier represents each backend URL under backend-URL dedup, so every
+	// supplier's own relay path is directly validated every N cycles.
+	cycleCounter uint64
 }
 
 // HealthCheckExecutorConfig contains configuration for creating a HealthCheckExecutor.
@@ -941,18 +948,47 @@ type EndpointInfo struct {
 	SessionID string
 }
 
+// checkOutcome captures the result of executing one health check relay so that a
+// backend-derived result can be replayed ("fanned") onto sibling suppliers that
+// share the same backend URL, without firing a redundant relay for each of them.
+//
+// Only backend-derived state is fanned (reputation signal, block-height observation,
+// archival verdict). The relay-volume metric and supplier-blacklist recovery stay
+// with the representative that actually made the relay.
+type checkOutcome struct {
+	check   HealthCheckConfig
+	err     error
+	latency time.Duration
+
+	// httpStatus and body are the representative's response, used to replay the
+	// block-height / quality observation for siblings. body is empty when the relay
+	// failed before a response was received (transport error, session rollover).
+	httpStatus int
+	body       []byte
+
+	// archivalResolved is true when this was an archival check that reached a
+	// definitive pass/fail verdict, so siblings can mark/clear archival too.
+	archivalResolved bool
+	archivalPass     bool
+}
+
 // ExecuteCheckViaProtocol executes a health check through the protocol layer.
 // This sends the health check as a synthetic relay request, testing the full path
 // including relay miners, just like regular user requests.
 //
 // This is the preferred method for health checks as it validates the entire request path.
 // syncAllowance is the service-level sync_allowance from health check config (0 = disabled).
+//
+// If capture is non-nil, the representative's response (status, body, archival verdict)
+// is recorded into it so the caller can fan the backend-derived result to sibling
+// suppliers on the same URL. Passing nil disables capture (behavior is otherwise identical).
 func (e *HealthCheckExecutor) ExecuteCheckViaProtocol(
 	ctx context.Context,
 	serviceID protocol.ServiceID,
 	endpointAddr protocol.EndpointAddr,
 	check HealthCheckConfig,
 	syncAllowance uint64,
+	capture *checkOutcome,
 ) (time.Duration, error) {
 	if e.protocol == nil {
 		return 0, fmt.Errorf("protocol not configured for health check executor")
@@ -1065,6 +1101,13 @@ func (e *HealthCheckExecutor) ExecuteCheckViaProtocol(
 			Msg("Health check relay response received from supplier")
 	}
 
+	// Capture the backend response so the caller can fan block-height / quality
+	// observations to sibling suppliers sharing this backend URL (backend-URL dedup).
+	if capture != nil {
+		capture.httpStatus = httpStatusCode
+		capture.body = responseBody
+	}
+
 	// Heuristic analysis - detect bad gateway, empty responses, and other error patterns
 	// This runs BEFORE QoS validation to catch issues the basic validation might miss
 	heuristicResult := heuristic.Analyze(responseBody, httpStatusCode, servicePayload.EffectiveRPCType(), "")
@@ -1117,6 +1160,10 @@ func (e *HealthCheckExecutor) ExecuteCheckViaProtocol(
 		// clear the archival status. This ensures endpoints that return errors are not marked as archival.
 		if check.Archival {
 			e.clearEndpointArchival(serviceID, endpointAddr, check)
+			if capture != nil {
+				capture.archivalResolved = true
+				capture.archivalPass = false
+			}
 		}
 
 		// Record relay metric for validation failure (relay succeeded but validation failed)
@@ -1197,6 +1244,10 @@ func (e *HealthCheckExecutor) ExecuteCheckViaProtocol(
 	// marking endpoints that returned "false success" responses (like "0x0" for archival queries).
 	if check.Archival {
 		e.markEndpointArchival(serviceID, endpointAddr, check)
+		if capture != nil {
+			capture.archivalResolved = true
+			capture.archivalPass = true
+		}
 	}
 
 	e.logger.Debug().
@@ -1542,21 +1593,48 @@ func (e *HealthCheckExecutor) RunChecksForEndpointViaProtocol(
 		return nil
 	}
 
+	// Run every check type; build the legacy name->error map from the outcomes.
+	outcomes := e.runEndpointChecks(ctx, serviceID, endpointAddr, svcConfig, true, true)
+	results := make(map[string]error, len(outcomes))
+	for i := range outcomes {
+		results[outcomes[i].check.Name] = outcomes[i].err
+	}
+	return results
+}
+
+// runEndpointChecks executes the configured checks for one endpoint, recording each
+// result to the reputation system, and returns the captured outcomes.
+//
+// runHTTP/runWS select which check types to execute. Under backend-URL dedup, the
+// representative runs with both true; siblings run with runHTTP=false (their HTTP
+// outcomes are fanned from the representative) and runWS=true (WebSocket connectivity
+// is genuinely per-endpoint and must be probed directly).
+//
+// Only HTTP/REST outcomes are returned (they are what gets fanned); WebSocket and gRPC
+// checks are recorded here but not included in the returned slice.
+func (e *HealthCheckExecutor) runEndpointChecks(
+	ctx context.Context,
+	serviceID protocol.ServiceID,
+	endpointAddr protocol.EndpointAddr,
+	svcConfig *ServiceHealthCheckConfig,
+	runHTTP, runWS bool,
+) []checkOutcome {
 	// Get sync_allowance from service config (0 = disabled)
 	var syncAllowance uint64
 	if svcConfig.SyncAllowance != nil && *svcConfig.SyncAllowance > 0 {
 		syncAllowance = uint64(*svcConfig.SyncAllowance)
 	}
 
-	results := make(map[string]error)
+	var httpOutcomes []checkOutcome
 	for _, check := range svcConfig.Checks {
-		var err error
-		var latency time.Duration
-
 		switch check.Type {
 		case HealthCheckTypeWebSocket:
-			// WebSocket checks use the protocol's CheckWebsocketConnection
-			latency, err = e.ExecuteWebSocketCheckViaProtocol(ctx, serviceID, endpointAddr, check)
+			if !runWS {
+				continue
+			}
+			// WebSocket checks use the protocol's CheckWebsocketConnection.
+			latency, err := e.ExecuteWebSocketCheckViaProtocol(ctx, serviceID, endpointAddr, check)
+			e.recordCheckResult(ctx, serviceID, endpointAddr, check, err, latency)
 		case HealthCheckTypeGRPC:
 			// gRPC checks not yet implemented
 			e.logger.Debug().
@@ -1564,19 +1642,119 @@ func (e *HealthCheckExecutor) RunChecksForEndpointViaProtocol(
 				Str("endpoint", string(endpointAddr)).
 				Str("check", check.Name).
 				Msg("Skipping gRPC check - not yet implemented")
-			continue
 		default:
-			// HTTP-based checks (jsonrpc, rest)
-			latency, err = e.ExecuteCheckViaProtocol(ctx, serviceID, endpointAddr, check, syncAllowance)
+			if !runHTTP {
+				continue
+			}
+			// HTTP-based checks (jsonrpc, rest). Capture the response so it can be fanned.
+			var outcome checkOutcome
+			latency, err := e.ExecuteCheckViaProtocol(ctx, serviceID, endpointAddr, check, syncAllowance, &outcome)
+			outcome.check = check
+			outcome.err = err
+			outcome.latency = latency
+			e.recordCheckResult(ctx, serviceID, endpointAddr, check, err, latency)
+			httpOutcomes = append(httpOutcomes, outcome)
+		}
+	}
+	return httpOutcomes
+}
+
+// fanOutcomeToSibling replays a representative's HTTP check outcomes onto a sibling
+// supplier that shares the same backend URL, WITHOUT firing a relay. It records the
+// same reputation signal, replays the block-height / quality observation, and fans the
+// archival verdict — the backend-derived state that is identical across suppliers on the
+// same backend. It deliberately does NOT record a relay metric (that would defeat the
+// load reduction) or attempt supplier-blacklist recovery (that needs a real relay).
+func (e *HealthCheckExecutor) fanOutcomeToSibling(
+	ctx context.Context,
+	serviceID protocol.ServiceID,
+	siblingAddr protocol.EndpointAddr,
+	outcomes []checkOutcome,
+) {
+	for i := range outcomes {
+		o := outcomes[i]
+
+		// Same reputation signal the representative recorded (recovery success or error).
+		e.recordCheckResult(ctx, serviceID, siblingAddr, o.check, o.err, o.latency)
+
+		// Replay the block-height / quality observation so the sibling's stored height
+		// stays fresh and it is not falsely filtered as out-of-sync. Only possible when a
+		// response body was received.
+		if len(o.body) > 0 {
+			payload := e.buildServicePayload(o.check)
+			e.processObservationSync(serviceID, siblingAddr, o.check, payload, time.Now().Add(-o.latency), o.latency, o.httpStatus, o.body)
 		}
 
-		results[check.Name] = err
+		// Fan the archival verdict (same backend => same archival capability).
+		if o.archivalResolved {
+			if o.archivalPass {
+				e.markEndpointArchival(serviceID, siblingAddr, o.check)
+			} else {
+				e.clearEndpointArchival(serviceID, siblingAddr, o.check)
+			}
+		}
 
-		// Record the result to reputation with latency
-		e.recordCheckResult(ctx, serviceID, endpointAddr, check, err, latency)
+		metrics.RecordHealthCheckDeduped(string(serviceID))
+	}
+}
+
+// backendDedupEnabled reports whether backend-URL health check deduplication is on.
+// Defaults to enabled when unset.
+func (e *HealthCheckExecutor) backendDedupEnabled() bool {
+	return e.config == nil || e.config.BackendDedup == nil || *e.config.BackendDedup
+}
+
+// representativeIndex selects which member of a same-URL group fires the real relay
+// this cycle. Rotating by cycle gives every member a directly-probed turn every
+// len(group) cycles, so a supplier's own relay path is validated even when its
+// backend-derived result is otherwise fanned from a sibling.
+func representativeIndex(cycle uint64, groupSize int) int {
+	if groupSize <= 1 {
+		return 0
+	}
+	return int(cycle % uint64(groupSize))
+}
+
+// endpointSessionActive reports whether the endpoint's session is still active, so a
+// stale (rolled-over) endpoint is skipped. Endpoints without a session ID are treated
+// as active (nothing to invalidate against).
+func (e *HealthCheckExecutor) endpointSessionActive(ctx context.Context, serviceID protocol.ServiceID, ep EndpointInfo) bool {
+	if ep.SessionID == "" || e.protocol == nil {
+		return true
+	}
+	return e.protocol.IsSessionActive(ctx, serviceID, ep.SessionID)
+}
+
+// groupEndpointsByURL groups endpoints by their backend HTTP URL. Endpoints sharing a
+// URL front the same backend, so one relay per URL suffices per cycle for backend-derived
+// checks. Groups and their members are returned in a stable (sorted) order so that
+// representative rotation is deterministic across cycles. Endpoints with no HTTP URL
+// (e.g. WebSocket-only) each form their own singleton group and are never deduped.
+func groupEndpointsByURL(endpoints []EndpointInfo) [][]EndpointInfo {
+	byURL := make(map[string][]EndpointInfo)
+	var singletons [][]EndpointInfo
+	for _, ep := range endpoints {
+		if ep.HTTPURL == "" {
+			singletons = append(singletons, []EndpointInfo{ep})
+			continue
+		}
+		byURL[ep.HTTPURL] = append(byURL[ep.HTTPURL], ep)
 	}
 
-	return results
+	urls := make([]string, 0, len(byURL))
+	for u := range byURL {
+		urls = append(urls, u)
+	}
+	sort.Strings(urls)
+
+	groups := make([][]EndpointInfo, 0, len(byURL)+len(singletons))
+	for _, u := range urls {
+		grp := byURL[u]
+		sort.Slice(grp, func(i, j int) bool { return grp[i].Addr < grp[j].Addr })
+		groups = append(groups, grp)
+	}
+	groups = append(groups, singletons...)
+	return groups
 }
 
 // RunAllChecksViaProtocol runs health checks through the protocol layer for all configured services.
@@ -1610,6 +1788,11 @@ func (e *HealthCheckExecutor) RunAllChecksViaProtocol(
 	group := e.pool.NewGroup()
 	totalJobs := 0
 
+	dedup := e.backendDedupEnabled()
+	// One rotation tick per cycle: every backend-URL group advances its representative
+	// by exactly one, giving each supplier on a URL a directly-probed turn every N cycles.
+	cycle := atomic.AddUint64(&e.cycleCounter, 1)
+
 	// Submit health check jobs to the worker pool
 	for _, svcConfig := range serviceConfigs {
 		if svcConfig.Enabled != nil && !*svcConfig.Enabled {
@@ -1632,28 +1815,77 @@ func (e *HealthCheckExecutor) RunAllChecksViaProtocol(
 			continue
 		}
 
-		// Submit a job for each endpoint
-		for _, endpointInfo := range endpointInfos {
-			// Capture loop variables for closure
-			serviceID := svcConfig.ServiceID
-			endpoint := endpointInfo.Addr
-			sessionID := endpointInfo.SessionID
+		serviceID := svcConfig.ServiceID
+		// Snapshot config per service so closures don't alias the loop variable.
+		cfg := svcConfig
 
+		if !dedup {
+			// Legacy behavior: one relay job per endpoint (no backend-URL dedup).
+			for _, endpointInfo := range endpointInfos {
+				endpoint := endpointInfo.Addr
+				sessionID := endpointInfo.SessionID
+				group.Submit(func() {
+					if ctx.Err() != nil {
+						return
+					}
+					if sessionID != "" && e.protocol != nil && !e.protocol.IsSessionActive(ctx, serviceID, sessionID) {
+						return
+					}
+					e.runEndpointChecks(ctx, serviceID, endpoint, &cfg, true, true)
+				})
+				totalJobs++
+			}
+			continue
+		}
+
+		// Backend-URL dedup: fire ONE relay per unique backend URL (a rotating
+		// representative supplier) and fan the backend-derived result to the other
+		// suppliers on that URL. WebSocket checks are still probed per-endpoint.
+		urlGroups := groupEndpointsByURL(endpointInfos)
+		for _, grp := range urlGroups {
+			grp := grp
+			repIdx := representativeIndex(cycle, len(grp))
 			group.Submit(func() {
-				select {
-				case <-ctx.Done():
+				if ctx.Err() != nil {
 					return
-				default:
-					// Check if session is still active before executing health check
-					// This prevents errors when session has rolled over between collection and execution
-					if sessionID != "" && e.protocol != nil {
-						if !e.protocol.IsSessionActive(ctx, serviceID, sessionID) {
-							// Session no longer active - skip silently
-							// This is expected during session rollover
-							return
+				}
+
+				// Pick the representative: the rotated member, or the next active one
+				// if it rolled over, so a single stale endpoint doesn't skip the group.
+				rep := grp[repIdx]
+				if !e.endpointSessionActive(ctx, serviceID, rep) {
+					for off := 1; off < len(grp); off++ {
+						cand := grp[(repIdx+off)%len(grp)]
+						if e.endpointSessionActive(ctx, serviceID, cand) {
+							rep = cand
+							repIdx = (repIdx + off) % len(grp)
+							break
 						}
 					}
-					e.RunChecksForEndpointViaProtocol(ctx, serviceID, endpoint)
+				}
+
+				var outcomes []checkOutcome
+				if e.endpointSessionActive(ctx, serviceID, rep) {
+					outcomes = e.runEndpointChecks(ctx, serviceID, rep.Addr, &cfg, true, true)
+				}
+
+				// Siblings: fan the representative's HTTP outcomes (no relay), and still
+				// probe each sibling's own WebSocket connectivity (per-endpoint).
+				for i := range grp {
+					if i == repIdx {
+						continue
+					}
+					if ctx.Err() != nil {
+						return
+					}
+					sib := grp[i]
+					if !e.endpointSessionActive(ctx, serviceID, sib) {
+						continue
+					}
+					if len(outcomes) > 0 {
+						e.fanOutcomeToSibling(ctx, serviceID, sib.Addr, outcomes)
+					}
+					e.runEndpointChecks(ctx, serviceID, sib.Addr, &cfg, false, true)
 				}
 			})
 			totalJobs++

--- a/gateway/health_check_executor_test.go
+++ b/gateway/health_check_executor_test.go
@@ -669,3 +669,157 @@ func TestRecordCheckResult_SuccessRecordsRecoverySignal(t *testing.T) {
 // but kept here so future tests that need RPCType can copy this file as a
 // template without hunting for the import.
 var _ = sharedtypes.RPCType_JSON_RPC
+
+// ---------------------------------------------------------------------------
+// Backend-URL health check dedup
+// ---------------------------------------------------------------------------
+
+// TestGroupEndpointsByURL pins the grouping used for backend-URL dedup: endpoints
+// that share an identical backend URL are collapsed into one group (one relay per
+// URL), endpoints with no HTTP URL each stay a singleton (never deduped), and both
+// groups and members come back in a stable order so rotation is deterministic.
+func TestGroupEndpointsByURL(t *testing.T) {
+	eps := []EndpointInfo{
+		{Addr: "sB-https://r2.example.com", HTTPURL: "https://r2.example.com"},
+		{Addr: "sA-https://r1.example.com", HTTPURL: "https://r1.example.com"},
+		{Addr: "sC-https://r1.example.com", HTTPURL: "https://r1.example.com"},
+		{Addr: "sD-https://r1.example.com", HTTPURL: "https://r1.example.com"},
+		{Addr: "wsOnly", HTTPURL: "", WebSocketURL: "wss://ws.example.com"},
+	}
+
+	groups := groupEndpointsByURL(eps)
+
+	// r1 (3 members) + r2 (1 member) + ws-only singleton = 3 groups.
+	require.Len(t, groups, 3)
+
+	// First group is r1 (sorted URL order), members sorted by Addr.
+	require.Len(t, groups[0], 3)
+	require.Equal(t, protocol.EndpointAddr("sA-https://r1.example.com"), groups[0][0].Addr)
+	require.Equal(t, protocol.EndpointAddr("sC-https://r1.example.com"), groups[0][1].Addr)
+	require.Equal(t, protocol.EndpointAddr("sD-https://r1.example.com"), groups[0][2].Addr)
+
+	// Second group is r2 (single member).
+	require.Len(t, groups[1], 1)
+	require.Equal(t, protocol.EndpointAddr("sB-https://r2.example.com"), groups[1][0].Addr)
+
+	// Third group is the WS-only singleton — never merged with anything.
+	require.Len(t, groups[2], 1)
+	require.Equal(t, protocol.EndpointAddr("wsOnly"), groups[2][0].Addr)
+}
+
+// TestGroupEndpointsByURL_Stable pins that grouping is deterministic across calls,
+// so representative rotation actually round-robins the same ordering each cycle.
+func TestGroupEndpointsByURL_Stable(t *testing.T) {
+	eps := []EndpointInfo{
+		{Addr: "s3-https://b.example.com", HTTPURL: "https://b.example.com"},
+		{Addr: "s1-https://a.example.com", HTTPURL: "https://a.example.com"},
+		{Addr: "s2-https://a.example.com", HTTPURL: "https://a.example.com"},
+	}
+	first := groupEndpointsByURL(eps)
+	for i := 0; i < 5; i++ {
+		require.Equal(t, first, groupEndpointsByURL(eps))
+	}
+}
+
+// TestRepresentativeIndex_RoundRobin pins that rotation gives every member of a
+// same-URL group a directly-probed turn within len(group) consecutive cycles.
+func TestRepresentativeIndex_RoundRobin(t *testing.T) {
+	require.Equal(t, 0, representativeIndex(7, 1), "singleton group always uses index 0")
+	require.Equal(t, 0, representativeIndex(7, 0), "empty group must not divide-by-zero")
+
+	const size = 4
+	seen := make(map[int]struct{})
+	for cycle := uint64(1); cycle <= size; cycle++ {
+		seen[representativeIndex(cycle, size)] = struct{}{}
+	}
+	require.Len(t, seen, size, "every member must be representative once per %d cycles", size)
+}
+
+// TestBackendDedupEnabled pins the default-on behavior and explicit override.
+func TestBackendDedupEnabled(t *testing.T) {
+	tru, fls := true, false
+	require.True(t, (&HealthCheckExecutor{}).backendDedupEnabled(), "nil config defaults to enabled")
+	require.True(t, (&HealthCheckExecutor{config: &ActiveHealthChecksConfig{}}).backendDedupEnabled(), "nil flag defaults to enabled")
+	require.True(t, (&HealthCheckExecutor{config: &ActiveHealthChecksConfig{BackendDedup: &tru}}).backendDedupEnabled())
+	require.False(t, (&HealthCheckExecutor{config: &ActiveHealthChecksConfig{BackendDedup: &fls}}).backendDedupEnabled())
+}
+
+// TestHydrateDefaults_BackendDedup pins that dedup ships on by default.
+func TestHydrateDefaults_BackendDedup(t *testing.T) {
+	cfg := &ActiveHealthChecksConfig{}
+	cfg.HydrateDefaults(true)
+	require.NotNil(t, cfg.BackendDedup)
+	require.True(t, *cfg.BackendDedup)
+
+	// Explicit false must be preserved, not overwritten by the default.
+	fls := false
+	cfg2 := &ActiveHealthChecksConfig{BackendDedup: &fls}
+	cfg2.HydrateDefaults(true)
+	require.NotNil(t, cfg2.BackendDedup)
+	require.False(t, *cfg2.BackendDedup)
+}
+
+// TestFanOutcomeToSibling_RecordsSignals pins that fanning replays one reputation
+// signal per HTTP outcome onto the sibling — a passing check recovers it, a failing
+// check penalizes it — mirroring what the representative recorded, without a relay.
+func TestFanOutcomeToSibling_RecordsSignals(t *testing.T) {
+	rep := &recordedSignalReputationSvc{}
+	executor := &HealthCheckExecutor{
+		logger:        polyzero.NewLogger(),
+		reputationSvc: rep,
+		// observationQueue nil => processObservationSync is a no-op; archival not resolved
+		// => no SetArchivalStatus call. Isolates the reputation-signal fan.
+	}
+
+	outcomes := []checkOutcome{
+		{
+			check:   HealthCheckConfig{Name: "block-number", Type: "json_rpc"},
+			err:     nil, // pass
+			latency: 40 * time.Millisecond,
+		},
+		{
+			check:   HealthCheckConfig{Name: "chain-id", Type: "json_rpc", ReputationSignal: "critical_error"},
+			err:     fmt.Errorf("wrong chain id"),
+			latency: 60 * time.Millisecond,
+		},
+	}
+
+	executor.fanOutcomeToSibling(
+		context.Background(),
+		protocol.ServiceID("bsc"),
+		protocol.EndpointAddr("pokt1sibling-https://r1.example.com"),
+		outcomes,
+	)
+
+	signals := rep.RecordedSignals()
+	require.Len(t, signals, 2, "one fanned reputation signal per HTTP outcome")
+	require.Equal(t, reputation.SignalTypeRecoverySuccess, signals[0].Type, "passing check recovers the sibling")
+	require.Equal(t, reputation.SignalTypeCriticalError, signals[1].Type, "failing check penalizes the sibling at configured severity")
+}
+
+// TestFanOutcomeToSibling_OverServicedNotPenalized pins that a representative's
+// over-serviced (stake-exhausted) result, when fanned, still skips the sibling
+// penalty — same no-penalty rule as a direct relay.
+func TestFanOutcomeToSibling_OverServicedNotPenalized(t *testing.T) {
+	rep := &recordedSignalReputationSvc{}
+	executor := &HealthCheckExecutor{
+		logger:        polyzero.NewLogger(),
+		reputationSvc: rep,
+	}
+
+	outcomes := []checkOutcome{{
+		check:   HealthCheckConfig{Name: "block-number", Type: "json_rpc", ReputationSignal: "major_error"},
+		err:     fmt.Errorf("relay miner returned error: offchain rate limit hit by relayer proxy"),
+		latency: 20 * time.Millisecond,
+	}}
+
+	executor.fanOutcomeToSibling(
+		context.Background(),
+		protocol.ServiceID("bsc"),
+		protocol.EndpointAddr("pokt1sibling-https://r1.example.com"),
+		outcomes,
+	)
+
+	require.Empty(t, rep.RecordedSignals(),
+		"fanned over-serviced failures must not penalize the sibling")
+}

--- a/gateway/http_request_context_handle_request.go
+++ b/gateway/http_request_context_handle_request.go
@@ -887,6 +887,12 @@ func (rc *requestContext) handleSingleRelayRequest() error {
 		metrics.RecordRetryResult(metrics.NormalizeRPCType(rpcType.String()), string(rc.serviceID), strconv.Itoa(maxAttempts-1), metrics.RetryResultFailure, totalLatency)
 	}
 
+	// Record the give-up: this relay exhausted its retries and returns an error (a 500 on the
+	// lastErr path) that path_requests_total does not count. relay_exhausted_total closes that
+	// blind spot; the `capability` category isolates backend-reported unavailable
+	// historical/pruned state — a client asking for data the node does not retain.
+	metrics.RecordRelayExhausted(string(rc.serviceID), metrics.NormalizeRPCType(rpcType.String()), relayExhaustionCategory(lastHeuristicResult, lastErr))
+
 	if lastErr != nil {
 		logger.Error().Err(lastErr).
 			Int("max_attempts", maxAttempts).
@@ -905,6 +911,26 @@ func (rc *requestContext) handleSingleRelayRequest() error {
 	// Set the protocol error on QoS context for more informative client error messages
 	rc.qosCtx.SetProtocolError(statusErr)
 	return statusErr
+}
+
+// relayExhaustionCategory classifies why a relay exhausted its retries, for the
+// relay_exhausted_total metric:
+//   - capability: the backend correctly reported unavailable historical/pruned state
+//     (IsCapabilityLimitationError) — a client asking for data the node does not retain.
+//   - heuristic: any other heuristic-detected error payload in a 2xx response.
+//   - transport: a connection/protocol error with no heuristic result.
+//   - status: a non-success HTTP status with neither of the above.
+func relayExhaustionCategory(hr *heuristic.AnalysisResult, err error) string {
+	if hr != nil {
+		if heuristic.IsCapabilityLimitationError(hr.MatchedPattern) {
+			return "capability"
+		}
+		return "heuristic"
+	}
+	if err != nil {
+		return "transport"
+	}
+	return "status"
 }
 
 // batchPayloadResult holds the result of processing a single payload in a batch.

--- a/gateway/protocol.go
+++ b/gateway/protocol.go
@@ -197,6 +197,15 @@ type ProtocolRequestContext interface {
 	// success/error feedback).
 	MarkAsRetry()
 
+	// MarkAsHealthCheck tags this request as an active health-check relay issued by the
+	// health-check executor. The executor records its own relays_total entry
+	// (request_type="health_check") for every outcome, so the protocol layer must SKIP its
+	// own relay metric recording for these — otherwise the same paid relay is also recorded
+	// as request_type="normal", double-counting it and polluting every "excludes health
+	// checks" dashboard. Must be called before HandleServiceRequest. Reputation signals and
+	// observations are unaffected.
+	MarkAsHealthCheck()
+
 	// GetObservations builds and returns the set of protocol-specific observations using the current context.
 	//
 	// Hypothetical illustrative example.

--- a/gateway/relay_exhaustion_test.go
+++ b/gateway/relay_exhaustion_test.go
@@ -1,0 +1,41 @@
+package gateway
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/pokt-network/path/qos/heuristic"
+)
+
+// Test_relayExhaustionCategory verifies the classification feeding relay_exhausted_total,
+// especially that backend-reported historical/pruned state is isolated as "capability".
+func Test_relayExhaustionCategory(t *testing.T) {
+	hr := func(pattern string) *heuristic.AnalysisResult {
+		return &heuristic.AnalysisResult{MatchedPattern: pattern}
+	}
+
+	// MatchedPattern holds the short errorPatterns key that matched (e.g. "historical state"),
+	// NOT the full backend message — that is what IsCapabilityLimitationError switches on.
+	tests := []struct {
+		name string
+		hr   *heuristic.AnalysisResult
+		err  error
+		want string
+	}{
+		{"capability: historical state", hr("historical state"), nil, "capability"},
+		{"capability: pruned state", hr("is pruned"), nil, "capability"},
+		{"capability: state not available", hr("state not available"), nil, "capability"},
+		{"capability: missing trie node", hr("missing trie node"), nil, "capability"},
+		{"heuristic: non-capability pattern", hr("execution reverted"), nil, "heuristic"},
+		{"transport: error, no heuristic", nil, errors.New("dial tcp: connection refused"), "transport"},
+		{"status: no heuristic, no error", nil, nil, "status"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, relayExhaustionCategory(tc.hr, tc.err))
+		})
+	}
+}

--- a/gateway/static_route_test.go
+++ b/gateway/static_route_test.go
@@ -10,14 +10,14 @@ func staticTestConfig() *UnifiedServicesConfig {
 	return &UnifiedServicesConfig{
 		Defaults: ServiceDefaults{
 			StaticRoutes: []StaticRoute{
-				{Path: "/identity", Body: "global-body"},
+				{Path: "/example", Body: "global-body"},
 			},
 		},
 		Services: []ServiceConfig{
 			{
 				ID: "solana",
 				StaticRoutes: []StaticRoute{
-					{Path: "/identity", Body: "solana-body"},
+					{Path: "/example", Body: "solana-body"},
 				},
 			},
 			{
@@ -44,17 +44,17 @@ func Test_ResolveStaticResponse_PerServiceOverridesDefault(t *testing.T) {
 	c := require.New(t)
 	cfg := staticTestConfig()
 
-	body, status, headers, ok := cfg.ResolveStaticResponse("solana", "/identity", "GET")
+	body, status, headers, ok := cfg.ResolveStaticResponse("solana", "/example", "GET")
 	c.True(ok)
 	c.Equal("solana-body", string(body), "per-service route overrides the global default")
 	c.Equal(200, status, "status defaults to 200")
 	c.Equal("text/plain; charset=utf-8", headers["Content-Type"], "content-type defaults to text/plain")
 
-	body, _, _, ok = cfg.ResolveStaticResponse("eth", "/identity", "GET")
+	body, _, _, ok = cfg.ResolveStaticResponse("eth", "/example", "GET")
 	c.True(ok)
-	c.Equal("global-body", string(body), "service without its own /identity falls back to the default")
+	c.Equal("global-body", string(body), "service without its own /example falls back to the default")
 
-	body, _, _, ok = cfg.ResolveStaticResponse("unknown-service", "/identity", "GET")
+	body, _, _, ok = cfg.ResolveStaticResponse("unknown-service", "/example", "GET")
 	c.True(ok)
 	c.Equal("global-body", string(body), "unknown service still gets the global default")
 }
@@ -108,7 +108,7 @@ func Test_validateStaticRoutes(t *testing.T) {
 	}{
 		{
 			name:   "valid single route",
-			routes: []StaticRoute{{Path: "/identity", Body: "x"}},
+			routes: []StaticRoute{{Path: "/example", Body: "x"}},
 		},
 		{
 			name:   "valid same path, disjoint methods",
@@ -121,7 +121,7 @@ func Test_validateStaticRoutes(t *testing.T) {
 		},
 		{
 			name:    "path without leading slash",
-			routes:  []StaticRoute{{Path: "identity", Body: "x"}},
+			routes:  []StaticRoute{{Path: "example", Body: "x"}},
 			wantErr: true,
 		},
 		{

--- a/gateway/static_route_test.go
+++ b/gateway/static_route_test.go
@@ -1,0 +1,164 @@
+package gateway
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func staticTestConfig() *UnifiedServicesConfig {
+	return &UnifiedServicesConfig{
+		Defaults: ServiceDefaults{
+			StaticRoutes: []StaticRoute{
+				{Path: "/identity", Body: "global-body"},
+			},
+		},
+		Services: []ServiceConfig{
+			{
+				ID: "solana",
+				StaticRoutes: []StaticRoute{
+					{Path: "/identity", Body: "solana-body"},
+				},
+			},
+			{
+				ID: "eth",
+				StaticRoutes: []StaticRoute{
+					{
+						Path:        "/info",
+						Methods:     []string{"POST"},
+						StatusCode:  201,
+						ContentType: "application/json",
+						Body:        `{"ok":true}`,
+						Headers:     map[string]string{"X-Custom": "1"},
+					},
+				},
+			},
+		},
+	}
+}
+
+// Test_ResolveStaticResponse_PerServiceOverridesDefault verifies a per-service route wins
+// over a global default on the same path, while a service without its own route falls back
+// to the default.
+func Test_ResolveStaticResponse_PerServiceOverridesDefault(t *testing.T) {
+	c := require.New(t)
+	cfg := staticTestConfig()
+
+	body, status, headers, ok := cfg.ResolveStaticResponse("solana", "/identity", "GET")
+	c.True(ok)
+	c.Equal("solana-body", string(body), "per-service route overrides the global default")
+	c.Equal(200, status, "status defaults to 200")
+	c.Equal("text/plain; charset=utf-8", headers["Content-Type"], "content-type defaults to text/plain")
+
+	body, _, _, ok = cfg.ResolveStaticResponse("eth", "/identity", "GET")
+	c.True(ok)
+	c.Equal("global-body", string(body), "service without its own /identity falls back to the default")
+
+	body, _, _, ok = cfg.ResolveStaticResponse("unknown-service", "/identity", "GET")
+	c.True(ok)
+	c.Equal("global-body", string(body), "unknown service still gets the global default")
+}
+
+// Test_ResolveStaticResponse_NoMatch verifies a path with no configured route resolves to
+// ok=false so the caller relays normally.
+func Test_ResolveStaticResponse_NoMatch(t *testing.T) {
+	c := require.New(t)
+	cfg := staticTestConfig()
+
+	_, _, _, ok := cfg.ResolveStaticResponse("solana", "/not-configured", "GET")
+	c.False(ok)
+}
+
+// Test_ResolveStaticResponse_MethodFilter verifies a route with a Methods set matches only
+// the listed methods, and that all response fields are honored.
+func Test_ResolveStaticResponse_MethodFilter(t *testing.T) {
+	c := require.New(t)
+	cfg := staticTestConfig()
+
+	_, _, _, ok := cfg.ResolveStaticResponse("eth", "/info", "GET")
+	c.False(ok, "GET must not match a POST-only route")
+
+	body, status, headers, ok := cfg.ResolveStaticResponse("eth", "/info", "post")
+	c.True(ok, "method match is case-insensitive")
+	c.Equal(`{"ok":true}`, string(body))
+	c.Equal(201, status)
+	c.Equal("application/json", headers["Content-Type"])
+	c.Equal("1", headers["X-Custom"])
+}
+
+// Test_ResolveStaticResponse_HeadersCopied verifies the returned headers map is a fresh copy
+// so a caller writing onto it cannot mutate the shared config.
+func Test_ResolveStaticResponse_HeadersCopied(t *testing.T) {
+	c := require.New(t)
+	cfg := staticTestConfig()
+
+	_, _, headers, ok := cfg.ResolveStaticResponse("eth", "/info", "POST")
+	c.True(ok)
+	headers["X-Custom"] = "mutated"
+
+	_, _, headers2, _ := cfg.ResolveStaticResponse("eth", "/info", "POST")
+	c.Equal("1", headers2["X-Custom"], "config must be unaffected by a caller mutating returned headers")
+}
+
+func Test_validateStaticRoutes(t *testing.T) {
+	tests := []struct {
+		name    string
+		routes  []StaticRoute
+		wantErr bool
+	}{
+		{
+			name:   "valid single route",
+			routes: []StaticRoute{{Path: "/identity", Body: "x"}},
+		},
+		{
+			name:   "valid same path, disjoint methods",
+			routes: []StaticRoute{{Path: "/p", Methods: []string{"GET"}}, {Path: "/p", Methods: []string{"POST"}}},
+		},
+		{
+			name:    "empty path",
+			routes:  []StaticRoute{{Path: "", Body: "x"}},
+			wantErr: true,
+		},
+		{
+			name:    "path without leading slash",
+			routes:  []StaticRoute{{Path: "identity", Body: "x"}},
+			wantErr: true,
+		},
+		{
+			name:    "relay-root path is rejected",
+			routes:  []StaticRoute{{Path: "/", Body: "x"}},
+			wantErr: true,
+		},
+		{
+			name:    "status code out of range",
+			routes:  []StaticRoute{{Path: "/p", StatusCode: 99}},
+			wantErr: true,
+		},
+		{
+			name:    "duplicate all-methods path",
+			routes:  []StaticRoute{{Path: "/p"}, {Path: "/p"}},
+			wantErr: true,
+		},
+		{
+			name:    "specific method conflicts with all-methods on same path",
+			routes:  []StaticRoute{{Path: "/p"}, {Path: "/p", Methods: []string{"GET"}}},
+			wantErr: true,
+		},
+		{
+			name:    "duplicate path+method",
+			routes:  []StaticRoute{{Path: "/p", Methods: []string{"GET"}}, {Path: "/p", Methods: []string{"get"}}},
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateStaticRoutes(tc.routes)
+			if tc.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/gateway/unified_service_config.go
+++ b/gateway/unified_service_config.go
@@ -850,11 +850,15 @@ func (c *UnifiedServicesConfig) GetMergedServiceConfig(serviceID protocol.Servic
 // DefaultMaxOperatorShare is the per-operator concentration cap applied when neither the
 // service nor the global defaults specify one. Shipped ON: no single operator (eTLD+1)
 // receives more than this fraction of a service's endpoint selections when the valid pool
-// spans multiple operators. Tuned from production concentration data — it bounds the
-// clearly-concentrated tail (one operator holding the large majority of a service) while
-// leaving ordinary multi-operator distributions unchanged. Set a per-service or default
-// value of >= 1 (or <= 0) to disable.
-const DefaultMaxOperatorShare = 0.75
+// spans multiple operators. Tuned from production concentration data: a canary survey found
+// the dominant operator held 58–90% of most services' sessions, yet reputation/validation
+// filtering trims its effective valid-pool share enough that a 0.75 cap almost never
+// engaged. 0.65 makes the cap actually bound the concentrated tail (12 of 19 sampled
+// services) at negligible redistribution cost — the excess spreads across a handful of
+// other valid operators — while staying above the uniform-over-operators feasibility floor
+// for services with as few as two operators. Set a per-service or default value of >= 1
+// (or <= 0) to disable.
+const DefaultMaxOperatorShare = 0.65
 
 // GetMaxOperatorShareForService returns the per-operator concentration cap for a service.
 // It checks per-service config first, then global defaults, then DefaultMaxOperatorShare.

--- a/gateway/unified_service_config.go
+++ b/gateway/unified_service_config.go
@@ -6,6 +6,7 @@ package gateway
 
 import (
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 
@@ -221,6 +222,38 @@ type ServiceFallbackConfig struct {
 	Endpoints      []map[string]string `yaml:"endpoints,omitempty"`
 }
 
+// StaticRoute defines a fixed response served directly by the gateway for a specific
+// request path, without relaying to a backend endpoint. It lets the gateway expose small,
+// service-scoped metadata endpoints (for example an identity/info route) whose body is a
+// constant configured value rather than something fetched from a supplier.
+//
+// A static route short-circuits the relay pipeline: a matching request never reaches
+// RPC-type detection or endpoint selection, so it does not interact with a service's
+// rpc_types (a REST service is unaffected unless it explicitly configures the same path).
+// Matching is exact on Path and, when Methods is set, on the request method.
+type StaticRoute struct {
+	// Path is the exact request path this route serves, matched after the gateway strips
+	// the API-version and portal-app-id prefixes (e.g. "/identity"). Must begin with "/"
+	// and must not be the relay root ("/") — that would shadow all of a service's traffic.
+	Path string `yaml:"path"`
+
+	// Methods restricts the route to the listed HTTP methods (case-insensitive). Empty
+	// matches any method.
+	Methods []string `yaml:"methods,omitempty"`
+
+	// StatusCode is the HTTP status returned. Defaults to 200 when unset.
+	StatusCode int `yaml:"status_code,omitempty"`
+
+	// ContentType sets the Content-Type header. Defaults to "text/plain; charset=utf-8".
+	ContentType string `yaml:"content_type,omitempty"`
+
+	// Body is the exact response body returned verbatim.
+	Body string `yaml:"body"`
+
+	// Headers are additional response headers set on the reply.
+	Headers map[string]string `yaml:"headers,omitempty"`
+}
+
 // ServiceDefaults contains default settings inherited by all services.
 type ServiceDefaults struct {
 	Type                 ServiceType                  `yaml:"type,omitempty"`
@@ -236,6 +269,10 @@ type ServiceDefaults struct {
 	TimeoutConfig        ServiceTimeoutConfig         `yaml:"timeout_config,omitempty"`
 	ActiveHealthChecks   ServiceHealthCheckOverride   `yaml:"active_health_checks,omitempty"`
 	ExternalBlockSources []ExternalBlockSource        `yaml:"external_block_sources,omitempty"`
+
+	// StaticRoutes are gateway-served fixed responses applied to every service as a global
+	// default. A per-service StaticRoutes entry with the same Path overrides the global one.
+	StaticRoutes []StaticRoute `yaml:"static_routes,omitempty"`
 
 	// MaxOperatorShare is the default per-operator concentration cap applied to any
 	// service that does not set its own. nil falls back to DefaultMaxOperatorShare.
@@ -267,6 +304,11 @@ type ServiceConfig struct {
 	// Unlike the auto-generated supplier blacklist (which is temporary/session-scoped),
 	// this is a persistent, config-driven blocklist.
 	BlockedSuppliers []string `yaml:"blocked_suppliers,omitempty"`
+
+	// StaticRoutes are gateway-served fixed responses for this service. A route whose Path
+	// matches a global default (ServiceDefaults.StaticRoutes) overrides that default for this
+	// service; paths present only in the defaults still apply.
+	StaticRoutes []StaticRoute `yaml:"static_routes,omitempty"`
 
 	// MaxOperatorShare caps the fraction of this service's endpoint selections that
 	// any single operator (registrable domain / eTLD+1) may receive, bounding the blast
@@ -349,6 +391,10 @@ func (c *UnifiedServicesConfig) Validate() error {
 				}
 			}
 		}
+
+		if err := validateStaticRoutes(svc.StaticRoutes); err != nil {
+			return fmt.Errorf("services[%d] (%s): %w", i, svc.ID, err)
+		}
 	}
 
 	if c.Defaults.Type != "" {
@@ -365,6 +411,49 @@ func (c *UnifiedServicesConfig) Validate() error {
 		}
 	}
 
+	if err := validateStaticRoutes(c.Defaults.StaticRoutes); err != nil {
+		return fmt.Errorf("defaults: %w", err)
+	}
+
+	return nil
+}
+
+// validateStaticRoutes checks a set of static routes for well-formed paths, unique
+// path+method coverage, and valid status codes. Returns the first problem found.
+func validateStaticRoutes(routes []StaticRoute) error {
+	// Track (path, method) pairs so two routes cannot both claim the same request. A
+	// route with no methods claims all methods for its path, so it conflicts with any
+	// other route on that path.
+	pathAllMethods := make(map[string]struct{})
+	pathMethod := make(map[string]struct{})
+	for i, rt := range routes {
+		if rt.Path == "" || rt.Path[0] != '/' {
+			return fmt.Errorf("static_routes[%d]: path must be non-empty and begin with '/'", i)
+		}
+		if rt.Path == "/" {
+			return fmt.Errorf("static_routes[%d]: path '/' would shadow all relay traffic and is not allowed", i)
+		}
+		if rt.StatusCode != 0 && (rt.StatusCode < 100 || rt.StatusCode > 599) {
+			return fmt.Errorf("static_routes[%d] (%s): status_code %d out of range 100-599", i, rt.Path, rt.StatusCode)
+		}
+		if len(rt.Methods) == 0 {
+			if _, dup := pathAllMethods[rt.Path]; dup {
+				return fmt.Errorf("static_routes[%d]: duplicate path '%s'", i, rt.Path)
+			}
+			pathAllMethods[rt.Path] = struct{}{}
+			continue
+		}
+		if _, dup := pathAllMethods[rt.Path]; dup {
+			return fmt.Errorf("static_routes[%d]: path '%s' conflicts with an all-methods route on the same path", i, rt.Path)
+		}
+		for _, m := range rt.Methods {
+			key := rt.Path + " " + strings.ToUpper(m)
+			if _, dup := pathMethod[key]; dup {
+				return fmt.Errorf("static_routes[%d]: duplicate path+method '%s'", i, key)
+			}
+			pathMethod[key] = struct{}{}
+		}
+	}
 	return nil
 }
 
@@ -872,6 +961,67 @@ func (c *UnifiedServicesConfig) GetMaxOperatorShareForService(serviceID protocol
 		return *c.Defaults.MaxOperatorShare
 	}
 	return DefaultMaxOperatorShare
+}
+
+// ResolveStaticResponse returns the configured static response for a service's request path
+// and method, or ok=false if none applies. Per-service routes take precedence over the
+// global defaults on a matching path; the defaults cover paths a service does not override.
+// It implements the router's static-response resolver so a matching request is served
+// directly, bypassing endpoint selection and the relay.
+//
+// The returned headers map always carries Content-Type (defaulting to text/plain) and is a
+// fresh copy safe for the caller to write onto the response.
+func (c *UnifiedServicesConfig) ResolveStaticResponse(
+	serviceID, path, method string,
+) (body []byte, statusCode int, headers map[string]string, ok bool) {
+	if svc := c.GetServiceConfig(protocol.ServiceID(serviceID)); svc != nil {
+		if rt, found := matchStaticRoute(svc.StaticRoutes, path, method); found {
+			return buildStaticResponse(rt)
+		}
+	}
+	// Defaults are set once at load and read-only thereafter, so no lock is needed.
+	if rt, found := matchStaticRoute(c.Defaults.StaticRoutes, path, method); found {
+		return buildStaticResponse(rt)
+	}
+	return nil, 0, nil, false
+}
+
+// matchStaticRoute returns the first route whose path equals the request path and whose
+// method set is empty (any) or contains the request method (case-insensitive).
+func matchStaticRoute(routes []StaticRoute, path, method string) (StaticRoute, bool) {
+	for _, rt := range routes {
+		if rt.Path != path {
+			continue
+		}
+		if len(rt.Methods) == 0 {
+			return rt, true
+		}
+		for _, m := range rt.Methods {
+			if strings.EqualFold(m, method) {
+				return rt, true
+			}
+		}
+	}
+	return StaticRoute{}, false
+}
+
+// buildStaticResponse materializes a route into a response, applying defaults for status
+// code (200) and Content-Type (text/plain).
+func buildStaticResponse(rt StaticRoute) (body []byte, statusCode int, headers map[string]string, ok bool) {
+	statusCode = rt.StatusCode
+	if statusCode == 0 {
+		statusCode = 200
+	}
+	contentType := rt.ContentType
+	if contentType == "" {
+		contentType = "text/plain; charset=utf-8"
+	}
+	headers = make(map[string]string, len(rt.Headers)+1)
+	for k, v := range rt.Headers {
+		headers[k] = v
+	}
+	headers["Content-Type"] = contentType
+	return []byte(rt.Body), statusCode, headers, true
 }
 
 // GetSyncAllowanceForService returns the sync allowance for a service.

--- a/gateway/unified_service_config.go
+++ b/gateway/unified_service_config.go
@@ -236,6 +236,10 @@ type ServiceDefaults struct {
 	TimeoutConfig        ServiceTimeoutConfig         `yaml:"timeout_config,omitempty"`
 	ActiveHealthChecks   ServiceHealthCheckOverride   `yaml:"active_health_checks,omitempty"`
 	ExternalBlockSources []ExternalBlockSource        `yaml:"external_block_sources,omitempty"`
+
+	// MaxOperatorTrafficShare is the default per-operator concentration cap applied to any
+	// service that does not set its own. nil falls back to DefaultMaxOperatorShare.
+	MaxOperatorTrafficShare *float64 `yaml:"max_operator_traffic_share,omitempty"`
 }
 
 // ServiceConfig defines configuration for a single service.
@@ -263,6 +267,14 @@ type ServiceConfig struct {
 	// Unlike the auto-generated supplier blacklist (which is temporary/session-scoped),
 	// this is a persistent, config-driven blocklist.
 	BlockedSuppliers []string `yaml:"blocked_suppliers,omitempty"`
+
+	// MaxOperatorTrafficShare caps the fraction of this service's endpoint selections that
+	// any single operator (registrable domain / eTLD+1) may receive, bounding the blast
+	// radius of one operator failing when it holds most of the valid endpoint pool. The
+	// excess above the cap is spread across the other valid operators (water-filling).
+	// nil = use the global default (DefaultMaxOperatorShare). A value <= 0 or >= 1 disables
+	// the cap for this service (flat selection ∝ endpoint count).
+	MaxOperatorTrafficShare *float64 `yaml:"max_operator_traffic_share,omitempty"`
 }
 
 // UnifiedServicesConfig is the top-level configuration for the unified service system.
@@ -828,6 +840,29 @@ func (c *UnifiedServicesConfig) GetMergedServiceConfig(serviceID protocol.Servic
 	}
 
 	return &merged
+}
+
+// DefaultMaxOperatorShare is the per-operator concentration cap applied when neither the
+// service nor the global defaults specify one. Shipped ON: no single operator (eTLD+1)
+// receives more than this fraction of a service's endpoint selections when the valid pool
+// spans multiple operators. Tuned from production concentration data — it bounds the
+// clearly-concentrated tail (one operator holding the large majority of a service) while
+// leaving ordinary multi-operator distributions unchanged. Set a per-service or default
+// value of >= 1 (or <= 0) to disable.
+const DefaultMaxOperatorShare = 0.75
+
+// GetMaxOperatorShareForService returns the per-operator concentration cap for a service.
+// It checks per-service config first, then global defaults, then DefaultMaxOperatorShare.
+// A configured value <= 0 or >= 1 disables the cap for that service.
+func (c *UnifiedServicesConfig) GetMaxOperatorShareForService(serviceID protocol.ServiceID) float64 {
+	svc := c.GetServiceConfig(serviceID)
+	if svc != nil && svc.MaxOperatorTrafficShare != nil {
+		return *svc.MaxOperatorTrafficShare
+	}
+	if c.Defaults.MaxOperatorTrafficShare != nil {
+		return *c.Defaults.MaxOperatorTrafficShare
+	}
+	return DefaultMaxOperatorShare
 }
 
 // GetSyncAllowanceForService returns the sync allowance for a service.

--- a/gateway/unified_service_config.go
+++ b/gateway/unified_service_config.go
@@ -277,6 +277,10 @@ type ServiceDefaults struct {
 	// MaxOperatorShare is the default per-operator concentration cap applied to any
 	// service that does not set its own. nil falls back to DefaultMaxOperatorShare.
 	MaxOperatorShare *float64 `yaml:"max_operator_share,omitempty"`
+
+	// WebsocketRebindOperatorUniform is the default WebSocket rebind selection strategy.
+	// nil falls back to DefaultWebsocketRebindOperatorUniform (ON).
+	WebsocketRebindOperatorUniform *bool `yaml:"websocket_rebind_operator_uniform,omitempty"`
 }
 
 // ServiceConfig defines configuration for a single service.
@@ -322,6 +326,18 @@ type ServiceConfig struct {
 	// multi-endpoint selection (parallel fan-out / hedge), which draw from the same
 	// reputation-filtered pool via separate code paths.
 	MaxOperatorShare *float64 `yaml:"max_operator_share,omitempty"`
+
+	// WebsocketRebindOperatorUniform selects the WebSocket rebind strategy for this service.
+	// When true (the default), a session-rollover rebind picks the target operator uniformly
+	// (every provider equally likely), then an endpoint within it — maximizing per-provider
+	// spread. When false, the rebind uses the endpoint-count-weighted concentration cap
+	// (MaxOperatorShare) instead. nil = use the global default
+	// (ServiceDefaults.WebsocketRebindOperatorUniform, then DefaultWebsocketRebindOperatorUniform).
+	//
+	// Note: operator-uniform gives a thin operator the same share as a large one regardless
+	// of endpoint count, so a single-endpoint operator absorbs a full operator-share of the
+	// WebSocket load. Disable per-service if that overloads a small provider.
+	WebsocketRebindOperatorUniform *bool `yaml:"websocket_rebind_operator_uniform,omitempty"`
 }
 
 // UnifiedServicesConfig is the top-level configuration for the unified service system.
@@ -948,6 +964,27 @@ func (c *UnifiedServicesConfig) GetMergedServiceConfig(serviceID protocol.Servic
 // for services with as few as two operators. Set a per-service or default value of >= 1
 // (or <= 0) to disable.
 const DefaultMaxOperatorShare = 0.65
+
+// DefaultWebsocketRebindOperatorUniform is the WebSocket rebind strategy applied when neither
+// the service nor the global defaults specify one. Shipped ON: a session-rollover rebind
+// spreads uniformly across operators (each provider equally likely) rather than by endpoint
+// count, so no single operator accumulates WebSocket connections in proportion to its
+// (often dominant) endpoint share.
+const DefaultWebsocketRebindOperatorUniform = true
+
+// GetWebsocketRebindOperatorUniformForService returns whether the WebSocket rebind should
+// pick the target operator uniformly (true) or via the endpoint-count-weighted concentration
+// cap (false). It checks per-service config first, then global defaults, then
+// DefaultWebsocketRebindOperatorUniform.
+func (c *UnifiedServicesConfig) GetWebsocketRebindOperatorUniformForService(serviceID protocol.ServiceID) bool {
+	if svc := c.GetServiceConfig(serviceID); svc != nil && svc.WebsocketRebindOperatorUniform != nil {
+		return *svc.WebsocketRebindOperatorUniform
+	}
+	if c.Defaults.WebsocketRebindOperatorUniform != nil {
+		return *c.Defaults.WebsocketRebindOperatorUniform
+	}
+	return DefaultWebsocketRebindOperatorUniform
+}
 
 // GetMaxOperatorShareForService returns the per-operator concentration cap for a service.
 // It checks per-service config first, then global defaults, then DefaultMaxOperatorShare.

--- a/gateway/unified_service_config.go
+++ b/gateway/unified_service_config.go
@@ -237,9 +237,9 @@ type ServiceDefaults struct {
 	ActiveHealthChecks   ServiceHealthCheckOverride   `yaml:"active_health_checks,omitempty"`
 	ExternalBlockSources []ExternalBlockSource        `yaml:"external_block_sources,omitempty"`
 
-	// MaxOperatorTrafficShare is the default per-operator concentration cap applied to any
+	// MaxOperatorShare is the default per-operator concentration cap applied to any
 	// service that does not set its own. nil falls back to DefaultMaxOperatorShare.
-	MaxOperatorTrafficShare *float64 `yaml:"max_operator_traffic_share,omitempty"`
+	MaxOperatorShare *float64 `yaml:"max_operator_share,omitempty"`
 }
 
 // ServiceConfig defines configuration for a single service.
@@ -268,13 +268,18 @@ type ServiceConfig struct {
 	// this is a persistent, config-driven blocklist.
 	BlockedSuppliers []string `yaml:"blocked_suppliers,omitempty"`
 
-	// MaxOperatorTrafficShare caps the fraction of this service's endpoint selections that
+	// MaxOperatorShare caps the fraction of this service's endpoint selections that
 	// any single operator (registrable domain / eTLD+1) may receive, bounding the blast
 	// radius of one operator failing when it holds most of the valid endpoint pool. The
 	// excess above the cap is spread across the other valid operators (water-filling).
 	// nil = use the global default (DefaultMaxOperatorShare). A value <= 0 or >= 1 disables
 	// the cap for this service (flat selection ∝ endpoint count).
-	MaxOperatorTrafficShare *float64 `yaml:"max_operator_traffic_share,omitempty"`
+	//
+	// Scope: the cap governs the primary single-endpoint selection (the bulk of traffic,
+	// HTTP and WebSocket, plus the WebSocket rebind target). It does NOT reshape
+	// multi-endpoint selection (parallel fan-out / hedge), which draw from the same
+	// reputation-filtered pool via separate code paths.
+	MaxOperatorShare *float64 `yaml:"max_operator_share,omitempty"`
 }
 
 // UnifiedServicesConfig is the top-level configuration for the unified service system.
@@ -856,11 +861,11 @@ const DefaultMaxOperatorShare = 0.75
 // A configured value <= 0 or >= 1 disables the cap for that service.
 func (c *UnifiedServicesConfig) GetMaxOperatorShareForService(serviceID protocol.ServiceID) float64 {
 	svc := c.GetServiceConfig(serviceID)
-	if svc != nil && svc.MaxOperatorTrafficShare != nil {
-		return *svc.MaxOperatorTrafficShare
+	if svc != nil && svc.MaxOperatorShare != nil {
+		return *svc.MaxOperatorShare
 	}
-	if c.Defaults.MaxOperatorTrafficShare != nil {
-		return *c.Defaults.MaxOperatorTrafficShare
+	if c.Defaults.MaxOperatorShare != nil {
+		return *c.Defaults.MaxOperatorShare
 	}
 	return DefaultMaxOperatorShare
 }

--- a/gateway/unified_service_config.go
+++ b/gateway/unified_service_config.go
@@ -224,7 +224,7 @@ type ServiceFallbackConfig struct {
 
 // StaticRoute defines a fixed response served directly by the gateway for a specific
 // request path, without relaying to a backend endpoint. It lets the gateway expose small,
-// service-scoped metadata endpoints (for example an identity/info route) whose body is a
+// service-scoped metadata endpoints (for example an info/version route) whose body is a
 // constant configured value rather than something fetched from a supplier.
 //
 // A static route short-circuits the relay pipeline: a matching request never reaches
@@ -233,7 +233,7 @@ type ServiceFallbackConfig struct {
 // Matching is exact on Path and, when Methods is set, on the request method.
 type StaticRoute struct {
 	// Path is the exact request path this route serves, matched after the gateway strips
-	// the API-version and portal-app-id prefixes (e.g. "/identity"). Must begin with "/"
+	// the API-version and portal-app-id prefixes (e.g. "/example"). Must begin with "/"
 	// and must not be the relay root ("/") — that would shadow all of a service's traffic.
 	Path string `yaml:"path"`
 

--- a/gateway/websocket_rebind_config_test.go
+++ b/gateway/websocket_rebind_config_test.go
@@ -1,0 +1,32 @@
+package gateway
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// Test_GetWebsocketRebindOperatorUniformForService verifies the resolution order:
+// per-service > global default > DefaultWebsocketRebindOperatorUniform (ON).
+func Test_GetWebsocketRebindOperatorUniformForService(t *testing.T) {
+	c := require.New(t)
+	on, off := true, false
+
+	cfg := &UnifiedServicesConfig{
+		Services: []ServiceConfig{
+			{ID: "explicit-off", WebsocketRebindOperatorUniform: &off},
+			{ID: "explicit-on", WebsocketRebindOperatorUniform: &on},
+			{ID: "inherits"},
+		},
+	}
+
+	c.True(cfg.GetWebsocketRebindOperatorUniformForService("inherits"), "default is ON")
+	c.True(cfg.GetWebsocketRebindOperatorUniformForService("unknown"), "unknown service → default ON")
+	c.False(cfg.GetWebsocketRebindOperatorUniformForService("explicit-off"))
+	c.True(cfg.GetWebsocketRebindOperatorUniformForService("explicit-on"))
+
+	// A global default flips the inheriting services, but a per-service value still wins.
+	cfg.Defaults.WebsocketRebindOperatorUniform = &off
+	c.False(cfg.GetWebsocketRebindOperatorUniformForService("inherits"), "global default overrides to OFF")
+	c.True(cfg.GetWebsocketRebindOperatorUniformForService("explicit-on"), "per-service still wins over the default")
+}

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -834,6 +834,13 @@ const (
 	WSRebindFailedReplay       = "failed_replay"        // reconnected, but building/writing subscription replay frames failed
 	WSRebindFailedSelect       = "failed_select"        // generic selection failure with no more specific reason
 
+	// --- WebSocket session-rebind trigger labels (experimental)
+	// The `trigger` dimension of WebsocketRebindTotal: what initiated the rebind episode,
+	// so the outcome mix can be read per cause (e.g. whether stalls rotate suppliers more
+	// often than routine rollovers).
+	WSRebindTriggerRollover = "rollover" // routine Shannon session-boundary reconnect
+	WSRebindTriggerStall    = "stall"    // staleness watchdog forced a rebind off a silent supplier
+
 	// --- WebSocket endpoint-staleness watchdog result labels (experimental)
 	// The `result` dimension of WebsocketEndpointStallTotal. A stall is a silent supplier
 	// (endpoint transport alive, no subscription data past the staleness threshold) that
@@ -888,9 +895,9 @@ var WebsocketMessagesTotal = promauto.NewCounterVec(
 var WebsocketRebindTotal = promauto.NewCounterVec(
 	prometheus.CounterOpts{
 		Name: MetricPrefix + "websocket_rebind_total",
-		Help: "WebSocket session-rebind episodes by domain, service_id, and result (success_same_supplier/success_different_supplier/failed_*). EXPERIMENTAL.",
+		Help: "WebSocket session-rebind episodes by domain, service_id, result (success_same_supplier/success_different_supplier/failed_*), and trigger (rollover/stall). EXPERIMENTAL.",
 	},
-	[]string{LabelDomain, LabelServiceID, "result"},
+	[]string{LabelDomain, LabelServiceID, "result", "trigger"},
 )
 
 // WebsocketSubscriptionsReplayedTotal counts subscriptions replayed onto a
@@ -1227,9 +1234,10 @@ func RecordWebsocketMessage(domain, serviceID, direction, reputationSignal strin
 
 // RecordWebsocketRebind records a websocket session-rebind episode outcome and, on
 // success, the number of subscriptions replayed. EXPERIMENTAL / canary observability
-// for the session-rebind feature. result should be one of the WSRebind* labels.
-func RecordWebsocketRebind(domain, serviceID, result string, replayedSubscriptions int) {
-	WebsocketRebindTotal.WithLabelValues(domain, serviceID, result).Inc()
+// for the session-rebind feature. result should be one of the WSRebind* labels; trigger
+// one of the WSRebindTrigger* labels (what initiated the rebind).
+func RecordWebsocketRebind(domain, serviceID, result, trigger string, replayedSubscriptions int) {
+	WebsocketRebindTotal.WithLabelValues(domain, serviceID, result, trigger).Inc()
 	if replayedSubscriptions > 0 {
 		WebsocketSubscriptionsReplayedTotal.WithLabelValues(domain, serviceID).Add(float64(replayedSubscriptions))
 	}

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -671,6 +671,27 @@ func RecordConcentrationCapReshaped(serviceID string) {
 	ConcentrationCapReshapedTotal.WithLabelValues(serviceID).Inc()
 }
 
+// ReputationRateCooldownTotal counts endpoints cooled down by the volume-independent
+// sustained-critical-rate detector (as opposed to the consecutive-strike/burst path).
+// The strike system decays 3 strikes per success and therefore only catches bursts; a
+// high-traffic endpoint bleeding a steady fraction of critical/fatal errors refills its
+// strike budget with successes and is never cooled. A nonzero rate on a service_id is the
+// live signal that the rate detector is filtering a chronically-failing high-volume
+// endpoint the burst-strike system would have missed.
+var ReputationRateCooldownTotal = promauto.NewCounterVec(
+	prometheus.CounterOpts{
+		Name: MetricPrefix + "reputation_rate_cooldown_total",
+		Help: "Endpoints cooled down by the sustained-critical-rate detector, by service_id. Nonzero = volume-independent filtering of a chronically-failing endpoint the burst-strike system missed.",
+	},
+	[]string{LabelServiceID},
+)
+
+// RecordReputationRateCooldown increments the rate-cooldown counter for a service.
+// Called once each time an endpoint is cooled down by the sustained-critical-rate detector.
+func RecordReputationRateCooldown(serviceID string) {
+	ReputationRateCooldownTotal.WithLabelValues(serviceID).Inc()
+}
+
 // Severity classes for supplier_signal_total. The reputation layer emits 8
 // distinct signal-type strings; carrying all 8 as a label multiplies this
 // counter's cardinality 8× on top of the (supplier × service_id) base — the

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -692,6 +692,25 @@ func RecordReputationRateCooldown(serviceID string) {
 	ReputationRateCooldownTotal.WithLabelValues(serviceID).Inc()
 }
 
+// ReputationPoolCollapseGuardTotal counts how often reputation filtering would have removed
+// EVERY endpoint for a service (all in cooldown or below threshold) and the pool-collapse
+// guard instead kept the least-bad tier. A nonzero rate is the signal that a service is
+// fully degraded — every endpoint is failing enough to be filtered — and is being served by
+// its least-bad endpoints rather than a reputation-blind random fallback.
+var ReputationPoolCollapseGuardTotal = promauto.NewCounterVec(
+	prometheus.CounterOpts{
+		Name: MetricPrefix + "reputation_pool_collapse_guard_total",
+		Help: "Selections where reputation filtered ALL endpoints and the pool-collapse guard kept the least-bad tier, by service_id and rpc_type. Nonzero = a fully-degraded service being kept reputation-aware instead of falling back to random.",
+	},
+	[]string{LabelServiceID, LabelRPCType},
+)
+
+// RecordReputationPoolCollapseGuard increments the pool-collapse guard counter.
+// Called once each time the guard keeps the least-bad tier because filtering emptied the pool.
+func RecordReputationPoolCollapseGuard(serviceID, rpcType string) {
+	ReputationPoolCollapseGuardTotal.WithLabelValues(serviceID, rpcType).Inc()
+}
+
 // Severity classes for supplier_signal_total. The reputation layer emits 8
 // distinct signal-type strings; carrying all 8 as a label multiplies this
 // counter's cardinality 8× on top of the (supplier × service_id) base — the

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -650,6 +650,27 @@ var HedgeSelfOperatorAvoidedTotal = promauto.NewCounterVec(
 	[]string{LabelServiceID},
 )
 
+// ConcentrationCapReshapedTotal counts endpoint selections whose distribution the
+// per-operator (eTLD+1) concentration cap actually altered — either an operator's share
+// exceeded the cap and its excess was water-filled to other operators, or the pool was
+// too concentrated to satisfy the cap and selection fell back to uniform-over-operators.
+// Selections where no operator exceeded the cap (the cap is a no-op) are NOT counted, so a
+// nonzero rate on a service_id is the live signal that the cap is bounding a real
+// concentration — the operational proof the shipped-on default is doing something.
+var ConcentrationCapReshapedTotal = promauto.NewCounterVec(
+	prometheus.CounterOpts{
+		Name: MetricPrefix + "concentration_cap_reshaped_total",
+		Help: "Endpoint selections reshaped by the per-operator (eTLD+1) concentration cap, by service_id. Nonzero = the cap is actively bounding a dominant operator's selection share.",
+	},
+	[]string{LabelServiceID},
+)
+
+// RecordConcentrationCapReshaped increments the concentration-cap reshape counter for a
+// service. Called once per selection whose distribution the cap actually altered.
+func RecordConcentrationCapReshaped(serviceID string) {
+	ConcentrationCapReshapedTotal.WithLabelValues(serviceID).Inc()
+}
+
 // Severity classes for supplier_signal_total. The reputation layer emits 8
 // distinct signal-type strings; carrying all 8 as a label multiplies this
 // counter's cardinality 8× on top of the (supplier × service_id) base — the

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -129,6 +129,18 @@ var HealthCheckStatus = promauto.NewCounterVec(
 	[]string{LabelDomain, LabelSupplier, LabelRPCType, LabelServiceID, LabelHealthCheckName, LabelReputationSignal},
 )
 
+// HealthCheckDeduped counts health check relays SKIPPED by backend-URL deduplication.
+// Each increment is one supplier×check whose backend-derived result was fanned from a
+// representative sharing the same URL instead of firing its own relay. Compare against
+// path_relays_total{request_type="health_check"} to see the load reduction.
+var HealthCheckDeduped = promauto.NewCounterVec(
+	prometheus.CounterOpts{
+		Name: MetricPrefix + "health_check_deduped_total",
+		Help: "Health check relays skipped via backend-URL dedup (result fanned from a same-URL representative).",
+	},
+	[]string{LabelServiceID},
+)
+
 // =============================================================================
 // Observation Pipeline (Counter)
 // Labels: domain, rpc_type, service_id, network_type, method, reputation_signal
@@ -931,6 +943,11 @@ var WebsocketEndpointStallTotal = promauto.NewCounterVec(
 // RecordHealthCheck records a health check result per supplier
 func RecordHealthCheck(domain, supplier, rpcType, serviceID, healthCheckName, reputationSignal string) {
 	HealthCheckStatus.WithLabelValues(domain, supplier, rpcType, serviceID, healthCheckName, reputationSignal).Inc()
+}
+
+// RecordHealthCheckDeduped records a health check relay skipped via backend-URL dedup.
+func RecordHealthCheckDeduped(serviceID string) {
+	HealthCheckDeduped.WithLabelValues(serviceID).Inc()
 }
 
 // RecordObservation records an observation pipeline event

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -960,6 +960,28 @@ func RecordRetryResult(rpcType, serviceID, retryCount, result string, latencySec
 	RetryResultsLatency.WithLabelValues(rpcType, serviceID, retryCount, result).Observe(latencySeconds)
 }
 
+// RelayExhaustedTotal counts relay requests that exhausted all retry attempts and returned an
+// error (HTTP 500) to the client, by service_id, rpc_type, and category. These 500s are
+// produced on the relay-failure path and are NOT reflected in path_requests_total (which is
+// recorded only for completed relays), so this counter is the visibility into that blind spot
+// — the gap between what the edge proxy sees on the wire and what PATH's own request metric
+// reports. The `capability` category isolates exhaustions where the backend correctly reported
+// unavailable historical/pruned state (a client asking for data the node does not retain),
+// which PATH currently retries as a blockchain error before giving up.
+var RelayExhaustedTotal = promauto.NewCounterVec(
+	prometheus.CounterOpts{
+		Name: MetricPrefix + "relay_exhausted_total",
+		Help: "Relay requests that exhausted all retries and returned 500 to the client, by service_id, rpc_type, and category (capability/heuristic/transport/status). NOT counted in path_requests_total.",
+	},
+	[]string{LabelServiceID, LabelRPCType, "category"},
+)
+
+// RecordRelayExhausted records a relay that exhausted all retries and returned 500 to the
+// client. category classifies the last failure (capability/heuristic/transport/status).
+func RecordRelayExhausted(serviceID, rpcType, category string) {
+	RelayExhaustedTotal.WithLabelValues(serviceID, rpcType, category).Inc()
+}
+
 // =============================================================================
 // Hedge Request Metrics (Counter + Histogram)
 // Labels: rpc_type, service_id, result

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -719,6 +719,13 @@ func supplierSignalSeverity(signalType string) string {
 
 const (
 	// --- Request type labels for relays
+	//
+	// request_type PARTITIONS relays_total: every paid relay PATH sends to a supplier is
+	// recorded under exactly ONE request_type. So "total billable/paid relays" = the sum
+	// across ALL request_type values, NOT just request_type="normal". In particular,
+	// health checks are real paid relays and are counted under request_type="health_check"
+	// — they must NOT be summed on top of "normal" (they are not in it). Filtering to
+	// request_type="normal" gives user-facing primary traffic only.
 
 	RelayTypeNormal      = "normal"
 	RelayTypeHealthCheck = "health_check"
@@ -739,7 +746,7 @@ const (
 var RelaysTotal = promauto.NewCounterVec(
 	prometheus.CounterOpts{
 		Name: MetricPrefix + "relays_total",
-		Help: "Total outgoing relays to suppliers by domain, rpc_type, service_id, status_code, reputation_signal, and request_type.",
+		Help: "Total outgoing (paid) relays to suppliers by domain, rpc_type, service_id, status_code, reputation_signal, and request_type. request_type partitions relays: total paid relays = sum over ALL request_type values (health checks are counted under request_type=\"health_check\", not \"normal\").",
 	},
 	[]string{LabelDomain, LabelRPCType, LabelServiceID, LabelStatusCode, LabelReputationSignal, "request_type"},
 )

--- a/protocol/shannon/context.go
+++ b/protocol/shannon/context.go
@@ -162,6 +162,17 @@ type requestContext struct {
 	// overflow is measurable. Does not affect reputation signals.
 	isRetry bool
 
+	// isHealthCheck marks this request as an active health-check relay issued by the
+	// health-check executor (not user traffic). Set by MarkAsHealthCheck() before
+	// HandleServiceRequest. The health-check executor records its own path_relays_total
+	// entry (request_type="health_check", with health-check-specific signals) for every
+	// outcome, so the Shannon layer SKIPS its RecordRelay for these — otherwise the same
+	// relay was ALSO recorded as request_type="normal", leaving every "excludes health
+	// checks" dashboard panel still containing 100% of health-check volume (phantom
+	// "normal" traffic on services with no user requests). Does not affect reputation
+	// signals or observations.
+	isHealthCheck bool
+
 	// tieredSelector provides access to tier-based selection and probation status.
 	// Used to check if endpoints are in probation when recording success signals.
 	// If non-nil and endpoint is in probation, RecoverySuccessSignal is used instead of SuccessSignal.
@@ -488,6 +499,14 @@ func (rc *requestContext) MarkAsHedge() {
 // `isRetry` (metric request_type only; reputation signals unaffected).
 func (rc *requestContext) MarkAsRetry() {
 	rc.isRetry = true
+}
+
+// MarkAsHealthCheck tags this request as an active health-check relay so the Shannon layer
+// skips its path_relays_total recording (the health-check executor is the sole recorder,
+// avoiding a phantom request_type="normal" double-count). Implements
+// gateway.ProtocolRequestContext. See the field doc on `isHealthCheck`.
+func (rc *requestContext) MarkAsHealthCheck() {
+	rc.isHealthCheck = true
 }
 
 // getSelectedEndpoint returns the currently selected endpoint in a thread-safe manner.
@@ -1248,31 +1267,34 @@ func (rc *requestContext) handleEndpointError(
 			Msg("Skipping domain reputation penalty for blacklisted supplier")
 	}
 
-	// Record relay metric for failed request
-	domain, domainErr := shannonmetrics.ExtractDomainOrHost(string(selectedEndpointAddr))
-	if domainErr != nil {
-		domain = shannonmetrics.ErrDomain
-	}
-	rpcTypeStr := metrics.NormalizeRPCType(rc.getCurrentRPCType().String())
-	reputationSignal := mapSignalTypeToMetricSignal(signal.Type)
+	// Record relay metric for failed request — unless this is a health-check relay, which
+	// the health-check executor records itself (skipping here avoids a phantom "normal").
+	if !rc.isHealthCheck {
+		domain, domainErr := shannonmetrics.ExtractDomainOrHost(string(selectedEndpointAddr))
+		if domainErr != nil {
+			domain = shannonmetrics.ErrDomain
+		}
+		rpcTypeStr := metrics.NormalizeRPCType(rc.getCurrentRPCType().String())
+		reputationSignal := mapSignalTypeToMetricSignal(signal.Type)
 
-	// Extract status code from error if possible, otherwise use "error"
-	statusCodeStr := "error"
-	if statusCode, ok := extractHTTPStatusCode(endpointErr); ok {
-		statusCodeStr = metrics.GetStatusCodeCategory(statusCode)
-	}
+		// Extract status code from error if possible, otherwise use "error"
+		statusCodeStr := "error"
+		if statusCode, ok := extractHTTPStatusCode(endpointErr); ok {
+			statusCodeStr = metrics.GetStatusCodeCategory(statusCode)
+		}
 
-	// Determine relay type - errors are recorded as normal type (probation detection requires success).
-	// Hedge/retry errors are tagged so they don't pollute the per-domain RPS view (hedge and
-	// retry are mutually exclusive request kinds).
-	relayType := metrics.RelayTypeNormal
-	switch {
-	case rc.isHedge:
-		relayType = metrics.RelayTypeHedge
-	case rc.isRetry:
-		relayType = metrics.RelayTypeRetry
+		// Determine relay type - errors are recorded as normal type (probation detection requires success).
+		// Hedge/retry errors are tagged so they don't pollute the per-domain RPS view (hedge and
+		// retry are mutually exclusive request kinds).
+		relayType := metrics.RelayTypeNormal
+		switch {
+		case rc.isHedge:
+			relayType = metrics.RelayTypeHedge
+		case rc.isRetry:
+			relayType = metrics.RelayTypeRetry
+		}
+		metrics.RecordRelay(domain, rpcTypeStr, string(rc.serviceID), statusCodeStr, reputationSignal, relayType, latency.Seconds())
 	}
-	metrics.RecordRelay(domain, rpcTypeStr, string(rc.serviceID), statusCodeStr, reputationSignal, relayType, latency.Seconds())
 
 	// Return the original response (preserving any response bytes) with the error.
 	// This allows the gateway to return the actual backend response to the user
@@ -1416,14 +1438,18 @@ func (rc *requestContext) handleEndpointSuccess(
 		relayType = metrics.RelayTypeRetry
 	}
 
-	// Record relay metric for successful request
-	domain, domainErr := shannonmetrics.ExtractDomainOrHost(string(selectedEndpointAddr))
-	if domainErr != nil {
-		domain = shannonmetrics.ErrDomain
+	// Record relay metric for successful request — unless this is a health-check relay,
+	// which the health-check executor records itself (skipping here avoids a phantom
+	// request_type="normal" duplicate).
+	if !rc.isHealthCheck {
+		domain, domainErr := shannonmetrics.ExtractDomainOrHost(string(selectedEndpointAddr))
+		if domainErr != nil {
+			domain = shannonmetrics.ErrDomain
+		}
+		statusCodeStr := metrics.GetStatusCodeCategory(endpointResponse.HTTPStatusCode)
+		rpcTypeStr := metrics.NormalizeRPCType(rc.getCurrentRPCType().String())
+		metrics.RecordRelay(domain, rpcTypeStr, string(rc.serviceID), statusCodeStr, reputationSignal, relayType, latency.Seconds())
 	}
-	statusCodeStr := metrics.GetStatusCodeCategory(endpointResponse.HTTPStatusCode)
-	rpcTypeStr := metrics.NormalizeRPCType(rc.getCurrentRPCType().String())
-	metrics.RecordRelay(domain, rpcTypeStr, string(rc.serviceID), statusCodeStr, reputationSignal, relayType, latency.Seconds())
 
 	// Return relay response received from endpoint.
 	return nil

--- a/protocol/shannon/healthcheck_tagging_test.go
+++ b/protocol/shannon/healthcheck_tagging_test.go
@@ -1,0 +1,46 @@
+package shannon
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/pokt-network/path/gateway"
+)
+
+// TestRequestContext_SatisfiesProtocolRequestContext_HealthCheck is a compile-time
+// guarantee that *requestContext implements gateway.ProtocolRequestContext including the
+// MarkAsHealthCheck method. If this stops compiling, the interface drifted.
+func TestRequestContext_SatisfiesProtocolRequestContext_HealthCheck(t *testing.T) {
+	var _ gateway.ProtocolRequestContext = (*requestContext)(nil)
+}
+
+// TestMarkAsHealthCheck_SetsFlag verifies that MarkAsHealthCheck flips the isHealthCheck
+// bit, which is what gates the relays_total recording skip in handleEndpointSuccess /
+// handleEndpointError (the health-check executor is the sole recorder, so recording here
+// too would double-count the relay as request_type="normal").
+func TestMarkAsHealthCheck_SetsFlag(t *testing.T) {
+	rc := &requestContext{}
+	require.False(t, rc.isHealthCheck, "default should be false (a normal relay is recorded by the protocol layer)")
+	rc.MarkAsHealthCheck()
+	require.True(t, rc.isHealthCheck, "MarkAsHealthCheck must set isHealthCheck=true so the protocol layer skips its relay metric")
+}
+
+// TestMarkAsHealthCheck_Idempotent verifies calling MarkAsHealthCheck twice is a no-op.
+func TestMarkAsHealthCheck_Idempotent(t *testing.T) {
+	rc := &requestContext{}
+	rc.MarkAsHealthCheck()
+	rc.MarkAsHealthCheck()
+	require.True(t, rc.isHealthCheck)
+}
+
+// TestHealthCheck_IndependentOfHedgeRetry verifies the health-check flag is orthogonal to
+// hedge/retry: a health-check relay is never also a user hedge/retry, and the flags don't
+// interfere.
+func TestHealthCheck_IndependentOfHedgeRetry(t *testing.T) {
+	rc := &requestContext{}
+	rc.MarkAsHealthCheck()
+	require.True(t, rc.isHealthCheck)
+	require.False(t, rc.isHedge)
+	require.False(t, rc.isRetry)
+}

--- a/protocol/shannon/reputation.go
+++ b/protocol/shannon/reputation.go
@@ -122,6 +122,40 @@ func (p *Protocol) filterByReputation(
 		}
 	}
 
+	// Pool-collapse guard: if reputation filtered out EVERY endpoint (all in cooldown or
+	// below threshold), do NOT return empty. An empty result drops the caller to a
+	// reputation-BLIND fallback (random / least-stale) that ignores which endpoints are
+	// actually least-bad — observed making a fully-degraded service worse (e.g. poly-zkevm
+	// went 50%→100% error when every endpoint was cooled and selection fell to random). A
+	// hard bench should relatively deprioritize an endpoint, never remove the last ones
+	// standing when there is no better alternative. Keep the least-bad TIER (the endpoints at
+	// the maximum score) so selection stays reputation-aware over the degraded pool.
+	if len(filtered) == 0 && len(cached) > 0 {
+		scoreOf := func(ak addrKey) float64 {
+			if sc, ok := scores[ak.key]; ok {
+				return sc.Value
+			}
+			return reputation.InitialScore
+		}
+		maxScore := scoreOf(cached[0])
+		for _, ak := range cached[1:] {
+			if v := scoreOf(ak); v > maxScore {
+				maxScore = v
+			}
+		}
+		for _, ak := range cached {
+			if scoreOf(ak) >= maxScore-1e-9 {
+				filtered[ak.addr] = ak.ep
+			}
+		}
+		logger.Warn().
+			Int("total_endpoints", len(cached)).
+			Int("kept_least_bad", len(filtered)).
+			Float64("max_score", maxScore).
+			Msg("Reputation filtered ALL endpoints; keeping the least-bad tier to avoid reputation-blind fallback")
+		metrics.RecordReputationPoolCollapseGuard(serviceIDLabel, rpcTypeLabel)
+	}
+
 	return filtered
 }
 

--- a/protocol/shannon/reputation_test.go
+++ b/protocol/shannon/reputation_test.go
@@ -349,6 +349,55 @@ func TestReputation_FilterByReputation(t *testing.T) {
 	require.NotContains(t, filtered, protocol.EndpointAddr("supplier2-https://bad.example.com"))
 }
 
+// TestReputation_FilterByReputation_PoolCollapseGuard verifies that when EVERY endpoint is
+// below threshold (the whole pool would be filtered out), filterByReputation does not return
+// empty — it keeps the least-bad tier (the highest-scoring endpoint(s)) so selection stays
+// reputation-aware instead of collapsing to a reputation-blind fallback.
+func TestReputation_FilterByReputation_PoolCollapseGuard(t *testing.T) {
+	ctx := context.Background()
+	logger := polyzero.NewLogger()
+
+	config := reputation.Config{
+		Enabled: true, InitialScore: 80, MinThreshold: 30,
+		RecoveryTimeout: 5 * time.Minute, StorageType: "memory",
+	}
+	config.HydrateDefaults()
+	store := reputationstorage.NewMemoryStorage(config.RecoveryTimeout)
+	svc := reputation.NewService(config, store)
+	require.NoError(t, svc.Start(ctx))
+	defer func() { _ = svc.Stop() }()
+
+	p := &Protocol{logger: logger, reputationService: svc}
+	serviceID := protocol.ServiceID("collapse-test")
+
+	endpoints := map[protocol.EndpointAddr]endpoint{
+		"s1-https://a.example.com": &mockEndpoint{addr: "s1-https://a.example.com"},
+		"s2-https://b.example.com": &mockEndpoint{addr: "s2-https://b.example.com"},
+		"s3-https://c.example.com": &mockEndpoint{addr: "s3-https://c.example.com"},
+	}
+	kb := svc.KeyBuilderForService(serviceID)
+	// Drive ALL three below the threshold with Major errors (-10 each; no cooldown, no rate
+	// detector — this isolates the below-threshold collapse). c is the least-bad.
+	//   a,b: 8 major -> score 0    c: 6 major -> score 20   (all < 30 threshold)
+	cKey := kb.BuildKey(serviceID, "s3-https://c.example.com", sharedtypes.RPCType_JSON_RPC)
+	for _, addr := range []protocol.EndpointAddr{"s1-https://a.example.com", "s2-https://b.example.com"} {
+		k := kb.BuildKey(serviceID, addr, sharedtypes.RPCType_JSON_RPC)
+		for i := 0; i < 8; i++ {
+			require.NoError(t, svc.RecordSignal(ctx, k, reputation.NewMajorErrorSignal("degraded", 0)))
+		}
+	}
+	for i := 0; i < 6; i++ {
+		require.NoError(t, svc.RecordSignal(ctx, cKey, reputation.NewMajorErrorSignal("degraded", 0)))
+	}
+
+	filtered := p.filterByReputation(ctx, serviceID, endpoints, sharedtypes.RPCType_JSON_RPC, logger, "")
+
+	// Guard must keep the least-bad endpoint (c, score 20), NOT return an empty pool.
+	require.NotEmpty(t, filtered, "pool-collapse guard must keep the least-bad endpoint(s), not return empty")
+	require.Contains(t, filtered, protocol.EndpointAddr("s3-https://c.example.com"), "the highest-scoring (least-bad) endpoint must be kept")
+	require.Len(t, filtered, 1, "only the least-bad tier (c) should be kept, not the strictly-worse a/b")
+}
+
 // TestReputation_DisabledNoFiltering verifies that when reputation
 // is disabled (nil service), no filtering occurs.
 func TestReputation_DisabledNoFiltering(t *testing.T) {
@@ -1310,9 +1359,15 @@ func TestReputationFiltering_RPCTypeAware(t *testing.T) {
 	serviceID := protocol.ServiceID("eth")
 	endpointAddr := protocol.EndpointAddr("supplier1-https://node.example.com")
 
+	// A second, healthy endpoint so the below-threshold WS endpoint is genuinely excluded
+	// (its presence keeps the WS pool non-empty, so the pool-collapse guard does not fire and
+	// re-admit the bad endpoint as "least-bad"). It gets the initial score for both RPC types.
+	healthyAddr := protocol.EndpointAddr("supplier2-https://healthy.example.com")
+
 	// Create test endpoints
 	endpoints := map[protocol.EndpointAddr]endpoint{
 		endpointAddr: &mockEndpoint{addr: endpointAddr},
+		healthyAddr:  &mockEndpoint{addr: healthyAddr},
 	}
 
 	// Setup: Endpoint has high JSON-RPC score, low WebSocket score.
@@ -1345,15 +1400,15 @@ func TestReputationFiltering_RPCTypeAware(t *testing.T) {
 	require.GreaterOrEqual(t, jsonRpcScore.Value, config.MinThreshold, "JSON-RPC should be above threshold")
 	require.Less(t, websocketScore.Value, config.MinThreshold, "WebSocket should be below threshold")
 
-	// Filter for JSON-RPC → endpoint should be included
+	// Filter for JSON-RPC → the endpoint (high JSON score) should be included.
 	filteredJsonRpc := p.filterByReputation(ctx, serviceID, endpoints, sharedtypes.RPCType_JSON_RPC, logger, "")
-	require.Len(t, filteredJsonRpc, 1, "JSON-RPC filtering should include endpoint (high score)")
-	require.Contains(t, filteredJsonRpc, endpointAddr, "Endpoint should be included for JSON-RPC")
+	require.Contains(t, filteredJsonRpc, endpointAddr, "Endpoint should be included for JSON-RPC (high score)")
 
-	// Filter for WebSocket → endpoint should be excluded
+	// Filter for WebSocket → the endpoint (low WS score) should be excluded, while the healthy
+	// endpoint remains (so the pool is non-empty and the collapse guard does not re-admit it).
 	filteredWebsocket := p.filterByReputation(ctx, serviceID, endpoints, sharedtypes.RPCType_WEBSOCKET, logger, "")
-	require.Len(t, filteredWebsocket, 0, "WebSocket filtering should exclude endpoint (low score)")
-	require.NotContains(t, filteredWebsocket, endpointAddr, "Endpoint should be excluded for WebSocket")
+	require.NotContains(t, filteredWebsocket, endpointAddr, "Endpoint should be excluded for WebSocket (low score)")
+	require.Contains(t, filteredWebsocket, healthyAddr, "Healthy endpoint should remain for WebSocket")
 
 	t.Log("Verified: Filtering respects RPC type - same endpoint included for JSON-RPC, excluded for WebSocket")
 }

--- a/protocol/shannon/reputation_test.go
+++ b/protocol/shannon/reputation_test.go
@@ -312,8 +312,11 @@ func TestReputation_FilterByReputation(t *testing.T) {
 	// - bad endpoint: score 20 (below threshold of 30)
 	// - new endpoint: no score (should be allowed - treated as initial score)
 
-	goodKey := reputation.NewEndpointKey(serviceID, "supplier1-https://good.example.com", sharedtypes.RPCType_JSON_RPC)
-	badKey := reputation.NewEndpointKey(serviceID, "supplier2-https://bad.example.com", sharedtypes.RPCType_JSON_RPC)
+	// Seed scores via the SAME key builder filterByReputation reads with, so the test is
+	// robust to key granularity config (default is per-URL).
+	kb := svc.KeyBuilderForService(serviceID)
+	goodKey := kb.BuildKey(serviceID, "supplier1-https://good.example.com", sharedtypes.RPCType_JSON_RPC)
+	badKey := kb.BuildKey(serviceID, "supplier2-https://bad.example.com", sharedtypes.RPCType_JSON_RPC)
 
 	// Record signals to establish scores
 	// Good endpoint: 1 success -> 80 + 1 = 81
@@ -452,13 +455,15 @@ func TestReputation_WebsocketSignalAttributionAfterRebind(t *testing.T) {
 
 	wrc.recordWebsocketSignal(reputation.NewMajorErrorSignal("ws_endpoint_stalled", 0))
 
-	reboundScore, err := svc.GetScore(ctx, reputation.NewEndpointKey(serviceID, rebound.Addr(), sharedtypes.RPCType_WEBSOCKET))
+	// Read via the same key builder recordWebsocketSignal uses (robust to granularity).
+	kb := svc.KeyBuilderForService(serviceID)
+	reboundScore, err := svc.GetScore(ctx, kb.BuildKey(serviceID, rebound.Addr(), sharedtypes.RPCType_WEBSOCKET))
 	require.NoError(t, err)
 	require.Equal(t, config.InitialScore-10, reboundScore.Value, "rebound (current) supplier must be penalized")
 
 	// The original supplier received no signal, so its key must be absent (ErrNotFound) —
 	// proving the penalty did NOT leak to the pre-rebind endpoint.
-	_, err = svc.GetScore(ctx, reputation.NewEndpointKey(serviceID, original.Addr(), sharedtypes.RPCType_WEBSOCKET))
+	_, err = svc.GetScore(ctx, kb.BuildKey(serviceID, original.Addr(), sharedtypes.RPCType_WEBSOCKET))
 	require.ErrorIs(t, err, reputation.ErrNotFound, "original supplier must NOT be penalized after rebind")
 }
 
@@ -480,8 +485,10 @@ func TestReputation_FilterByReputation_Websocket(t *testing.T) {
 	}
 
 	// Good WS endpoint: 1 success. Bad WS endpoint: 3 critical errors -> below threshold.
-	goodKey := reputation.NewEndpointKey(serviceID, "supplier1-https://good.example.com", sharedtypes.RPCType_WEBSOCKET)
-	badKey := reputation.NewEndpointKey(serviceID, "supplier2-https://bad.example.com", sharedtypes.RPCType_WEBSOCKET)
+	// Seed via the service key builder so keys match filterByReputation (default per-URL).
+	kb := svc.KeyBuilderForService(serviceID)
+	goodKey := kb.BuildKey(serviceID, "supplier1-https://good.example.com", sharedtypes.RPCType_WEBSOCKET)
+	badKey := kb.BuildKey(serviceID, "supplier2-https://bad.example.com", sharedtypes.RPCType_WEBSOCKET)
 	require.NoError(t, svc.RecordSignal(ctx, goodKey, reputation.NewSuccessSignal(100*time.Millisecond)))
 	for i := 0; i < 3; i++ {
 		require.NoError(t, svc.RecordSignal(ctx, badKey, reputation.NewCriticalErrorSignal("service_error", 200*time.Millisecond)))
@@ -514,7 +521,8 @@ func TestReputation_DisqualifiedMetric(t *testing.T) {
 	}
 
 	// Bad WS endpoint: 6 Major errors (-10 each) -> 80-60 = 20 < 30 threshold, no cooldown.
-	badKey := reputation.NewEndpointKey(serviceID, "supplier2-https://bad.example.com", sharedtypes.RPCType_WEBSOCKET)
+	// Seed via the service key builder so keys match filterByReputation (default per-URL).
+	badKey := svc.KeyBuilderForService(serviceID).BuildKey(serviceID, "supplier2-https://bad.example.com", sharedtypes.RPCType_WEBSOCKET)
 	for i := 0; i < 6; i++ {
 		require.NoError(t, svc.RecordSignal(ctx, badKey, reputation.NewMajorErrorSignal("ws_endpoint_stalled", 0)))
 	}
@@ -1142,10 +1150,10 @@ func TestReputation_KeyGranularityDefault(t *testing.T) {
 		MinThreshold:    30,
 		RecoveryTimeout: 5 * time.Minute,
 		StorageType:     "memory",
-		// KeyGranularity not set - should default to per-endpoint
+		// KeyGranularity not set - should default to per-URL
 	}
 	config.HydrateDefaults()
-	require.Equal(t, reputation.KeyGranularityEndpoint, config.KeyGranularity)
+	require.Equal(t, reputation.KeyGranularityURL, config.KeyGranularity)
 
 	store := reputationstorage.NewMemoryStorage(config.RecoveryTimeout)
 	svc := reputation.NewService(config, store)
@@ -1164,16 +1172,17 @@ func TestReputation_KeyGranularityDefault(t *testing.T) {
 	endpoint1Addr := protocol.EndpointAddr("pokt1supplier1-https://node1.example.com")
 	endpoint2Addr := protocol.EndpointAddr("pokt1supplier1-https://node2.example.com")
 
-	// Get the key builder for the service
+	// Get the key builder for the service (default is now per-URL)
 	keyBuilder := svc.KeyBuilderForService(serviceID)
-	require.IsType(t, &reputation.EndpointKeyBuilder{}, keyBuilder)
+	require.IsType(t, &reputation.URLKeyBuilder{}, keyBuilder)
 
-	// Build keys - each endpoint should have a DIFFERENT key
+	// Build keys - each endpoint has a DIFFERENT backend URL, so per-URL keeps them separate
+	// (distinct URLs are never merged — the no-dilution property vs per-domain).
 	key1 := keyBuilder.BuildKey(serviceID, endpoint1Addr, sharedtypes.RPCType_JSON_RPC)
 	key2 := keyBuilder.BuildKey(serviceID, endpoint2Addr, sharedtypes.RPCType_JSON_RPC)
 
-	// Verify keys are different (per-endpoint granularity)
-	require.NotEqual(t, key1, key2, "Each endpoint should have its own key")
+	// Verify keys are different (distinct URLs stay independent)
+	require.NotEqual(t, key1, key2, "Each distinct URL should have its own key")
 
 	// Record critical errors ONLY on endpoint1
 	for i := 0; i < 3; i++ {
@@ -1306,9 +1315,12 @@ func TestReputationFiltering_RPCTypeAware(t *testing.T) {
 		endpointAddr: &mockEndpoint{addr: endpointAddr},
 	}
 
-	// Setup: Endpoint has high JSON-RPC score, low WebSocket score
-	jsonRpcKey := reputation.NewEndpointKey(serviceID, endpointAddr, sharedtypes.RPCType_JSON_RPC)
-	websocketKey := reputation.NewEndpointKey(serviceID, endpointAddr, sharedtypes.RPCType_WEBSOCKET)
+	// Setup: Endpoint has high JSON-RPC score, low WebSocket score.
+	// Build keys via the service key builder so the recorded scores land under the same
+	// keys filterByReputation reads — correct under any key granularity (default per-URL).
+	kb := svc.KeyBuilderForService(serviceID)
+	jsonRpcKey := kb.BuildKey(serviceID, endpointAddr, sharedtypes.RPCType_JSON_RPC)
+	websocketKey := kb.BuildKey(serviceID, endpointAddr, sharedtypes.RPCType_WEBSOCKET)
 
 	// JSON-RPC: Record success to establish a good score
 	// Initial: 80, after success: 81

--- a/protocol/shannon/websocket_context.go
+++ b/protocol/shannon/websocket_context.go
@@ -382,16 +382,49 @@ func (p *Protocol) getReconnectEndpoint(
 	}
 
 	// Per-operator concentration cap for the rebind target (config-driven, shipped ON).
-	// A tier-2/stall rebind otherwise deterministically funnels every connection to the
-	// single smallest-address top-scored endpoint; when scores tie (the common case) this
-	// re-homes an outsized share onto one operator. The cap spreads the tied-best band
-	// across operators, seeded by the connection's original endpoint so the choice stays
-	// reproducible across replays.
 	maxOperatorShare := 0.0
 	if p.unifiedServicesConfig != nil {
 		maxOperatorShare = p.unifiedServicesConfig.GetMaxOperatorShareForService(serviceID)
 	}
 
+	return chooseRebindEndpoint(
+		logger,
+		serviceID,
+		endpoints,
+		preferredAddr,
+		avoidPreferred,
+		maxOperatorShare,
+		p.websocketReconnectScoreFunc(ctx, serviceID, endpoints),
+	)
+}
+
+// chooseRebindEndpoint applies the rebind selection policy to a non-empty candidate set. It
+// is split out of getReconnectEndpoint so the policy is unit-testable without a live session
+// or reputation service — getReconnectEndpoint builds `endpoints`, `maxOperatorShare`, and
+// `scoreOf`, and this decides which one to rebind onto.
+//
+//   - avoidPreferred (staleness watchdog): the currently bound supplier is stalling, so
+//     exclude it and force a different supplier. If it was the only endpoint there is nothing
+//     to escape to → error so the bridge closes the client.
+//   - Cap DISABLED (maxOperatorShare <= 0 or >= 1): keep seamless tier-1 reuse — reuse the
+//     original supplier+URL if still present. Load-bearing: with the cap off the capped
+//     selector collapses to a deterministic smallest-address pick that would funnel every
+//     connection onto one endpoint.
+//   - Cap ENGAGED: skip the reuse shortcut and route through the capped selector so the
+//     connection re-spreads across the tied-best operator band. The original endpoint stays a
+//     candidate, so a rebind that lands back on it is still reported as seamless.
+//
+// Returns (endpoint, differentSupplier, failureReason, error): differentSupplier is true when
+// the rebind re-homed onto a different endpoint than the original.
+func chooseRebindEndpoint(
+	logger polylog.Logger,
+	serviceID protocol.ServiceID,
+	endpoints map[protocol.EndpointAddr]endpoint,
+	preferredAddr protocol.EndpointAddr,
+	avoidPreferred bool,
+	maxOperatorShare float64,
+	scoreOf func(endpoint) float64,
+) (endpoint, bool, string, error) {
 	// Staleness rebind: the current supplier is the one stalling, so exclude it and force
 	// a different supplier. If it was the session's only endpoint, there is nothing to
 	// escape to → fail so the bridge closes the client.
@@ -401,7 +434,7 @@ func (p *Protocol) getReconnectEndpoint(
 			err := fmt.Errorf("%w: service %s new session has no alternate websocket endpoint to escape a stalling supplier", protocol.ErrEndpointUnavailable, serviceID)
 			return nil, false, metrics.WSRebindFailedNoEndpoints, err
 		}
-		ep := selectReconnectEndpointWithCap(serviceID, endpoints, p.websocketReconnectScoreFunc(ctx, serviceID, endpoints), maxOperatorShare)
+		ep := selectReconnectEndpointWithCap(serviceID, endpoints, scoreOf, maxOperatorShare)
 		logger.Warn().
 			Str("stalling_endpoint", string(preferredAddr)).
 			Str("replacement_endpoint", string(ep.Addr())).
@@ -424,7 +457,7 @@ func (p *Protocol) getReconnectEndpoint(
 
 	// Capped rotation (or original rotated out): pick across the tied-best band. The
 	// original endpoint is still in `endpoints` when present, so it remains a candidate.
-	ep := selectReconnectEndpointWithCap(serviceID, endpoints, p.websocketReconnectScoreFunc(ctx, serviceID, endpoints), maxOperatorShare)
+	ep := selectReconnectEndpointWithCap(serviceID, endpoints, scoreOf, maxOperatorShare)
 
 	// A rebind that lands back on the original endpoint is a seamless outcome — same node,
 	// no supplier change to report.

--- a/protocol/shannon/websocket_context.go
+++ b/protocol/shannon/websocket_context.go
@@ -167,9 +167,10 @@ func (p *Protocol) BuildWebsocketRequestContextForEndpoint(
 	// Enable websocket session rebind: track subscriptions and give the bridge a way to
 	// re-select an endpoint for the current session on a rollover. When disabled, both
 	// stay nil and the bridge tears the connection down on a rollover (pre-rebind
-	// behavior). getReconnectEndpoint re-fetches the current session and prefers the
-	// original supplier, falling back to the best-available endpoint if that supplier
-	// rotated out of the new session.
+	// behavior). getReconnectEndpoint re-fetches the current session and re-selects an
+	// endpoint per its rotation policy (with the per-operator cap engaged it re-spreads
+	// across operators rather than pinning the original supplier), falling back to the
+	// best-available endpoint if the original supplier rotated out of the new session.
 	if p.websocketSessionRebindEnabled {
 		wrc.registry = websockets.NewSubscriptionRegistry()
 		wrc.reconnectProvider = func(reconnectCtx context.Context, avoidCurrent bool) (endpoint, bool, string, error) {
@@ -313,26 +314,37 @@ func (p *Protocol) getPreSelectedEndpoint(
 }
 
 // getReconnectEndpoint re-selects a websocket endpoint for the CURRENT session on a
-// session rollover. It is the tier-1/tier-2 rebind selector:
+// session rollover. Its selection policy depends on whether the per-operator concentration
+// cap is engaged for the service:
 //
-//   - Tier 1 (seamless): if the ORIGINAL supplier+URL is still in the new session, reuse
-//     it. Same node → no data seam for the client's subscriptions.
-//   - Tier 2 (survive rotation): if that supplier rotated out — the common case for
-//     large-pool services, where the pinned supplier persists only ~NumSuppliersPerSession
-//     / poolSize of the time — fall back to the best-available endpoint in the new session
-//     so the client's connection survives regardless. Shannon supplier rotation is a
-//     protocol detail; the client only wants uninterrupted RPC data.
+//   - Cap ENGAGED (0 < maxOperatorShare < 1): do NOT auto-prefer the original supplier.
+//     Route every rebind through the capped selector so WebSocket connections re-spread
+//     across the tied-best operator band each session boundary instead of pinning to
+//     whichever supplier was selected first. The original endpoint stays eligible (it is
+//     still in the candidate set), so a 1-endpoint pool never fails and a strictly-best
+//     original still wins — only the tied band is reshuffled. Rotating off a still-present
+//     supplier is cheap: the bridge already replays subscriptions on any rebind.
+//   - Cap DISABLED (maxOperatorShare <= 0 or >= 1): keep the seamless tier-1 behavior — if
+//     the ORIGINAL supplier+URL is still in the new session, reuse it (same node → no data
+//     seam). This is load-bearing: with the cap off the capped selector collapses to a
+//     deterministic smallest-address pick, which would funnel ALL connections onto one
+//     endpoint — strictly worse than pinning.
+//
+// In both cases, if the original supplier rotated OUT of the new session, selection falls
+// back to the best-available endpoint so the client's connection survives regardless.
+// Shannon supplier rotation is a protocol detail; the client only wants uninterrupted data.
 //
 // Only when the new session has zero usable endpoints (or session lookup fails) does it
 // error, letting the bridge fall back to closing the client with reconnect guidance.
 //
 // Returns (endpoint, differentSupplier, failureReason, error): differentSupplier is true
-// when tier-2 chose a new supplier; failureReason is a metrics label on error.
+// when the rebind re-homed the connection onto a different endpoint than the original;
+// failureReason is a metrics label on error.
 //
-// avoidPreferred skips tier-1 and excludes preferredAddr from the candidate set: the
-// staleness watchdog sets it because the currently bound supplier is the one stalling, so
-// reselecting it would just stall again. When it is the only endpoint in the new session,
-// selection fails with WSRebindFailedNoEndpoints and the bridge closes the client.
+// avoidPreferred skips reuse entirely and excludes preferredAddr from the candidate set:
+// the staleness watchdog sets it because the currently bound supplier is the one stalling,
+// so reselecting it would just stall again. When it is the only endpoint in the new
+// session, selection fails with WSRebindFailedNoEndpoints and the bridge closes the client.
 func (p *Protocol) getReconnectEndpoint(
 	ctx context.Context,
 	serviceID protocol.ServiceID,
@@ -398,18 +410,43 @@ func (p *Protocol) getReconnectEndpoint(
 		return ep, true, "", nil
 	}
 
-	// Tier 1: original supplier+URL still present → seamless rebind.
-	if ep, ok := endpoints[preferredAddr]; ok {
+	// Rotation policy hinges on the cap: with it OFF, the capped selector collapses to a
+	// deterministic smallest-address pick that would funnel every connection onto one
+	// endpoint, so keep seamless tier-1 reuse. With it ON, skip the reuse shortcut and let
+	// the capped selector re-spread the connection across the tied-best operator band.
+	capEngaged := maxOperatorShare > 0 && maxOperatorShare < 1
+	if !capEngaged {
+		// Cap disabled: original supplier+URL still present → seamless rebind.
+		if ep, ok := endpoints[preferredAddr]; ok {
+			return ep, false, "", nil
+		}
+	}
+
+	// Capped rotation (or original rotated out): pick across the tied-best band. The
+	// original endpoint is still in `endpoints` when present, so it remains a candidate.
+	ep := selectReconnectEndpointWithCap(serviceID, endpoints, p.websocketReconnectScoreFunc(ctx, serviceID, endpoints), maxOperatorShare)
+
+	// A rebind that lands back on the original endpoint is a seamless outcome — same node,
+	// no supplier change to report.
+	if ep.Addr() == preferredAddr {
 		return ep, false, "", nil
 	}
 
-	// Tier 2: original supplier rotated out of the new session → best-available fallback.
-	ep := selectReconnectEndpointWithCap(serviceID, endpoints, p.websocketReconnectScoreFunc(ctx, serviceID, endpoints), maxOperatorShare)
-	logger.Warn().
-		Str("original_endpoint", string(preferredAddr)).
-		Str("fallback_endpoint", string(ep.Addr())).
-		Str("fallback_supplier", ep.Supplier()).
-		Msg("🔀 [WS-REBIND] original supplier rotated out — rebinding to a different supplier for the current session")
+	// The connection re-homed onto a different endpoint. Distinguish an intentional rotation
+	// off a still-present supplier from the original having rotated out of the new session.
+	if _, originalStillPresent := endpoints[preferredAddr]; originalStillPresent {
+		logger.Info().
+			Str("original_endpoint", string(preferredAddr)).
+			Str("rebind_endpoint", string(ep.Addr())).
+			Str("rebind_supplier", ep.Supplier()).
+			Msg("🔀 [WS-REBIND-ROTATE] rotating off the still-present original supplier to spread WebSocket load across operators")
+	} else {
+		logger.Warn().
+			Str("original_endpoint", string(preferredAddr)).
+			Str("fallback_endpoint", string(ep.Addr())).
+			Str("fallback_supplier", ep.Supplier()).
+			Msg("🔀 [WS-REBIND] original supplier rotated out — rebinding to a different supplier for the current session")
+	}
 	return ep, true, "", nil
 }
 

--- a/protocol/shannon/websocket_context.go
+++ b/protocol/shannon/websocket_context.go
@@ -5,10 +5,8 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
-	"hash/fnv"
 	"math"
 	"net/http"
-	"sort"
 	"strconv"
 	"time"
 
@@ -391,7 +389,7 @@ func (p *Protocol) getReconnectEndpoint(
 			err := fmt.Errorf("%w: service %s new session has no alternate websocket endpoint to escape a stalling supplier", protocol.ErrEndpointUnavailable, serviceID)
 			return nil, false, metrics.WSRebindFailedNoEndpoints, err
 		}
-		ep := selectReconnectEndpointWithCap(endpoints, p.websocketReconnectScoreFunc(ctx, serviceID, endpoints), maxOperatorShare, preferredAddr)
+		ep := selectReconnectEndpointWithCap(endpoints, p.websocketReconnectScoreFunc(ctx, serviceID, endpoints), maxOperatorShare)
 		logger.Warn().
 			Str("stalling_endpoint", string(preferredAddr)).
 			Str("replacement_endpoint", string(ep.Addr())).
@@ -406,7 +404,7 @@ func (p *Protocol) getReconnectEndpoint(
 	}
 
 	// Tier 2: original supplier rotated out of the new session → best-available fallback.
-	ep := selectReconnectEndpointWithCap(endpoints, p.websocketReconnectScoreFunc(ctx, serviceID, endpoints), maxOperatorShare, preferredAddr)
+	ep := selectReconnectEndpointWithCap(endpoints, p.websocketReconnectScoreFunc(ctx, serviceID, endpoints), maxOperatorShare)
 	logger.Warn().
 		Str("original_endpoint", string(preferredAddr)).
 		Str("fallback_endpoint", string(ep.Addr())).
@@ -447,14 +445,15 @@ const reconnectScoreEpsilon = 1e-9
 // identical to selectBestReconnectEndpoint — the deterministic (non-fallback, highest
 // score, smallest address) pick. With the cap enabled it takes the set of endpoints tied
 // for best (same capability tier + top score — the candidates the deterministic pick
-// would break by address) and spreads them across operators via the shared concentration
-// cap, seeded by seedAddr (the connection's original endpoint, stable for its lifetime) so
-// the choice is reproducible across replays and pods.
+// would otherwise break by address) and spreads them across operators via the shared
+// concentration cap. The spread is a plain random pick: a WebSocket connection re-selects
+// fresh at every session boundary, so there is no value in a per-connection-stable choice
+// — and randomness also lets a reconnect *retry* land on a different endpoint than the one
+// that just failed to dial.
 func selectReconnectEndpointWithCap(
 	endpoints map[protocol.EndpointAddr]endpoint,
 	scoreOf func(endpoint) float64,
 	maxOperatorShare float64,
-	seedAddr protocol.EndpointAddr,
 ) endpoint {
 	if maxOperatorShare <= 0 || maxOperatorShare >= 1 || len(endpoints) <= 1 {
 		return selectBestReconnectEndpoint(endpoints, scoreOf)
@@ -465,12 +464,7 @@ func selectReconnectEndpointWithCap(
 		return selectBestReconnectEndpoint(endpoints, scoreOf)
 	}
 
-	// Stable order so the seeded concentration pick is deterministic (map iteration is not).
-	sort.Slice(band, func(i, j int) bool { return band[i] < band[j] })
-
-	h := fnv.New64a()
-	_, _ = h.Write([]byte(seedAddr))
-	chosen := selector.SelectWithConcentrationCapSeeded(band, maxOperatorShare, int64(h.Sum64()))
+	chosen := selector.SelectWithConcentrationCap(band, maxOperatorShare)
 	if ep, ok := endpoints[chosen]; ok {
 		return ep
 	}

--- a/protocol/shannon/websocket_context.go
+++ b/protocol/shannon/websocket_context.go
@@ -434,10 +434,6 @@ func selectBestReconnectEndpoint(endpoints map[protocol.EndpointAddr]endpoint, s
 	return best
 }
 
-// reconnectScoreEpsilon is the tolerance within which two reconnect candidates count as
-// tied on reputation score (scores are ~100-scale floats; exact equality is too brittle).
-const reconnectScoreEpsilon = 1e-9
-
 // selectReconnectEndpointWithCap chooses a rebind target, applying the per-operator
 // concentration cap when enabled.
 //
@@ -477,6 +473,12 @@ func selectReconnectEndpointWithCap(
 // reconnectTopBand returns the endpoint addresses tied for best under the
 // (non-fallback preferred, then highest score) ordering — exactly the candidates
 // selectBestReconnectEndpoint would otherwise break by smallest address.
+//
+// "Tied for best" uses exact score equality, matching betterReconnectCandidate (the
+// disabled-path picker), so both paths agree on which endpoints are tied. Reputation
+// scores are shared values (a stored score, or the same InitialScore constant for unscored
+// endpoints), so exact equality is the right test — no float tolerance is needed, and an
+// epsilon band here would disagree with the exact comparison there.
 func reconnectTopBand(endpoints map[protocol.EndpointAddr]endpoint, scoreOf func(endpoint) float64) []protocol.EndpointAddr {
 	hasNonFallback := false
 	for _, ep := range endpoints {
@@ -501,7 +503,7 @@ func reconnectTopBand(endpoints map[protocol.EndpointAddr]endpoint, scoreOf func
 		if hasNonFallback && ep.IsFallback() {
 			continue
 		}
-		if scoreOf(ep) >= maxScore-reconnectScoreEpsilon {
+		if scoreOf(ep) >= maxScore {
 			band = append(band, addr)
 		}
 	}

--- a/protocol/shannon/websocket_context.go
+++ b/protocol/shannon/websocket_context.go
@@ -91,6 +91,11 @@ type websocketRequestContext struct {
 	// failed selection or dial, consumed by OnReconnectOutcome. Bridge-goroutine only.
 	lastReconnectReason string
 
+	// lastReconnectTrigger holds what initiated the most recent rebind episode
+	// (WSRebindTriggerRollover / WSRebindTriggerStall), consumed by OnReconnectOutcome to
+	// tag the metric. Bridge-goroutine only.
+	lastReconnectTrigger string
+
 	// reputationService tracks endpoint reputation scores.
 	// If non-nil, signals are recorded on success/error for gradual reputation tracking.
 	reputationService reputation.ReputationService
@@ -381,10 +386,15 @@ func (p *Protocol) getReconnectEndpoint(
 		return nil, false, metrics.WSRebindFailedNoEndpoints, err
 	}
 
-	// Per-operator concentration cap for the rebind target (config-driven, shipped ON).
+	// Rebind selection strategy (config-driven, both shipped ON):
+	//   - operatorUniform: spread the rebind target uniformly across operators.
+	//   - maxOperatorShare: the endpoint-count-weighted concentration cap, used when
+	//     operator-uniform is disabled.
 	maxOperatorShare := 0.0
+	operatorUniform := gateway.DefaultWebsocketRebindOperatorUniform
 	if p.unifiedServicesConfig != nil {
 		maxOperatorShare = p.unifiedServicesConfig.GetMaxOperatorShareForService(serviceID)
+		operatorUniform = p.unifiedServicesConfig.GetWebsocketRebindOperatorUniformForService(serviceID)
 	}
 
 	return chooseRebindEndpoint(
@@ -394,6 +404,7 @@ func (p *Protocol) getReconnectEndpoint(
 		preferredAddr,
 		avoidPreferred,
 		maxOperatorShare,
+		operatorUniform,
 		p.websocketReconnectScoreFunc(ctx, serviceID, endpoints),
 	)
 }
@@ -406,13 +417,17 @@ func (p *Protocol) getReconnectEndpoint(
 //   - avoidPreferred (staleness watchdog): the currently bound supplier is stalling, so
 //     exclude it and force a different supplier. If it was the only endpoint there is nothing
 //     to escape to → error so the bridge closes the client.
-//   - Cap DISABLED (maxOperatorShare <= 0 or >= 1): keep seamless tier-1 reuse — reuse the
-//     original supplier+URL if still present. Load-bearing: with the cap off the capped
-//     selector collapses to a deterministic smallest-address pick that would funnel every
-//     connection onto one endpoint.
-//   - Cap ENGAGED: skip the reuse shortcut and route through the capped selector so the
-//     connection re-spreads across the tied-best operator band. The original endpoint stays a
-//     candidate, so a rebind that lands back on it is still reported as seamless.
+//   - ROTATE (operator-uniform on, or the concentration cap engaged): skip the reuse shortcut
+//     and route through the selected strategy so the connection re-spreads across operators.
+//     The original endpoint stays a candidate, so a rebind that lands back on it is still
+//     reported as seamless.
+//   - PIN (operator-uniform off AND cap disabled): keep seamless tier-1 reuse — reuse the
+//     original supplier+URL if still present. Load-bearing when the cap is the only strategy:
+//     with it off the capped selector collapses to a deterministic smallest-address pick that
+//     would funnel every connection onto one endpoint.
+//
+// operatorUniform selects the rotation strategy: uniform-over-operators (true) vs the
+// endpoint-count-weighted concentration cap (false).
 //
 // Returns (endpoint, differentSupplier, failureReason, error): differentSupplier is true when
 // the rebind re-homed onto a different endpoint than the original.
@@ -423,6 +438,7 @@ func chooseRebindEndpoint(
 	preferredAddr protocol.EndpointAddr,
 	avoidPreferred bool,
 	maxOperatorShare float64,
+	operatorUniform bool,
 	scoreOf func(endpoint) float64,
 ) (endpoint, bool, string, error) {
 	// Staleness rebind: the current supplier is the one stalling, so exclude it and force
@@ -434,7 +450,7 @@ func chooseRebindEndpoint(
 			err := fmt.Errorf("%w: service %s new session has no alternate websocket endpoint to escape a stalling supplier", protocol.ErrEndpointUnavailable, serviceID)
 			return nil, false, metrics.WSRebindFailedNoEndpoints, err
 		}
-		ep := selectReconnectEndpointWithCap(serviceID, endpoints, scoreOf, maxOperatorShare)
+		ep := selectRebindEndpoint(serviceID, endpoints, scoreOf, maxOperatorShare, operatorUniform)
 		logger.Warn().
 			Str("stalling_endpoint", string(preferredAddr)).
 			Str("replacement_endpoint", string(ep.Addr())).
@@ -443,21 +459,21 @@ func chooseRebindEndpoint(
 		return ep, true, "", nil
 	}
 
-	// Rotation policy hinges on the cap: with it OFF, the capped selector collapses to a
-	// deterministic smallest-address pick that would funnel every connection onto one
-	// endpoint, so keep seamless tier-1 reuse. With it ON, skip the reuse shortcut and let
-	// the capped selector re-spread the connection across the tied-best operator band.
-	capEngaged := maxOperatorShare > 0 && maxOperatorShare < 1
-	if !capEngaged {
-		// Cap disabled: original supplier+URL still present → seamless rebind.
+	// Rotate when a spreading strategy is active (operator-uniform, or the cap engaged).
+	// Otherwise (both off) keep seamless tier-1 reuse: the disabled cap selector collapses to
+	// a deterministic smallest-address pick that would funnel every connection onto one
+	// endpoint, so reusing the original is strictly better than rotating there.
+	rotate := operatorUniform || (maxOperatorShare > 0 && maxOperatorShare < 1)
+	if !rotate {
+		// Pin: original supplier+URL still present → seamless rebind.
 		if ep, ok := endpoints[preferredAddr]; ok {
 			return ep, false, "", nil
 		}
 	}
 
-	// Capped rotation (or original rotated out): pick across the tied-best band. The
+	// Rotation (or original rotated out): pick a target via the selected strategy. The
 	// original endpoint is still in `endpoints` when present, so it remains a candidate.
-	ep := selectReconnectEndpointWithCap(serviceID, endpoints, scoreOf, maxOperatorShare)
+	ep := selectRebindEndpoint(serviceID, endpoints, scoreOf, maxOperatorShare, operatorUniform)
 
 	// A rebind that lands back on the original endpoint is a seamless outcome — same node,
 	// no supplier change to report.
@@ -481,6 +497,50 @@ func chooseRebindEndpoint(
 			Msg("🔀 [WS-REBIND] original supplier rotated out — rebinding to a different supplier for the current session")
 	}
 	return ep, true, "", nil
+}
+
+// selectRebindEndpoint dispatches to the configured rebind selection strategy:
+// operator-uniform spread (operatorUniform=true) or the endpoint-count-weighted
+// concentration cap (false). Both operate over the tied-best band and fall back to the
+// deterministic pick when there is nothing to spread.
+func selectRebindEndpoint(
+	serviceID protocol.ServiceID,
+	endpoints map[protocol.EndpointAddr]endpoint,
+	scoreOf func(endpoint) float64,
+	maxOperatorShare float64,
+	operatorUniform bool,
+) endpoint {
+	if operatorUniform {
+		return selectReconnectEndpointOperatorUniform(serviceID, endpoints, scoreOf)
+	}
+	return selectReconnectEndpointWithCap(serviceID, endpoints, scoreOf, maxOperatorShare)
+}
+
+// selectReconnectEndpointOperatorUniform picks a rebind target so every operator in the
+// tied-best band is equally likely (then an endpoint uniformly within it) — the strongest
+// per-provider spread, giving a thin operator the same share as a large one. Restricting to
+// the tied-best band keeps selection reputation-aware (a degraded endpoint is never a rebind
+// target just because its operator is thin). With a single candidate or a single-endpoint
+// band it reduces to the deterministic pick.
+func selectReconnectEndpointOperatorUniform(
+	serviceID protocol.ServiceID,
+	endpoints map[protocol.EndpointAddr]endpoint,
+	scoreOf func(endpoint) float64,
+) endpoint {
+	if len(endpoints) <= 1 {
+		return selectBestReconnectEndpoint(endpoints, scoreOf)
+	}
+	band := reconnectTopBand(endpoints, scoreOf)
+	if len(band) <= 1 {
+		return selectBestReconnectEndpoint(endpoints, scoreOf)
+	}
+	chosen := selector.SelectOperatorUniform(serviceID, band)
+	if ep, ok := endpoints[chosen]; ok {
+		return ep
+	}
+	// Defensive: SelectOperatorUniform always returns a band member; fall back rather than
+	// return nil if that ever changes.
+	return selectBestReconnectEndpoint(endpoints, scoreOf)
 }
 
 // selectBestReconnectEndpoint chooses an endpoint from the new session for a tier-2 rebind
@@ -959,6 +1019,14 @@ func (wrc *websocketRequestContext) ReconnectEndpoint(ctx context.Context, avoid
 		return nil, fmt.Errorf("websocket session rebind not configured")
 	}
 
+	// Record what triggered this rebind so OnReconnectOutcome can tag the metric: the
+	// staleness watchdog sets avoidCurrentSupplier, everything else is a routine rollover.
+	if avoidCurrentSupplier {
+		wrc.lastReconnectTrigger = metrics.WSRebindTriggerStall
+	} else {
+		wrc.lastReconnectTrigger = metrics.WSRebindTriggerRollover
+	}
+
 	// Re-select an endpoint for the current session: the original supplier if it is still
 	// in the new session (seamless), else the best-available endpoint (tier-2). When
 	// avoidCurrentSupplier is set (staleness watchdog), the original supplier is excluded
@@ -1059,7 +1127,11 @@ func (wrc *websocketRequestContext) OnReconnectOutcome(success bool, replayedSub
 	serviceID := string(wrc.serviceID)
 
 	result := wrc.reconnectResultLabel(success, stage)
-	metrics.RecordWebsocketRebind(domain, serviceID, result, replayedSubscriptions)
+	trigger := wrc.lastReconnectTrigger
+	if trigger == "" {
+		trigger = metrics.WSRebindTriggerRollover
+	}
+	metrics.RecordWebsocketRebind(domain, serviceID, result, trigger, replayedSubscriptions)
 
 	// Error level ON PURPOSE for canary visibility. Temporary — downgrade once validated.
 	wrc.logger.Error().
@@ -1067,6 +1139,7 @@ func (wrc *websocketRequestContext) OnReconnectOutcome(success bool, replayedSub
 		Bool("different_supplier", wrc.lastReconnectDifferentSupplier).
 		Int("replayed_subscriptions", replayedSubscriptions).
 		Str("result", result).
+		Str("trigger", trigger).
 		Msg("📈 [WS-REBIND] rebind outcome recorded")
 }
 

--- a/protocol/shannon/websocket_context.go
+++ b/protocol/shannon/websocket_context.go
@@ -5,7 +5,10 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
+	"hash/fnv"
+	"math"
 	"net/http"
+	"sort"
 	"strconv"
 	"time"
 
@@ -22,6 +25,7 @@ import (
 	"github.com/pokt-network/path/observation"
 	protocolobservations "github.com/pokt-network/path/observation/protocol"
 	"github.com/pokt-network/path/protocol"
+	"github.com/pokt-network/path/qos/selector"
 	"github.com/pokt-network/path/reputation"
 	"github.com/pokt-network/path/request"
 	"github.com/pokt-network/path/websockets"
@@ -367,6 +371,17 @@ func (p *Protocol) getReconnectEndpoint(
 		return nil, false, metrics.WSRebindFailedNoEndpoints, err
 	}
 
+	// Per-operator concentration cap for the rebind target (config-driven, shipped ON).
+	// A tier-2/stall rebind otherwise deterministically funnels every connection to the
+	// single smallest-address top-scored endpoint; when scores tie (the common case) this
+	// re-homes an outsized share onto one operator. The cap spreads the tied-best band
+	// across operators, seeded by the connection's original endpoint so the choice stays
+	// reproducible across replays.
+	maxOperatorShare := 0.0
+	if p.unifiedServicesConfig != nil {
+		maxOperatorShare = p.unifiedServicesConfig.GetMaxOperatorShareForService(serviceID)
+	}
+
 	// Staleness rebind: the current supplier is the one stalling, so exclude it and force
 	// a different supplier. If it was the session's only endpoint, there is nothing to
 	// escape to → fail so the bridge closes the client.
@@ -376,7 +391,7 @@ func (p *Protocol) getReconnectEndpoint(
 			err := fmt.Errorf("%w: service %s new session has no alternate websocket endpoint to escape a stalling supplier", protocol.ErrEndpointUnavailable, serviceID)
 			return nil, false, metrics.WSRebindFailedNoEndpoints, err
 		}
-		ep := selectBestReconnectEndpoint(endpoints, p.websocketReconnectScoreFunc(ctx, serviceID, endpoints))
+		ep := selectReconnectEndpointWithCap(endpoints, p.websocketReconnectScoreFunc(ctx, serviceID, endpoints), maxOperatorShare, preferredAddr)
 		logger.Warn().
 			Str("stalling_endpoint", string(preferredAddr)).
 			Str("replacement_endpoint", string(ep.Addr())).
@@ -391,7 +406,7 @@ func (p *Protocol) getReconnectEndpoint(
 	}
 
 	// Tier 2: original supplier rotated out of the new session → best-available fallback.
-	ep := selectBestReconnectEndpoint(endpoints, p.websocketReconnectScoreFunc(ctx, serviceID, endpoints))
+	ep := selectReconnectEndpointWithCap(endpoints, p.websocketReconnectScoreFunc(ctx, serviceID, endpoints), maxOperatorShare, preferredAddr)
 	logger.Warn().
 		Str("original_endpoint", string(preferredAddr)).
 		Str("fallback_endpoint", string(ep.Addr())).
@@ -419,6 +434,83 @@ func selectBestReconnectEndpoint(endpoints map[protocol.EndpointAddr]endpoint, s
 		}
 	}
 	return best
+}
+
+// reconnectScoreEpsilon is the tolerance within which two reconnect candidates count as
+// tied on reputation score (scores are ~100-scale floats; exact equality is too brittle).
+const reconnectScoreEpsilon = 1e-9
+
+// selectReconnectEndpointWithCap chooses a rebind target, applying the per-operator
+// concentration cap when enabled.
+//
+// With the cap disabled (maxOperatorShare <= 0 or >= 1) or nothing to reshape it is
+// identical to selectBestReconnectEndpoint — the deterministic (non-fallback, highest
+// score, smallest address) pick. With the cap enabled it takes the set of endpoints tied
+// for best (same capability tier + top score — the candidates the deterministic pick
+// would break by address) and spreads them across operators via the shared concentration
+// cap, seeded by seedAddr (the connection's original endpoint, stable for its lifetime) so
+// the choice is reproducible across replays and pods.
+func selectReconnectEndpointWithCap(
+	endpoints map[protocol.EndpointAddr]endpoint,
+	scoreOf func(endpoint) float64,
+	maxOperatorShare float64,
+	seedAddr protocol.EndpointAddr,
+) endpoint {
+	if maxOperatorShare <= 0 || maxOperatorShare >= 1 || len(endpoints) <= 1 {
+		return selectBestReconnectEndpoint(endpoints, scoreOf)
+	}
+
+	band := reconnectTopBand(endpoints, scoreOf)
+	if len(band) <= 1 {
+		return selectBestReconnectEndpoint(endpoints, scoreOf)
+	}
+
+	// Stable order so the seeded concentration pick is deterministic (map iteration is not).
+	sort.Slice(band, func(i, j int) bool { return band[i] < band[j] })
+
+	h := fnv.New64a()
+	_, _ = h.Write([]byte(seedAddr))
+	chosen := selector.SelectWithConcentrationCapSeeded(band, maxOperatorShare, int64(h.Sum64()))
+	if ep, ok := endpoints[chosen]; ok {
+		return ep
+	}
+	// Defensive: the helper always returns a member of the band, but fall back rather than
+	// return nil if that ever changes.
+	return selectBestReconnectEndpoint(endpoints, scoreOf)
+}
+
+// reconnectTopBand returns the endpoint addresses tied for best under the
+// (non-fallback preferred, then highest score) ordering — exactly the candidates
+// selectBestReconnectEndpoint would otherwise break by smallest address.
+func reconnectTopBand(endpoints map[protocol.EndpointAddr]endpoint, scoreOf func(endpoint) float64) []protocol.EndpointAddr {
+	hasNonFallback := false
+	for _, ep := range endpoints {
+		if !ep.IsFallback() {
+			hasNonFallback = true
+			break
+		}
+	}
+
+	maxScore := math.Inf(-1)
+	for _, ep := range endpoints {
+		if hasNonFallback && ep.IsFallback() {
+			continue
+		}
+		if s := scoreOf(ep); s > maxScore {
+			maxScore = s
+		}
+	}
+
+	var band []protocol.EndpointAddr
+	for addr, ep := range endpoints {
+		if hasNonFallback && ep.IsFallback() {
+			continue
+		}
+		if scoreOf(ep) >= maxScore-reconnectScoreEpsilon {
+			band = append(band, addr)
+		}
+	}
+	return band
 }
 
 // betterReconnectCandidate reports whether a is a better rebind target than b:

--- a/protocol/shannon/websocket_context.go
+++ b/protocol/shannon/websocket_context.go
@@ -389,7 +389,7 @@ func (p *Protocol) getReconnectEndpoint(
 			err := fmt.Errorf("%w: service %s new session has no alternate websocket endpoint to escape a stalling supplier", protocol.ErrEndpointUnavailable, serviceID)
 			return nil, false, metrics.WSRebindFailedNoEndpoints, err
 		}
-		ep := selectReconnectEndpointWithCap(endpoints, p.websocketReconnectScoreFunc(ctx, serviceID, endpoints), maxOperatorShare)
+		ep := selectReconnectEndpointWithCap(serviceID, endpoints, p.websocketReconnectScoreFunc(ctx, serviceID, endpoints), maxOperatorShare)
 		logger.Warn().
 			Str("stalling_endpoint", string(preferredAddr)).
 			Str("replacement_endpoint", string(ep.Addr())).
@@ -404,7 +404,7 @@ func (p *Protocol) getReconnectEndpoint(
 	}
 
 	// Tier 2: original supplier rotated out of the new session → best-available fallback.
-	ep := selectReconnectEndpointWithCap(endpoints, p.websocketReconnectScoreFunc(ctx, serviceID, endpoints), maxOperatorShare)
+	ep := selectReconnectEndpointWithCap(serviceID, endpoints, p.websocketReconnectScoreFunc(ctx, serviceID, endpoints), maxOperatorShare)
 	logger.Warn().
 		Str("original_endpoint", string(preferredAddr)).
 		Str("fallback_endpoint", string(ep.Addr())).
@@ -451,6 +451,7 @@ const reconnectScoreEpsilon = 1e-9
 // — and randomness also lets a reconnect *retry* land on a different endpoint than the one
 // that just failed to dial.
 func selectReconnectEndpointWithCap(
+	serviceID protocol.ServiceID,
 	endpoints map[protocol.EndpointAddr]endpoint,
 	scoreOf func(endpoint) float64,
 	maxOperatorShare float64,
@@ -464,7 +465,7 @@ func selectReconnectEndpointWithCap(
 		return selectBestReconnectEndpoint(endpoints, scoreOf)
 	}
 
-	chosen := selector.SelectWithConcentrationCap(band, maxOperatorShare)
+	chosen := selector.SelectWithConcentrationCap(serviceID, band, maxOperatorShare)
 	if ep, ok := endpoints[chosen]; ok {
 		return ep
 	}

--- a/protocol/shannon/websocket_rebind_policy_test.go
+++ b/protocol/shannon/websocket_rebind_policy_test.go
@@ -33,7 +33,7 @@ func Test_chooseRebindEndpoint_CapDisabled_ReusesOriginal(t *testing.T) {
 
 	for _, disabled := range []float64{0.0, 1.0, -1.0} {
 		ep, different, reason, err := chooseRebindEndpoint(
-			testLogger(), "svc", cloneEndpoints(endpoints), preferred, false, disabled, noScore,
+			testLogger(), "svc", cloneEndpoints(endpoints), preferred, false, disabled, false, noScore,
 		)
 		c.NoError(err)
 		c.Empty(reason)
@@ -52,7 +52,7 @@ func Test_chooseRebindEndpoint_CapDisabled_OriginalRotatedOut(t *testing.T) {
 	ghost := protocol.EndpointAddr("pokt1ghost-https://n.ghost.tech") // not in the session
 
 	ep, different, reason, err := chooseRebindEndpoint(
-		testLogger(), "svc", cloneEndpoints(endpoints), ghost, false, 0.0, noScore,
+		testLogger(), "svc", cloneEndpoints(endpoints), ghost, false, 0.0, false, noScore,
 	)
 	c.NoError(err)
 	c.Empty(reason)
@@ -79,7 +79,7 @@ func Test_chooseRebindEndpoint_CapEngaged_SpreadsAcrossOperators(t *testing.T) {
 	rotatedOff := false
 	for i := 0; i < 400; i++ {
 		ep, different, reason, err := chooseRebindEndpoint(
-			testLogger(), "svc", cloneEndpoints(endpoints), preferred, false, 0.5, noScore,
+			testLogger(), "svc", cloneEndpoints(endpoints), preferred, false, 0.5, false, noScore,
 		)
 		c.NoError(err)
 		c.Empty(reason)
@@ -106,7 +106,7 @@ func Test_chooseRebindEndpoint_CapEngaged_SingleEndpointNeverFails(t *testing.T)
 	endpoints := map[protocol.EndpointAddr]endpoint{solo.Addr(): solo}
 
 	ep, different, reason, err := chooseRebindEndpoint(
-		testLogger(), "svc", cloneEndpoints(endpoints), solo.Addr(), false, 0.5, noScore,
+		testLogger(), "svc", cloneEndpoints(endpoints), solo.Addr(), false, 0.5, false, noScore,
 	)
 	c.NoError(err)
 	c.Empty(reason)
@@ -134,7 +134,7 @@ func Test_chooseRebindEndpoint_CapEngaged_StrictlyBestOriginalWins(t *testing.T)
 
 	for i := 0; i < 50; i++ {
 		ep, different, reason, err := chooseRebindEndpoint(
-			testLogger(), "svc", cloneEndpoints(endpoints), best.Addr(), false, 0.5, scoreOf,
+			testLogger(), "svc", cloneEndpoints(endpoints), best.Addr(), false, 0.5, false, scoreOf,
 		)
 		c.NoError(err)
 		c.Empty(reason)
@@ -152,7 +152,7 @@ func Test_chooseRebindEndpoint_CapEngaged_OriginalRotatedOut(t *testing.T) {
 	ghost := protocol.EndpointAddr("pokt1ghost-https://n.ghost.tech")
 
 	ep, different, reason, err := chooseRebindEndpoint(
-		testLogger(), "svc", cloneEndpoints(endpoints), ghost, false, 0.5, noScore,
+		testLogger(), "svc", cloneEndpoints(endpoints), ghost, false, 0.5, false, noScore,
 	)
 	c.NoError(err)
 	c.Empty(reason)
@@ -172,7 +172,7 @@ func Test_chooseRebindEndpoint_AvoidPreferred_ExcludesOriginal(t *testing.T) {
 
 	for i := 0; i < 100; i++ {
 		ep, different, reason, err := chooseRebindEndpoint(
-			testLogger(), "svc", cloneEndpoints(endpoints), preferred, true, 0.5, noScore,
+			testLogger(), "svc", cloneEndpoints(endpoints), preferred, true, 0.5, false, noScore,
 		)
 		c.NoError(err)
 		c.Empty(reason)
@@ -191,10 +191,63 @@ func Test_chooseRebindEndpoint_AvoidPreferred_OnlyOriginal_Errors(t *testing.T) 
 	endpoints := map[protocol.EndpointAddr]endpoint{solo.Addr(): solo}
 
 	ep, different, reason, err := chooseRebindEndpoint(
-		testLogger(), "svc", cloneEndpoints(endpoints), solo.Addr(), true, 0.5, noScore,
+		testLogger(), "svc", cloneEndpoints(endpoints), solo.Addr(), true, 0.5, false, noScore,
 	)
 	c.Error(err)
 	c.Nil(ep)
 	c.False(different)
 	c.Equal(metrics.WSRebindFailedNoEndpoints, reason)
+}
+
+// Test_chooseRebindEndpoint_OperatorUniform_EqualizesOperatorShare verifies the operator-
+// uniform strategy: each operator gets ~equal share regardless of endpoint count. op0 owns
+// 8 of 10 endpoints, yet lands ~1/3 — the opposite of the endpoint-weighted cap, which would
+// concentrate on op0.
+func Test_chooseRebindEndpoint_OperatorUniform_EqualizesOperatorShare(t *testing.T) {
+	c := require.New(t)
+
+	endpoints, ops := buildOperatorEndpoints([]int{8, 1, 1})
+	preferred := anyAddr(endpoints)
+
+	counts := map[string]int{}
+	const N = 3000
+	for i := 0; i < N; i++ {
+		ep, _, reason, err := chooseRebindEndpoint(
+			testLogger(), "svc", cloneEndpoints(endpoints), preferred, false, 0.65, true, noScore,
+		)
+		c.NoError(err)
+		c.Empty(reason)
+		counts[opOfAddr(string(ep.Addr()))]++
+	}
+	for _, op := range ops {
+		share := float64(counts[op]) / float64(N)
+		c.InDelta(1.0/3.0, share, 0.06, "operator %s share %.3f should be ~1/3 under operator-uniform", op, share)
+	}
+}
+
+// Test_chooseRebindEndpoint_OperatorUniform_RotatesWithCapDisabled verifies operator-uniform
+// forces rotation even when the concentration cap is disabled (where the cap path would pin
+// the original). The original stays eligible, so it is sometimes re-picked but never pinned.
+func Test_chooseRebindEndpoint_OperatorUniform_RotatesWithCapDisabled(t *testing.T) {
+	c := require.New(t)
+
+	endpoints, _ := buildOperatorEndpoints([]int{2, 2, 2})
+	preferred := anyAddr(endpoints)
+
+	seenOps := map[string]bool{}
+	rotatedOff := false
+	for i := 0; i < 300; i++ {
+		ep, different, reason, err := chooseRebindEndpoint(
+			testLogger(), "svc", cloneEndpoints(endpoints), preferred, false, 0.0 /* cap off */, true /* operator-uniform */, noScore,
+		)
+		c.NoError(err)
+		c.Empty(reason)
+		c.Equal(ep.Addr() != preferred, different)
+		seenOps[opOfAddr(string(ep.Addr()))] = true
+		if ep.Addr() != preferred {
+			rotatedOff = true
+		}
+	}
+	c.GreaterOrEqual(len(seenOps), 2, "operator-uniform must rotate even with the cap disabled")
+	c.True(rotatedOff, "operator-uniform must sometimes rotate off the original supplier")
 }

--- a/protocol/shannon/websocket_rebind_policy_test.go
+++ b/protocol/shannon/websocket_rebind_policy_test.go
@@ -1,0 +1,200 @@
+package shannon
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/pokt-network/path/metrics"
+	"github.com/pokt-network/path/protocol"
+)
+
+// cloneEndpoints (defined in endpoint_filters_bench_test.go) returns a shallow copy so a test
+// can call chooseRebindEndpoint — which deletes preferredAddr on the avoidPreferred path —
+// without mutating the shared fixture.
+
+// anyAddr returns one address from the map (map order is unspecified; callers that need a
+// specific endpoint construct it directly instead).
+func anyAddr(m map[protocol.EndpointAddr]endpoint) protocol.EndpointAddr {
+	for a := range m {
+		return a
+	}
+	return ""
+}
+
+// Test_chooseRebindEndpoint_CapDisabled_ReusesOriginal verifies the seamless tier-1 path:
+// with the cap disabled (0 or >= 1) and the original endpoint still present, the rebind
+// reuses it and reports a non-different (seamless) outcome.
+func Test_chooseRebindEndpoint_CapDisabled_ReusesOriginal(t *testing.T) {
+	c := require.New(t)
+
+	endpoints, _ := buildOperatorEndpoints([]int{2, 2, 2})
+	preferred := anyAddr(endpoints)
+
+	for _, disabled := range []float64{0.0, 1.0, -1.0} {
+		ep, different, reason, err := chooseRebindEndpoint(
+			testLogger(), "svc", cloneEndpoints(endpoints), preferred, false, disabled, noScore,
+		)
+		c.NoError(err)
+		c.Empty(reason)
+		c.Equal(preferred, ep.Addr(), "cap=%v: must reuse the original endpoint", disabled)
+		c.False(different, "cap=%v: reuse is a seamless (non-different) outcome", disabled)
+	}
+}
+
+// Test_chooseRebindEndpoint_CapDisabled_OriginalRotatedOut verifies that even with the cap
+// disabled, an original supplier that dropped out of the new session falls back to a
+// best-available endpoint (differentSupplier=true) rather than erroring.
+func Test_chooseRebindEndpoint_CapDisabled_OriginalRotatedOut(t *testing.T) {
+	c := require.New(t)
+
+	endpoints, _ := buildOperatorEndpoints([]int{1, 1, 1})
+	ghost := protocol.EndpointAddr("pokt1ghost-https://n.ghost.tech") // not in the session
+
+	ep, different, reason, err := chooseRebindEndpoint(
+		testLogger(), "svc", cloneEndpoints(endpoints), ghost, false, 0.0, noScore,
+	)
+	c.NoError(err)
+	c.Empty(reason)
+	c.NotNil(ep)
+	c.NotEqual(ghost, ep.Addr())
+	c.True(different, "original rotated out → different supplier")
+	_, inSet := endpoints[ep.Addr()]
+	c.True(inSet, "fallback must be a member of the new session")
+}
+
+// Test_chooseRebindEndpoint_CapEngaged_SpreadsAcrossOperators is the core Option-A assertion:
+// with the cap engaged and a tied-best band spanning multiple operators, repeated rebinds do
+// NOT pin the original supplier — they spread across operators, and the differentSupplier
+// flag tracks whether the pick moved off the original endpoint.
+func Test_chooseRebindEndpoint_CapEngaged_SpreadsAcrossOperators(t *testing.T) {
+	c := require.New(t)
+
+	// 3 operators, all endpoints non-fallback and equally scored → the whole set is the band.
+	endpoints, _ := buildOperatorEndpoints([]int{2, 2, 2})
+	preferred := anyAddr(endpoints)
+	preferredOp := opOfAddr(string(preferred))
+
+	seenOps := map[string]bool{}
+	rotatedOff := false
+	for i := 0; i < 400; i++ {
+		ep, different, reason, err := chooseRebindEndpoint(
+			testLogger(), "svc", cloneEndpoints(endpoints), preferred, false, 0.5, noScore,
+		)
+		c.NoError(err)
+		c.Empty(reason)
+		_, inSet := endpoints[ep.Addr()]
+		c.True(inSet, "pick must be a member of the session")
+		c.Equal(ep.Addr() != preferred, different, "differentSupplier must equal (chosen != original)")
+		seenOps[opOfAddr(string(ep.Addr()))] = true
+		if ep.Addr() != preferred {
+			rotatedOff = true
+		}
+	}
+	c.GreaterOrEqual(len(seenOps), 2, "cap-engaged rebind must spread across operators, not pin one")
+	c.True(rotatedOff, "cap-engaged rebind must sometimes rotate off the original supplier")
+	c.Contains(seenOps, preferredOp, "original operator must remain eligible (not excluded)")
+}
+
+// Test_chooseRebindEndpoint_CapEngaged_SingleEndpointNeverFails verifies the 1-endpoint-pool
+// safety: with the cap engaged and only the original endpoint present, selection lands back
+// on it (seamless) and never errors — the original stays in the candidate set.
+func Test_chooseRebindEndpoint_CapEngaged_SingleEndpointNeverFails(t *testing.T) {
+	c := require.New(t)
+
+	solo := newRCEndpoint("pokt1op0-https://n0.op0.tech", false)
+	endpoints := map[protocol.EndpointAddr]endpoint{solo.Addr(): solo}
+
+	ep, different, reason, err := chooseRebindEndpoint(
+		testLogger(), "svc", cloneEndpoints(endpoints), solo.Addr(), false, 0.5, noScore,
+	)
+	c.NoError(err)
+	c.Empty(reason)
+	c.Equal(solo.Addr(), ep.Addr())
+	c.False(different, "landing back on the sole original endpoint is seamless")
+}
+
+// Test_chooseRebindEndpoint_CapEngaged_StrictlyBestOriginalWins verifies that rotation only
+// reshuffles the tied band: a strictly higher-scored original is the whole band, so it is
+// still reused (seamless) even with the cap engaged.
+func Test_chooseRebindEndpoint_CapEngaged_StrictlyBestOriginalWins(t *testing.T) {
+	c := require.New(t)
+
+	best := newRCEndpoint("pokt1op0-https://n0.op0.tech", false)
+	other1 := newRCEndpoint("pokt1op1-https://n0.op1.tech", false)
+	other2 := newRCEndpoint("pokt1op2-https://n0.op2.tech", false)
+	endpoints := map[protocol.EndpointAddr]endpoint{
+		best.Addr():   best,
+		other1.Addr(): other1,
+		other2.Addr(): other2,
+	}
+	scoreOf := scoreByAddr(map[string]float64{
+		string(best.Addr()): 95, string(other1.Addr()): 40, string(other2.Addr()): 40,
+	})
+
+	for i := 0; i < 50; i++ {
+		ep, different, reason, err := chooseRebindEndpoint(
+			testLogger(), "svc", cloneEndpoints(endpoints), best.Addr(), false, 0.5, scoreOf,
+		)
+		c.NoError(err)
+		c.Empty(reason)
+		c.Equal(best.Addr(), ep.Addr(), "a strictly-best original is the whole band → reused")
+		c.False(different)
+	}
+}
+
+// Test_chooseRebindEndpoint_CapEngaged_OriginalRotatedOut verifies the tier-2 fallback under
+// an engaged cap: the original is absent, so the pick is a different endpoint from the set.
+func Test_chooseRebindEndpoint_CapEngaged_OriginalRotatedOut(t *testing.T) {
+	c := require.New(t)
+
+	endpoints, _ := buildOperatorEndpoints([]int{2, 2})
+	ghost := protocol.EndpointAddr("pokt1ghost-https://n.ghost.tech")
+
+	ep, different, reason, err := chooseRebindEndpoint(
+		testLogger(), "svc", cloneEndpoints(endpoints), ghost, false, 0.5, noScore,
+	)
+	c.NoError(err)
+	c.Empty(reason)
+	c.NotNil(ep)
+	c.True(different)
+	_, inSet := endpoints[ep.Addr()]
+	c.True(inSet)
+}
+
+// Test_chooseRebindEndpoint_AvoidPreferred_ExcludesOriginal verifies the stall-escape path:
+// avoidPreferred drops the original endpoint and forces a different one.
+func Test_chooseRebindEndpoint_AvoidPreferred_ExcludesOriginal(t *testing.T) {
+	c := require.New(t)
+
+	endpoints, _ := buildOperatorEndpoints([]int{2, 2, 2})
+	preferred := anyAddr(endpoints)
+
+	for i := 0; i < 100; i++ {
+		ep, different, reason, err := chooseRebindEndpoint(
+			testLogger(), "svc", cloneEndpoints(endpoints), preferred, true, 0.5, noScore,
+		)
+		c.NoError(err)
+		c.Empty(reason)
+		c.NotEqual(preferred, ep.Addr(), "avoidPreferred must never reselect the stalling endpoint")
+		c.True(different)
+	}
+}
+
+// Test_chooseRebindEndpoint_AvoidPreferred_OnlyOriginal_Errors verifies that when the
+// stalling endpoint is the session's only endpoint, the escape fails with the
+// no-endpoints reason so the bridge closes the client.
+func Test_chooseRebindEndpoint_AvoidPreferred_OnlyOriginal_Errors(t *testing.T) {
+	c := require.New(t)
+
+	solo := newRCEndpoint("pokt1op0-https://n0.op0.tech", false)
+	endpoints := map[protocol.EndpointAddr]endpoint{solo.Addr(): solo}
+
+	ep, different, reason, err := chooseRebindEndpoint(
+		testLogger(), "svc", cloneEndpoints(endpoints), solo.Addr(), true, 0.5, noScore,
+	)
+	c.Error(err)
+	c.Nil(ep)
+	c.False(different)
+	c.Equal(metrics.WSRebindFailedNoEndpoints, reason)
+}

--- a/protocol/shannon/websocket_reconnect_test.go
+++ b/protocol/shannon/websocket_reconnect_test.go
@@ -1,12 +1,24 @@
 package shannon
 
 import (
+	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
 	"github.com/pokt-network/path/protocol"
 )
+
+// opOfAddr extracts the "opN.tech" eTLD+1 from a test endpoint address of the form
+// "pokt1<op><k>-https://n<k>.<op>.tech" — the last two dot-separated segments.
+func opOfAddr(addr string) string {
+	segs := strings.Split(addr, ".")
+	if len(segs) < 2 {
+		return addr
+	}
+	return segs[len(segs)-2] + "." + segs[len(segs)-1]
+}
 
 // rcEndpoint wraps cfgEndpoint to make IsFallback configurable for tier-2 selection tests.
 type rcEndpoint struct {
@@ -123,6 +135,89 @@ func Test_selectBestReconnectEndpoint_SingleAndEmpty(t *testing.T) {
 	c.Equal(only.Addr(), selectBestReconnectEndpoint(map[protocol.EndpointAddr]endpoint{only.Addr(): only}, noScore).Addr())
 
 	c.Nil(selectBestReconnectEndpoint(map[protocol.EndpointAddr]endpoint{}, noScore), "empty set returns nil")
+}
+
+// buildOperatorEndpoints creates a reconnect-candidate map where operator opX.tech owns
+// keyCounts[i] non-fallback endpoints, in the "supplier-https://host" address form so the
+// concentration cap can resolve each endpoint's eTLD+1.
+func buildOperatorEndpoints(keyCounts []int) (map[protocol.EndpointAddr]endpoint, []string) {
+	endpoints := map[protocol.EndpointAddr]endpoint{}
+	ops := make([]string, len(keyCounts))
+	for i, count := range keyCounts {
+		op := fmt.Sprintf("op%d", i)
+		ops[i] = op + ".tech"
+		for k := 0; k < count; k++ {
+			e := newRCEndpoint(fmt.Sprintf("pokt1%s%d-https://n%d.%s.tech", op, k, k, op), false)
+			endpoints[e.Addr()] = e
+		}
+	}
+	return endpoints, ops
+}
+
+// Test_selectReconnectEndpointWithCap_DisabledMatchesDeterministic verifies that with the
+// cap disabled the capped wrapper is identical to the deterministic pick.
+func Test_selectReconnectEndpointWithCap_DisabledMatchesDeterministic(t *testing.T) {
+	c := require.New(t)
+	endpoints, _ := buildOperatorEndpoints([]int{10, 1, 1, 1})
+
+	want := selectBestReconnectEndpoint(endpoints, noScore).Addr()
+	for _, disabled := range []float64{0, 1.0, -1, 2} {
+		got := selectReconnectEndpointWithCap(endpoints, noScore, disabled, "any-seed")
+		c.Equal(want, got.Addr(), "disabled cap (%v) must match deterministic pick", disabled)
+	}
+}
+
+// Test_selectReconnectEndpointWithCap_Deterministic verifies same-seed reproducibility.
+func Test_selectReconnectEndpointWithCap_Deterministic(t *testing.T) {
+	c := require.New(t)
+	endpoints, _ := buildOperatorEndpoints([]int{10, 1, 1, 1})
+
+	for _, seed := range []protocol.EndpointAddr{"origin-a", "origin-b", "pokt1zzz-https://x.op0.tech"} {
+		first := selectReconnectEndpointWithCap(endpoints, noScore, 0.4, seed).Addr()
+		for i := 0; i < 50; i++ {
+			c.Equal(first, selectReconnectEndpointWithCap(endpoints, noScore, 0.4, seed).Addr(),
+				"same seed must reproduce the same rebind target")
+		}
+	}
+}
+
+// Test_selectReconnectEndpointWithCap_SpreadsAcrossOperators verifies the cap spreads
+// tied-best rebind targets across operators instead of funneling to one address: across
+// many connection origins the 10-key operator's share converges near the 0.4 cap, not 0.77.
+func Test_selectReconnectEndpointWithCap_SpreadsAcrossOperators(t *testing.T) {
+	c := require.New(t)
+	endpoints, ops := buildOperatorEndpoints([]int{10, 1, 1, 1})
+
+	counts := map[string]int{}
+	const draws = 20_000
+	for i := 0; i < draws; i++ {
+		seed := protocol.EndpointAddr(fmt.Sprintf("origin-%d", i))
+		ep := selectReconnectEndpointWithCap(endpoints, noScore, 0.4, seed)
+		counts[opOfAddr(string(ep.Addr()))]++
+	}
+	c.InDelta(0.40, float64(counts[ops[0]])/float64(draws), 0.03,
+		"dominant operator's rebind share should be capped near 0.40")
+}
+
+// Test_selectReconnectEndpointWithCap_RespectsScoreBand verifies the cap only spreads
+// among the top-score band — a lower-scored endpoint is never chosen as a rebind target.
+func Test_selectReconnectEndpointWithCap_RespectsScoreBand(t *testing.T) {
+	c := require.New(t)
+
+	high1 := newRCEndpoint("pokt1a-https://n.alpha.tech", false)
+	high2 := newRCEndpoint("pokt1b-https://n.bravo.tech", false)
+	low := newRCEndpoint("pokt1c-https://n.charlie.tech", false)
+	endpoints := map[protocol.EndpointAddr]endpoint{
+		high1.Addr(): high1, high2.Addr(): high2, low.Addr(): low,
+	}
+	scoreOf := scoreByAddr(map[string]float64{
+		string(high1.Addr()): 95, string(high2.Addr()): 95, string(low.Addr()): 40,
+	})
+
+	for i := 0; i < 500; i++ {
+		ep := selectReconnectEndpointWithCap(endpoints, scoreOf, 0.6, protocol.EndpointAddr(fmt.Sprintf("o%d", i)))
+		c.NotEqual(low.Addr(), ep.Addr(), "a below-band (lower-score) endpoint must never be a rebind target")
+	}
 }
 
 // Test_betterReconnectCandidate verifies the ordering used by selectBestReconnectEndpoint:

--- a/protocol/shannon/websocket_reconnect_test.go
+++ b/protocol/shannon/websocket_reconnect_test.go
@@ -162,28 +162,14 @@ func Test_selectReconnectEndpointWithCap_DisabledMatchesDeterministic(t *testing
 
 	want := selectBestReconnectEndpoint(endpoints, noScore).Addr()
 	for _, disabled := range []float64{0, 1.0, -1, 2} {
-		got := selectReconnectEndpointWithCap(endpoints, noScore, disabled, "any-seed")
+		got := selectReconnectEndpointWithCap(endpoints, noScore, disabled)
 		c.Equal(want, got.Addr(), "disabled cap (%v) must match deterministic pick", disabled)
 	}
 }
 
-// Test_selectReconnectEndpointWithCap_Deterministic verifies same-seed reproducibility.
-func Test_selectReconnectEndpointWithCap_Deterministic(t *testing.T) {
-	c := require.New(t)
-	endpoints, _ := buildOperatorEndpoints([]int{10, 1, 1, 1})
-
-	for _, seed := range []protocol.EndpointAddr{"origin-a", "origin-b", "pokt1zzz-https://x.op0.tech"} {
-		first := selectReconnectEndpointWithCap(endpoints, noScore, 0.4, seed).Addr()
-		for i := 0; i < 50; i++ {
-			c.Equal(first, selectReconnectEndpointWithCap(endpoints, noScore, 0.4, seed).Addr(),
-				"same seed must reproduce the same rebind target")
-		}
-	}
-}
-
 // Test_selectReconnectEndpointWithCap_SpreadsAcrossOperators verifies the cap spreads
-// tied-best rebind targets across operators instead of funneling to one address: across
-// many connection origins the 10-key operator's share converges near the 0.4 cap, not 0.77.
+// tied-best rebind targets across operators instead of funneling to one address: over many
+// rebinds the 10-key operator's share converges near the 0.4 cap, not its 0.77 key-share.
 func Test_selectReconnectEndpointWithCap_SpreadsAcrossOperators(t *testing.T) {
 	c := require.New(t)
 	endpoints, ops := buildOperatorEndpoints([]int{10, 1, 1, 1})
@@ -191,8 +177,7 @@ func Test_selectReconnectEndpointWithCap_SpreadsAcrossOperators(t *testing.T) {
 	counts := map[string]int{}
 	const draws = 20_000
 	for i := 0; i < draws; i++ {
-		seed := protocol.EndpointAddr(fmt.Sprintf("origin-%d", i))
-		ep := selectReconnectEndpointWithCap(endpoints, noScore, 0.4, seed)
+		ep := selectReconnectEndpointWithCap(endpoints, noScore, 0.4)
 		counts[opOfAddr(string(ep.Addr()))]++
 	}
 	c.InDelta(0.40, float64(counts[ops[0]])/float64(draws), 0.03,
@@ -215,7 +200,7 @@ func Test_selectReconnectEndpointWithCap_RespectsScoreBand(t *testing.T) {
 	})
 
 	for i := 0; i < 500; i++ {
-		ep := selectReconnectEndpointWithCap(endpoints, scoreOf, 0.6, protocol.EndpointAddr(fmt.Sprintf("o%d", i)))
+		ep := selectReconnectEndpointWithCap(endpoints, scoreOf, 0.6)
 		c.NotEqual(low.Addr(), ep.Addr(), "a below-band (lower-score) endpoint must never be a rebind target")
 	}
 }

--- a/protocol/shannon/websocket_reconnect_test.go
+++ b/protocol/shannon/websocket_reconnect_test.go
@@ -162,7 +162,7 @@ func Test_selectReconnectEndpointWithCap_DisabledMatchesDeterministic(t *testing
 
 	want := selectBestReconnectEndpoint(endpoints, noScore).Addr()
 	for _, disabled := range []float64{0, 1.0, -1, 2} {
-		got := selectReconnectEndpointWithCap(endpoints, noScore, disabled)
+		got := selectReconnectEndpointWithCap("test", endpoints, noScore, disabled)
 		c.Equal(want, got.Addr(), "disabled cap (%v) must match deterministic pick", disabled)
 	}
 }
@@ -177,7 +177,7 @@ func Test_selectReconnectEndpointWithCap_SpreadsAcrossOperators(t *testing.T) {
 	counts := map[string]int{}
 	const draws = 20_000
 	for i := 0; i < draws; i++ {
-		ep := selectReconnectEndpointWithCap(endpoints, noScore, 0.4)
+		ep := selectReconnectEndpointWithCap("test", endpoints, noScore, 0.4)
 		counts[opOfAddr(string(ep.Addr()))]++
 	}
 	c.InDelta(0.40, float64(counts[ops[0]])/float64(draws), 0.03,
@@ -200,7 +200,7 @@ func Test_selectReconnectEndpointWithCap_RespectsScoreBand(t *testing.T) {
 	})
 
 	for i := 0; i < 500; i++ {
-		ep := selectReconnectEndpointWithCap(endpoints, scoreOf, 0.6)
+		ep := selectReconnectEndpointWithCap("test", endpoints, scoreOf, 0.6)
 		c.NotEqual(low.Addr(), ep.Addr(), "a below-band (lower-score) endpoint must never be a rebind target")
 	}
 }

--- a/qos/cosmos/concentration_cap_test.go
+++ b/qos/cosmos/concentration_cap_test.go
@@ -1,0 +1,30 @@
+package cosmos
+
+import (
+	"testing"
+
+	"github.com/pokt-network/poktroll/pkg/polylog/polyzero"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSetMaxOperatorShare_RoundTrip verifies the per-operator concentration cap round-trips
+// through the atomic float64-bits storage on simpleCosmosConfig, and that the Cosmos QoS
+// satisfies the SetMaxOperatorShare interface used by cmd/qos.go.
+func TestSetMaxOperatorShare_RoundTrip(t *testing.T) {
+	logger := polyzero.NewLogger()
+	qos := NewSimpleQoSInstance(logger, "cosmoshub")
+
+	// Default: disabled (0).
+	require.Equal(t, 0.0, qos.serviceQoSConfig.getMaxOperatorShare())
+
+	// Satisfies the setter interface cmd/qos.go asserts.
+	var _ interface{ SetMaxOperatorShare(float64) } = qos
+
+	for _, v := range []float64{0.4, 0.5, 0.75, 0.999} {
+		qos.SetMaxOperatorShare(v)
+		require.Equal(t, v, qos.serviceQoSConfig.getMaxOperatorShare())
+	}
+
+	qos.SetMaxOperatorShare(0)
+	require.Equal(t, 0.0, qos.serviceQoSConfig.getMaxOperatorShare())
+}

--- a/qos/cosmos/qos.go
+++ b/qos/cosmos/qos.go
@@ -2,6 +2,7 @@ package cosmos
 
 import (
 	"context"
+	"math"
 	"net/http"
 	"sync/atomic"
 	"time"
@@ -108,6 +109,9 @@ type simpleCosmosConfig struct {
 	serviceID     protocol.ServiceID
 	syncAllowance atomic.Uint64                    // If 0, uses default. Updated dynamically when external health check rules are loaded.
 	supportedAPIs map[sharedtypes.RPCType]struct{} // Supported RPC types
+	// maxOperatorShareBits holds a float64 (via math.Float64bits) for the per-operator
+	// concentration cap. 0 (the zero value) disables the cap. Updated dynamically.
+	maxOperatorShareBits atomic.Uint64
 }
 
 func (c *simpleCosmosConfig) GetServiceID() protocol.ServiceID { return c.serviceID }
@@ -120,6 +124,9 @@ func (c *simpleCosmosConfig) getSyncAllowance() uint64 {
 	}
 	return defaultCosmosSDKBlockNumberSyncAllowance
 }
+func (c *simpleCosmosConfig) getMaxOperatorShare() float64 {
+	return math.Float64frombits(c.maxOperatorShareBits.Load())
+}
 
 // SetSyncAllowance dynamically updates the sync allowance for this QoS instance.
 // This is called when external health check rules are loaded/refreshed, since those
@@ -127,6 +134,14 @@ func (c *simpleCosmosConfig) getSyncAllowance() uint64 {
 func (qos *QoS) SetSyncAllowance(syncAllowance uint64) {
 	if cfg, ok := qos.serviceQoSConfig.(*simpleCosmosConfig); ok {
 		cfg.syncAllowance.Store(syncAllowance)
+	}
+}
+
+// SetMaxOperatorShare dynamically sets the per-operator (eTLD+1) concentration cap used
+// during endpoint selection. A value <= 0 or >= 1 disables the cap (flat random pick).
+func (qos *QoS) SetMaxOperatorShare(maxOperatorShare float64) {
+	if cfg, ok := qos.serviceQoSConfig.(*simpleCosmosConfig); ok {
+		cfg.maxOperatorShareBits.Store(math.Float64bits(maxOperatorShare))
 	}
 }
 func (c *simpleCosmosConfig) getSupportedAPIs() map[sharedtypes.RPCType]struct{} {

--- a/qos/cosmos/qos.go
+++ b/qos/cosmos/qos.go
@@ -267,6 +267,21 @@ func (qos *QoS) GetPerceivedBlockNumber() uint64 {
 	return qos.perceivedBlockNumber
 }
 
+// ResetPerceivedBlockHeight clears the perceived block number (in-memory + Redis) so it
+// rebuilds from fresh endpoint observations. Used by the chain-state admin reset to
+// recover from a stuck/too-high perceived height (the max-wins path cannot lower it).
+// Must be invoked on each pod, since the perceived floor is per-pod in-memory state.
+func (qos *QoS) ResetPerceivedBlockHeight(ctx context.Context) error {
+	qos.serviceStateLock.Lock()
+	qos.perceivedBlockNumber = 0
+	qos.serviceStateLock.Unlock()
+
+	if qos.reputationSvc != nil {
+		return qos.reputationSvc.DeletePerceivedBlockNumber(ctx, qos.serviceQoSConfig.GetServiceID())
+	}
+	return nil
+}
+
 // ConsumeExternalBlockHeight consumes block heights from an external fetcher channel
 // and uses them as a floor for perceivedBlockNumber. This ensures that if all session
 // endpoints are behind the real chain tip, the perceived block is corrected.

--- a/qos/cosmos/qos.go
+++ b/qos/cosmos/qos.go
@@ -2,7 +2,6 @@ package cosmos
 
 import (
 	"context"
-	"math"
 	"net/http"
 	"sync/atomic"
 	"time"
@@ -13,6 +12,7 @@ import (
 	"github.com/pokt-network/path/gateway"
 	"github.com/pokt-network/path/metrics/devtools"
 	"github.com/pokt-network/path/protocol"
+	"github.com/pokt-network/path/qos/selector"
 	qostypes "github.com/pokt-network/path/qos/types"
 	"github.com/pokt-network/path/reputation"
 )
@@ -109,9 +109,9 @@ type simpleCosmosConfig struct {
 	serviceID     protocol.ServiceID
 	syncAllowance atomic.Uint64                    // If 0, uses default. Updated dynamically when external health check rules are loaded.
 	supportedAPIs map[sharedtypes.RPCType]struct{} // Supported RPC types
-	// maxOperatorShareBits holds a float64 (via math.Float64bits) for the per-operator
-	// concentration cap. 0 (the zero value) disables the cap. Updated dynamically.
-	maxOperatorShareBits atomic.Uint64
+	// maxOperatorShare is the per-operator concentration cap. 0 (the zero value) disables
+	// the cap. Updated dynamically via SetMaxOperatorShare.
+	maxOperatorShare selector.AtomicFloat64
 }
 
 func (c *simpleCosmosConfig) GetServiceID() protocol.ServiceID { return c.serviceID }
@@ -125,7 +125,7 @@ func (c *simpleCosmosConfig) getSyncAllowance() uint64 {
 	return defaultCosmosSDKBlockNumberSyncAllowance
 }
 func (c *simpleCosmosConfig) getMaxOperatorShare() float64 {
-	return math.Float64frombits(c.maxOperatorShareBits.Load())
+	return c.maxOperatorShare.Load()
 }
 
 // SetSyncAllowance dynamically updates the sync allowance for this QoS instance.
@@ -141,7 +141,7 @@ func (qos *QoS) SetSyncAllowance(syncAllowance uint64) {
 // during endpoint selection. A value <= 0 or >= 1 disables the cap (flat random pick).
 func (qos *QoS) SetMaxOperatorShare(maxOperatorShare float64) {
 	if cfg, ok := qos.serviceQoSConfig.(*simpleCosmosConfig); ok {
-		cfg.maxOperatorShareBits.Store(math.Float64bits(maxOperatorShare))
+		cfg.maxOperatorShare.Store(maxOperatorShare)
 	}
 }
 func (c *simpleCosmosConfig) getSupportedAPIs() map[sharedtypes.RPCType]struct{} {

--- a/qos/cosmos/qos.go
+++ b/qos/cosmos/qos.go
@@ -12,6 +12,7 @@ import (
 	"github.com/pokt-network/path/gateway"
 	"github.com/pokt-network/path/metrics/devtools"
 	"github.com/pokt-network/path/protocol"
+	pathqos "github.com/pokt-network/path/qos"
 	"github.com/pokt-network/path/qos/selector"
 	qostypes "github.com/pokt-network/path/qos/types"
 	"github.com/pokt-network/path/reputation"
@@ -316,7 +317,18 @@ func (qos *QoS) ConsumeExternalBlockHeight(ctx context.Context, heights <-chan i
 						Msg("External block floor skipped — no suppliers have reported yet")
 					continue
 				}
-				if h > qos.perceivedBlockNumber {
+				// Guard the external floor the same way the endpoint path is guarded
+				// (see service_state.go:101): an external source must not raise
+				// perceived more than MaxBlockHeightJump above the current value,
+				// blocking a misbehaving/mislabeled external source from poisoning
+				// perceived arbitrarily high and filtering out honest endpoints.
+				if h > qos.perceivedBlockNumber && !pathqos.IsPlausibleBlockHeight(h, qos.perceivedBlockNumber) {
+					qos.logger.Warn().
+						Str("service_id", string(serviceID)).
+						Uint64("external_block", h).
+						Uint64("perceived_block", qos.perceivedBlockNumber).
+						Msg("⚠️ ignoring implausible external block height (possible poisoned external source)")
+				} else if h > qos.perceivedBlockNumber {
 					qos.logger.Info().
 						Str("service_id", string(serviceID)).
 						Uint64("old_perceived", qos.perceivedBlockNumber).

--- a/qos/cosmos/redis_sync_test.go
+++ b/qos/cosmos/redis_sync_test.go
@@ -42,6 +42,13 @@ func (m *mockReputationSvc) SetPerceivedBlockNumber(_ context.Context, serviceID
 	return nil
 }
 
+func (m *mockReputationSvc) DeletePerceivedBlockNumber(_ context.Context, serviceID protocol.ServiceID) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	delete(m.perceivedBlock, serviceID)
+	return nil
+}
+
 func (m *mockReputationSvc) GetPerceivedBlockNumber(_ context.Context, serviceID protocol.ServiceID) uint64 {
 	m.mu.Lock()
 	defer m.mu.Unlock()

--- a/qos/cosmos/redis_sync_test.go
+++ b/qos/cosmos/redis_sync_test.go
@@ -270,3 +270,40 @@ func TestCosmos_ConsumeExternalBlockHeight_WritesToRedis(t *testing.T) {
 	assert.Equal(t, uint64(300), qos.GetPerceivedBlockNumber())
 	assert.Equal(t, uint64(300), mock.getBlock(serviceID))
 }
+
+// TestCosmos_ConsumeExternalBlockHeight_RejectsImplausible mirrors the Solana
+// slot-poisoning guard for the Cosmos external-floor path: an external source must
+// not raise perceived more than MaxBlockHeightJump above the current value, so a
+// mislabeled/misbehaving source cannot filter out all honest endpoints.
+func TestCosmos_ConsumeExternalBlockHeight_RejectsImplausible(t *testing.T) {
+	qos := newTestCosmosQoS()
+	mock := newMockReputationSvc()
+	qos.SetReputationService(mock)
+	serviceID := qos.serviceQoSConfig.GetServiceID()
+
+	const realHeight = 20_000_000
+	qos.serviceStateLock.Lock()
+	qos.perceivedBlockNumber = realHeight
+	qos.serviceStateLock.Unlock()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	heights := make(chan int64, 5)
+	qos.ConsumeExternalBlockHeight(ctx, heights, 1*time.Millisecond)
+	time.Sleep(10 * time.Millisecond)
+
+	// Implausible jump (~20M above the real tip) must be rejected.
+	heights <- 40_000_000
+	time.Sleep(100 * time.Millisecond)
+	assert.Equal(t, uint64(realHeight), qos.GetPerceivedBlockNumber(),
+		"an implausible external height must not poison perceived")
+	assert.NotEqual(t, uint64(40_000_000), mock.getBlock(serviceID),
+		"an implausible external height must not be written to Redis")
+
+	// A plausible advance is still applied.
+	heights <- realHeight + 5
+	time.Sleep(100 * time.Millisecond)
+	assert.Equal(t, uint64(realHeight+5), qos.GetPerceivedBlockNumber(),
+		"a plausible external advance must still raise perceived")
+}

--- a/qos/cosmos/service_qos_config.go
+++ b/qos/cosmos/service_qos_config.go
@@ -29,6 +29,9 @@ type CosmosSDKServiceQoSConfig interface {
 	getEVMChainID() string
 	getSyncAllowance() uint64
 	getSupportedAPIs() map[sharedtypes.RPCType]struct{}
+	// getMaxOperatorShare returns the per-operator (eTLD+1) concentration cap applied
+	// during endpoint selection. <= 0 or >= 1 disables the cap (flat random pick).
+	getMaxOperatorShare() float64
 }
 
 // NewCosmosSDKServiceQoSConfig creates a new CosmosSDK service configuration.
@@ -106,6 +109,14 @@ func (c cosmosSDKServiceQoSConfig) getSyncAllowance() uint64 {
 		c.syncAllowance = defaultCosmosSDKBlockNumberSyncAllowance
 	}
 	return c.syncAllowance
+}
+
+// getMaxOperatorShare returns the per-operator concentration cap. This static
+// test/config implementation leaves it disabled (0); the production simpleCosmosConfig
+// carries the dynamically-set value.
+// Implements the CosmosSDKServiceQoSConfig interface.
+func (cosmosSDKServiceQoSConfig) getMaxOperatorShare() float64 {
+	return 0
 }
 
 // getSupportedAPIs returns the RPC types supported by the service.

--- a/qos/cosmos/service_state_endpoint_selection.go
+++ b/qos/cosmos/service_state_endpoint_selection.go
@@ -61,6 +61,7 @@ func (ss *serviceState) Select(availableEndpoints protocol.EndpointAddrList) (pr
 	// the prior flat random pick.
 	// TODO_FUTURE: consider ranking filtered endpoints, e.g. based on latency, rather than randomization.
 	selectedEndpointAddr := selector.SelectWithConcentrationCap(
+		ss.serviceQoSConfig.GetServiceID(),
 		filteredEndpointsAddr,
 		ss.serviceQoSConfig.getMaxOperatorShare(),
 	)

--- a/qos/cosmos/service_state_endpoint_selection.go
+++ b/qos/cosmos/service_state_endpoint_selection.go
@@ -61,7 +61,6 @@ func (ss *serviceState) Select(availableEndpoints protocol.EndpointAddrList) (pr
 	// the prior flat random pick.
 	// TODO_FUTURE: consider ranking filtered endpoints, e.g. based on latency, rather than randomization.
 	selectedEndpointAddr := selector.SelectWithConcentrationCap(
-		logger,
 		filteredEndpointsAddr,
 		ss.serviceQoSConfig.getMaxOperatorShare(),
 	)

--- a/qos/cosmos/service_state_endpoint_selection.go
+++ b/qos/cosmos/service_state_endpoint_selection.go
@@ -56,8 +56,15 @@ func (ss *serviceState) Select(availableEndpoints protocol.EndpointAddrList) (pr
 
 	logger.Debug().Msgf("filtered %d endpoints from %d available endpoints", len(filteredEndpointsAddr), len(availableEndpoints))
 
+	// Select from the valid candidates, applying the per-operator (eTLD+1) concentration
+	// cap when configured. Disabled (getMaxOperatorShare() <= 0 or >= 1) → byte-for-byte
+	// the prior flat random pick.
 	// TODO_FUTURE: consider ranking filtered endpoints, e.g. based on latency, rather than randomization.
-	selectedEndpointAddr := filteredEndpointsAddr[rand.Intn(len(filteredEndpointsAddr))]
+	selectedEndpointAddr := selector.SelectWithConcentrationCap(
+		logger,
+		filteredEndpointsAddr,
+		ss.serviceQoSConfig.getMaxOperatorShare(),
+	)
 	return selectedEndpointAddr, nil
 }
 

--- a/qos/evm/block_consensus.go
+++ b/qos/evm/block_consensus.go
@@ -9,6 +9,7 @@ import (
 	"github.com/pokt-network/poktroll/pkg/polylog"
 
 	"github.com/pokt-network/path/protocol"
+	pathqos "github.com/pokt-network/path/qos"
 )
 
 const (
@@ -268,7 +269,17 @@ func (c *BlockHeightConsensus) calculatePerceivedLocked() uint64 {
 	// The floor is only applied after the grace period, giving suppliers time
 	// to report their block heights during cold start.
 	if ext := c.externalBlockHeight.Load(); ext > 0 && ext > maxValid {
-		if time.Since(c.createdAt) >= c.externalBlockGracePeriod {
+		if !pathqos.IsPlausibleBlockHeight(ext, maxValid) {
+			// An external source must not raise perceived more than
+			// MaxBlockHeightJump above the session consensus. This blocks a
+			// misbehaving/mislabeled source (e.g. one returning a slot ~5% above
+			// the real block height) from poisoning perceived arbitrarily high
+			// and filtering out honest endpoints.
+			c.logger.Warn().
+				Uint64("consensus_block", maxValid).
+				Uint64("external_block", ext).
+				Msg("⚠️ ignoring implausible external block height (possible poisoned external source)")
+		} else if time.Since(c.createdAt) >= c.externalBlockGracePeriod {
 			c.logger.Warn().
 				Uint64("consensus_block", maxValid).
 				Uint64("external_block", ext).

--- a/qos/evm/block_consensus_test.go
+++ b/qos/evm/block_consensus_test.go
@@ -157,6 +157,37 @@ func TestExternalBlockFloor_OverridesWhenHigher(t *testing.T) {
 	assert.Equal(t, uint64(100), perceived)
 }
 
+// TestExternalBlockFloor_RejectsImplausible guards against the poisoning class that
+// hit Solana on 2026-07-21: a mislabeled external source reporting a value far above
+// the true chain tip (e.g. a slot ~5% above block height). Applying it as the floor
+// would push perceived above every honest endpoint and filter them all out. The floor
+// must reject an external height more than MaxBlockHeightJump above session consensus,
+// while still accepting a normal advance.
+func TestExternalBlockFloor_RejectsImplausible(t *testing.T) {
+	logger := polyzero.NewLogger()
+	consensus := NewBlockHeightConsensus(logger, 10)
+	consensus.SetExternalBlockGracePeriod(0) // Disable grace period for test
+
+	// Establish consensus at a realistic height.
+	const consensusHeight = 20_000_000
+	consensus.AddObservation("endpoint1", consensusHeight)
+	consensus.AddObservation("endpoint2", consensusHeight)
+	consensus.AddObservation("endpoint3", consensusHeight)
+	assert.Equal(t, uint64(consensusHeight), consensus.GetPerceivedBlock())
+
+	// External height ~20M above consensus (> MaxBlockHeightJump) must be ignored.
+	consensus.SetExternalBlockHeight(40_000_000)
+	perceived := consensus.AddObservation("endpoint4", consensusHeight)
+	assert.Equal(t, uint64(consensusHeight), perceived,
+		"an implausible external height must not override session consensus")
+
+	// A plausible external advance is still applied as a floor.
+	consensus.SetExternalBlockHeight(consensusHeight + 5)
+	perceived = consensus.AddObservation("endpoint5", consensusHeight)
+	assert.Equal(t, uint64(consensusHeight+5), perceived,
+		"a plausible external advance must still act as a floor")
+}
+
 func TestExternalBlockFloor_IgnoredWhenLower(t *testing.T) {
 	logger := polyzero.NewLogger()
 	consensus := NewBlockHeightConsensus(logger, 10)

--- a/qos/evm/concentration_cap_e2e_test.go
+++ b/qos/evm/concentration_cap_e2e_test.go
@@ -1,0 +1,99 @@
+package evm
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/pokt-network/poktroll/pkg/polylog/polyzero"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pokt-network/path/metrics"
+	"github.com/pokt-network/path/protocol"
+)
+
+// TestSelectWithMetadata_ConcentrationCap_EndToEnd exercises the full production path —
+// config → getMaxOperatorShare → SelectWithMetadata → SelectWithConcentrationCap — rather
+// than the selector helper in isolation. It builds a real EVM QoS instance, enables the
+// cap via SetMaxOperatorShare, and confirms that a dominant operator's realized selection
+// share is bounded by the cap and that the reshape metric fires. The existing
+// endpoint_selection tests all run with the static config (cap == 0), so this is the only
+// coverage of the cap flowing end-to-end through Select.
+func TestSelectWithMetadata_ConcentrationCap_EndToEnd(t *testing.T) {
+	logger := polyzero.NewLogger()
+
+	// Real production QoS instance (simpleServiceConfig, syncAllowance 0 → block-height
+	// filtering off) with an empty endpoint store: every supplied endpoint is "fresh" and
+	// passes validation.
+	qos := NewSimpleQoSInstance(logger, "eth")
+	qos.SetMaxOperatorShare(0.4)
+
+	// Dominant operator op0 holds 10 endpoints; three singletons. Flat random would give
+	// op0 10/13 ≈ 0.77; the cap must pull it to ~0.40. Addresses use the production
+	// "supplier-https://host" form so the eTLD+1 resolves.
+	keyCounts := map[string]int{"op0.tech": 10, "op1.tech": 1, "op2.tech": 1, "op3.tech": 1}
+	var available protocol.EndpointAddrList
+	for dom, count := range keyCounts {
+		for k := 0; k < count; k++ {
+			available = append(available, protocol.EndpointAddr(
+				fmt.Sprintf("pokt1%s%d-https://node%d.%s", strings.TrimSuffix(dom, ".tech"), k, k, dom),
+			))
+		}
+	}
+
+	before := testutil.ToFloat64(metrics.ConcentrationCapReshapedTotal.WithLabelValues("eth"))
+
+	counts := map[string]int{}
+	const draws = 60_000
+	for i := 0; i < draws; i++ {
+		res, err := qos.SelectWithMetadata(available, false, "req")
+		require.NoError(t, err)
+		require.NotEmpty(t, res.SelectedEndpoint)
+		counts[operatorOfAddr(string(res.SelectedEndpoint))]++
+	}
+
+	// Dominant operator bounded near the cap, not its 0.77 key-share.
+	require.InDelta(t, 0.40, float64(counts["op0.tech"])/float64(draws), 0.03,
+		"end-to-end: dominant operator's selection share should be capped near 0.40, got %.3f",
+		float64(counts["op0.tech"])/float64(draws))
+
+	// The reshape metric fired for this service (the cap actually bit on every draw here).
+	after := testutil.ToFloat64(metrics.ConcentrationCapReshapedTotal.WithLabelValues("eth"))
+	require.Greater(t, after-before, 0.0, "concentration_cap_reshaped_total must increment when the cap reshapes")
+}
+
+// TestSelectWithMetadata_ConcentrationCap_DisabledByDefault confirms that the static test
+// config path (cap unset → 0) leaves selection as a flat key-weighted random pick, so the
+// cap is opt-in via SetMaxOperatorShare.
+func TestSelectWithMetadata_ConcentrationCap_DisabledByDefault(t *testing.T) {
+	logger := polyzero.NewLogger()
+	qos := NewSimpleQoSInstance(logger, "eth-disabled") // no SetMaxOperatorShare → cap 0
+
+	var available protocol.EndpointAddrList
+	for _, dom := range []string{"big.tech", "big.tech", "big.tech", "solo.tech"} {
+		available = append(available, protocol.EndpointAddr(
+			fmt.Sprintf("pokt1%d-https://n.%s", len(available), dom),
+		))
+	}
+
+	counts := map[string]int{}
+	const draws = 40_000
+	for i := 0; i < draws; i++ {
+		res, err := qos.SelectWithMetadata(available, false, "req")
+		require.NoError(t, err)
+		counts[operatorOfAddr(string(res.SelectedEndpoint))]++
+	}
+	// 3 of 4 endpoints are big.tech → flat random gives it ~0.75 (cap disabled).
+	require.InDelta(t, 0.75, float64(counts["big.tech"])/float64(draws), 0.03,
+		"disabled cap should leave a flat key-weighted distribution")
+}
+
+// operatorOfAddr extracts the trailing "name.tech" eTLD+1 from a test endpoint address.
+func operatorOfAddr(addr string) string {
+	segs := strings.Split(addr, ".")
+	if len(segs) < 2 {
+		return addr
+	}
+	return segs[len(segs)-2] + "." + segs[len(segs)-1]
+}

--- a/qos/evm/endpoint_selection.go
+++ b/qos/evm/endpoint_selection.go
@@ -187,7 +187,6 @@ func (ss *serviceState) SelectWithMetadata(availableEndpoints protocol.EndpointA
 	// selection — both reach here via requestContext.Select. When the cap is disabled
 	// (getMaxOperatorShare() <= 0 or >= 1), this is byte-for-byte the prior flat random pick.
 	selectedEndpointAddr := selector.SelectWithConcentrationCap(
-		logger,
 		filteredEndpointsAddr,
 		ss.serviceQoSConfig.getMaxOperatorShare(),
 	)

--- a/qos/evm/endpoint_selection.go
+++ b/qos/evm/endpoint_selection.go
@@ -187,6 +187,7 @@ func (ss *serviceState) SelectWithMetadata(availableEndpoints protocol.EndpointA
 	// selection — both reach here via requestContext.Select. When the cap is disabled
 	// (getMaxOperatorShare() <= 0 or >= 1), this is byte-for-byte the prior flat random pick.
 	selectedEndpointAddr := selector.SelectWithConcentrationCap(
+		ss.serviceQoSConfig.GetServiceID(),
 		filteredEndpointsAddr,
 		ss.serviceQoSConfig.getMaxOperatorShare(),
 	)

--- a/qos/evm/endpoint_selection.go
+++ b/qos/evm/endpoint_selection.go
@@ -180,8 +180,17 @@ func (ss *serviceState) SelectWithMetadata(availableEndpoints protocol.EndpointA
 
 	logger.Debug().Msgf("filtered %d endpoints from %d available endpoints", validCount, availableCount)
 
-	// Select random endpoint from valid candidates
-	selectedEndpointAddr := filteredEndpointsAddr[rand.Intn(validCount)]
+	// Select from the valid candidates, applying the per-operator (eTLD+1) concentration
+	// cap when configured. The cap bounds any single operator's selection probability so
+	// one supplier that holds most of a service's endpoints can't absorb an outsized share
+	// (and take that whole share down if it degrades). Covers both HTTP and WebSocket
+	// selection — both reach here via requestContext.Select. When the cap is disabled
+	// (getMaxOperatorShare() <= 0 or >= 1), this is byte-for-byte the prior flat random pick.
+	selectedEndpointAddr := selector.SelectWithConcentrationCap(
+		logger,
+		filteredEndpointsAddr,
+		ss.serviceQoSConfig.getMaxOperatorShare(),
+	)
 	return EndpointSelectionResult{
 		SelectedEndpoint: selectedEndpointAddr,
 		Metadata: EndpointSelectionMetadata{

--- a/qos/evm/endpoint_selection_test.go
+++ b/qos/evm/endpoint_selection_test.go
@@ -95,6 +95,10 @@ func (m *mockReputationService) SetPerceivedBlockNumber(ctx context.Context, ser
 	return nil
 }
 
+func (m *mockReputationService) DeletePerceivedBlockNumber(ctx context.Context, serviceID protocol.ServiceID) error {
+	return nil
+}
+
 func (m *mockReputationService) GetPerceivedBlockNumber(ctx context.Context, serviceID protocol.ServiceID) uint64 {
 	return 0
 }

--- a/qos/evm/qos.go
+++ b/qos/evm/qos.go
@@ -12,6 +12,7 @@ import (
 	"github.com/pokt-network/path/gateway"
 	"github.com/pokt-network/path/metrics/devtools"
 	"github.com/pokt-network/path/protocol"
+	pathqos "github.com/pokt-network/path/qos"
 	"github.com/pokt-network/path/qos/selector"
 	qostypes "github.com/pokt-network/path/qos/types"
 	"github.com/pokt-network/path/reputation"
@@ -422,12 +423,24 @@ func (qos *QoS) ConsumeExternalBlockHeight(ctx context.Context, heights <-chan i
 				// could cause other replicas to filter all endpoints.
 				if qos.reputationSvc != nil {
 					currentPerceived := qos.perceivedBlockNumber.Load()
-					if currentPerceived > 0 && h > currentPerceived {
+					// Guard the cross-replica Redis write: an external source must not
+					// raise perceived more than MaxBlockHeightJump above the current
+					// value. Without this, a mislabeled source (e.g. one returning a
+					// slot ~5% above the real block height) would poison perceived for
+					// every replica, filtering out honest endpoints network-wide. This
+					// mirrors the consensus-path guard in block_consensus.go.
+					if currentPerceived > 0 && h > currentPerceived && pathqos.IsPlausibleBlockHeight(h, currentPerceived) {
 						go func(block uint64) {
 							rCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 							defer cancel()
 							_ = qos.reputationSvc.SetPerceivedBlockNumber(rCtx, serviceID, block)
 						}(h)
+					} else if currentPerceived > 0 && h > currentPerceived {
+						qos.logger.Warn().
+							Str("service_id", string(serviceID)).
+							Uint64("external_block", h).
+							Uint64("perceived_block", currentPerceived).
+							Msg("⚠️ ignoring implausible external block height for Redis perceived write (possible poisoned external source)")
 					}
 				}
 			}

--- a/qos/evm/qos.go
+++ b/qos/evm/qos.go
@@ -2,6 +2,7 @@ package evm
 
 import (
 	"context"
+	"math"
 	"net/http"
 	"sync/atomic"
 	"time"
@@ -93,6 +94,9 @@ func NewSimpleQoSInstanceWithSyncAllowance(logger polylog.Logger, serviceID prot
 type simpleServiceConfig struct {
 	serviceID     protocol.ServiceID
 	syncAllowance atomic.Uint64 // If 0, uses default. Updated dynamically when external health check rules are loaded.
+	// maxOperatorShareBits holds a float64 (via math.Float64bits) for the per-operator
+	// concentration cap. 0 (the zero value) disables the cap. Updated dynamically.
+	maxOperatorShareBits atomic.Uint64
 }
 
 func (c *simpleServiceConfig) GetServiceID() protocol.ServiceID { return c.serviceID }
@@ -107,6 +111,9 @@ func (c *simpleServiceConfig) getSyncAllowance() uint64 {
 func (c *simpleServiceConfig) getSupportedAPIs() map[sharedtypes.RPCType]struct{} {
 	return map[sharedtypes.RPCType]struct{}{sharedtypes.RPCType_JSON_RPC: {}}
 }
+func (c *simpleServiceConfig) getMaxOperatorShare() float64 {
+	return math.Float64frombits(c.maxOperatorShareBits.Load())
+}
 
 // SetSyncAllowance dynamically updates the sync allowance for this QoS instance.
 // This is called when external health check rules are loaded/refreshed, since those
@@ -114,6 +121,15 @@ func (c *simpleServiceConfig) getSupportedAPIs() map[sharedtypes.RPCType]struct{
 func (qos *QoS) SetSyncAllowance(syncAllowance uint64) {
 	if cfg, ok := qos.serviceQoSConfig.(*simpleServiceConfig); ok {
 		cfg.syncAllowance.Store(syncAllowance)
+	}
+}
+
+// SetMaxOperatorShare dynamically sets the per-operator (eTLD+1) concentration cap
+// used during endpoint selection. A value <= 0 or >= 1 disables the cap (flat random
+// pick). Wired from configuration so it can be A/B tested on canary without a redeploy.
+func (qos *QoS) SetMaxOperatorShare(maxOperatorShare float64) {
+	if cfg, ok := qos.serviceQoSConfig.(*simpleServiceConfig); ok {
+		cfg.maxOperatorShareBits.Store(math.Float64bits(maxOperatorShare))
 	}
 }
 

--- a/qos/evm/qos.go
+++ b/qos/evm/qos.go
@@ -301,6 +301,22 @@ func (qos *QoS) GetPerceivedBlockNumber() uint64 {
 	return qos.perceivedBlockNumber.Load()
 }
 
+// ResetPerceivedBlockHeight clears the perceived block number (in-memory + Redis) and the
+// external block floor so consensus rebuilds from fresh endpoint observations. Used by the
+// chain-state admin reset to recover from a stuck/too-high perceived height (the max-wins
+// path cannot lower it). Must be invoked on each pod, since perceived state is per-pod.
+func (qos *QoS) ResetPerceivedBlockHeight(ctx context.Context) error {
+	qos.perceivedBlockNumber.Store(0)
+	if qos.blockConsensus != nil {
+		qos.blockConsensus.SetExternalBlockHeight(0)
+	}
+
+	if qos.reputationSvc != nil {
+		return qos.reputationSvc.DeletePerceivedBlockNumber(ctx, qos.serviceQoSConfig.GetServiceID())
+	}
+	return nil
+}
+
 // GetBlockConsensusStats returns the median block and observation count.
 // Used for observability to understand how block consensus is calculated.
 //

--- a/qos/evm/qos.go
+++ b/qos/evm/qos.go
@@ -2,7 +2,6 @@ package evm
 
 import (
 	"context"
-	"math"
 	"net/http"
 	"sync/atomic"
 	"time"
@@ -13,6 +12,7 @@ import (
 	"github.com/pokt-network/path/gateway"
 	"github.com/pokt-network/path/metrics/devtools"
 	"github.com/pokt-network/path/protocol"
+	"github.com/pokt-network/path/qos/selector"
 	qostypes "github.com/pokt-network/path/qos/types"
 	"github.com/pokt-network/path/reputation"
 )
@@ -94,9 +94,9 @@ func NewSimpleQoSInstanceWithSyncAllowance(logger polylog.Logger, serviceID prot
 type simpleServiceConfig struct {
 	serviceID     protocol.ServiceID
 	syncAllowance atomic.Uint64 // If 0, uses default. Updated dynamically when external health check rules are loaded.
-	// maxOperatorShareBits holds a float64 (via math.Float64bits) for the per-operator
-	// concentration cap. 0 (the zero value) disables the cap. Updated dynamically.
-	maxOperatorShareBits atomic.Uint64
+	// maxOperatorShare is the per-operator concentration cap. 0 (the zero value) disables
+	// the cap. Updated dynamically via SetMaxOperatorShare.
+	maxOperatorShare selector.AtomicFloat64
 }
 
 func (c *simpleServiceConfig) GetServiceID() protocol.ServiceID { return c.serviceID }
@@ -112,7 +112,7 @@ func (c *simpleServiceConfig) getSupportedAPIs() map[sharedtypes.RPCType]struct{
 	return map[sharedtypes.RPCType]struct{}{sharedtypes.RPCType_JSON_RPC: {}}
 }
 func (c *simpleServiceConfig) getMaxOperatorShare() float64 {
-	return math.Float64frombits(c.maxOperatorShareBits.Load())
+	return c.maxOperatorShare.Load()
 }
 
 // SetSyncAllowance dynamically updates the sync allowance for this QoS instance.
@@ -129,7 +129,7 @@ func (qos *QoS) SetSyncAllowance(syncAllowance uint64) {
 // pick). Wired from configuration so it can be A/B tested on canary without a redeploy.
 func (qos *QoS) SetMaxOperatorShare(maxOperatorShare float64) {
 	if cfg, ok := qos.serviceQoSConfig.(*simpleServiceConfig); ok {
-		cfg.maxOperatorShareBits.Store(math.Float64bits(maxOperatorShare))
+		cfg.maxOperatorShare.Store(maxOperatorShare)
 	}
 }
 

--- a/qos/evm/qos_test.go
+++ b/qos/evm/qos_test.go
@@ -11,6 +11,27 @@ import (
 	qostypes "github.com/pokt-network/path/qos/types"
 )
 
+// TestSetMaxOperatorShare_RoundTrip verifies the per-operator concentration cap value
+// round-trips through the atomic float64-bits storage on simpleServiceConfig. Guards the
+// math.Float64bits/Float64frombits plumbing behind SetMaxOperatorShare/getMaxOperatorShare.
+func TestSetMaxOperatorShare_RoundTrip(t *testing.T) {
+	logger := polyzero.NewLogger()
+	qos := NewSimpleQoSInstance(logger, "eth")
+
+	// Default: disabled (0).
+	require.Equal(t, 0.0, qos.serviceQoSConfig.getMaxOperatorShare())
+
+	for _, v := range []float64{0.4, 0.5, 0.85, 0.999} {
+		qos.SetMaxOperatorShare(v)
+		require.Equal(t, v, qos.serviceQoSConfig.getMaxOperatorShare(),
+			"max operator share should round-trip exactly")
+	}
+
+	// Reset to disabled.
+	qos.SetMaxOperatorShare(0)
+	require.Equal(t, 0.0, qos.serviceQoSConfig.getMaxOperatorShare())
+}
+
 // TestUpdateFromExtractedData_ArchivalBidirectional verifies that UpdateFromExtractedData
 // correctly handles both setting (IsArchival=true) and clearing (IsArchival=false) archival status.
 func TestUpdateFromExtractedData_ArchivalBidirectional(t *testing.T) {

--- a/qos/evm/redis_sync_test.go
+++ b/qos/evm/redis_sync_test.go
@@ -42,6 +42,13 @@ func (m *mockRedisSyncRepSvc) SetPerceivedBlockNumber(_ context.Context, service
 	return nil
 }
 
+func (m *mockRedisSyncRepSvc) DeletePerceivedBlockNumber(_ context.Context, serviceID protocol.ServiceID) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	delete(m.perceivedBlock, serviceID)
+	return nil
+}
+
 func (m *mockRedisSyncRepSvc) GetPerceivedBlockNumber(_ context.Context, serviceID protocol.ServiceID) uint64 {
 	m.mu.Lock()
 	defer m.mu.Unlock()

--- a/qos/evm/service_qos_config.go
+++ b/qos/evm/service_qos_config.go
@@ -36,6 +36,9 @@ type EVMServiceQoSConfig interface {
 	getEVMChainID() string
 	getSyncAllowance() uint64
 	getSupportedAPIs() map[sharedtypes.RPCType]struct{}
+	// getMaxOperatorShare returns the per-operator (eTLD+1) concentration cap applied
+	// during endpoint selection. <= 0 or >= 1 disables the cap (flat random pick).
+	getMaxOperatorShare() float64
 }
 
 // NewEVMServiceQoSConfig creates a new EVM service configuration.
@@ -107,4 +110,12 @@ func (c evmServiceQoSConfig) getSyncAllowance() uint64 {
 // Implements the EVMServiceQoSConfig interface.
 func (c evmServiceQoSConfig) getSupportedAPIs() map[sharedtypes.RPCType]struct{} {
 	return c.supportedAPIs
+}
+
+// getMaxOperatorShare returns the per-operator concentration cap.
+// This static test/config implementation leaves it disabled (0); the production
+// simpleServiceConfig carries the dynamically-set value.
+// Implements the EVMServiceQoSConfig interface.
+func (evmServiceQoSConfig) getMaxOperatorShare() float64 {
+	return 0
 }

--- a/qos/noop/concentration_cap_test.go
+++ b/qos/noop/concentration_cap_test.go
@@ -1,0 +1,30 @@
+package noop
+
+import (
+	"testing"
+
+	"github.com/pokt-network/poktroll/pkg/polylog/polyzero"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSetMaxOperatorShare_RoundTrip verifies the per-operator concentration cap round-trips
+// through the atomic float64-bits storage on NoOpQoS, and that NoOpQoS satisfies the
+// SetMaxOperatorShare interface used by cmd/qos.go.
+func TestSetMaxOperatorShare_RoundTrip(t *testing.T) {
+	logger := polyzero.NewLogger()
+	qos := NewNoOpQoSService(logger, "near")
+
+	// Default: disabled (0).
+	require.Equal(t, 0.0, qos.getMaxOperatorShare())
+
+	// Satisfies the setter interface cmd/qos.go asserts.
+	var _ interface{ SetMaxOperatorShare(float64) } = qos
+
+	for _, v := range []float64{0.4, 0.5, 0.75, 0.999} {
+		qos.SetMaxOperatorShare(v)
+		require.Equal(t, v, qos.getMaxOperatorShare())
+	}
+
+	qos.SetMaxOperatorShare(0)
+	require.Equal(t, 0.0, qos.getMaxOperatorShare())
+}

--- a/qos/noop/noop.go
+++ b/qos/noop/noop.go
@@ -207,6 +207,21 @@ func (n *NoOpQoS) GetPerceivedBlockNumber() uint64 {
 	return n.perceivedBlockHeight
 }
 
+// ResetPerceivedBlockHeight clears the perceived block height (in-memory + Redis) so it
+// rebuilds from fresh endpoint observations. Used by the chain-state admin reset to
+// recover from a stuck/too-high perceived height (the max path cannot lower it). Must be
+// invoked on each pod, since the perceived floor is per-pod in-memory state.
+func (n *NoOpQoS) ResetPerceivedBlockHeight(ctx context.Context) error {
+	n.serviceStateMu.Lock()
+	n.perceivedBlockHeight = 0
+	n.serviceStateMu.Unlock()
+
+	if n.reputationSvc != nil {
+		return n.reputationSvc.DeletePerceivedBlockNumber(ctx, n.serviceID)
+	}
+	return nil
+}
+
 // SetSyncAllowance dynamically updates the sync allowance for this QoS instance.
 // This is called when external health check rules are loaded/refreshed, since those
 // rules may specify a sync_allowance that wasn't available at QoS creation time.

--- a/qos/noop/noop.go
+++ b/qos/noop/noop.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"math"
 	"net/http"
 	"sync"
 	"sync/atomic"
@@ -49,9 +50,25 @@ type NoOpQoS struct {
 	// perceived block height before being filtered. 0 disables filtering.
 	syncAllowance atomic.Uint64
 
+	// maxOperatorShareBits holds a float64 (via math.Float64bits) for the per-operator
+	// (eTLD+1) concentration cap applied during selection. 0 disables the cap. Set
+	// dynamically from configuration via SetMaxOperatorShare.
+	maxOperatorShareBits atomic.Uint64
+
 	// reputationSvc provides shared perceived block height across replicas via Redis.
 	// Set via SetReputationService; nil when reputation is disabled.
 	reputationSvc reputation.ReputationService
+}
+
+// getMaxOperatorShare returns the configured per-operator concentration cap (0 = disabled).
+func (n *NoOpQoS) getMaxOperatorShare() float64 {
+	return math.Float64frombits(n.maxOperatorShareBits.Load())
+}
+
+// SetMaxOperatorShare dynamically sets the per-operator (eTLD+1) concentration cap used
+// during endpoint selection. A value <= 0 or >= 1 disables the cap (flat random pick).
+func (n *NoOpQoS) SetMaxOperatorShare(maxOperatorShare float64) {
+	n.maxOperatorShareBits.Store(math.Float64bits(maxOperatorShare))
 }
 
 // NewNoOpQoSService creates a new NoOp QoS service instance.

--- a/qos/noop/noop.go
+++ b/qos/noop/noop.go
@@ -264,7 +264,17 @@ func (n *NoOpQoS) ConsumeExternalBlockHeight(ctx context.Context, heights <-chan
 						Msg("External block floor skipped — no suppliers have reported yet")
 					continue
 				}
-				if h > n.perceivedBlockHeight {
+				// Guard the external floor the same way the endpoint path is guarded
+				// (see line ~165): an external source must not raise perceived more
+				// than MaxBlockHeightJump above the current value, blocking a
+				// misbehaving/mislabeled external source from poisoning perceived
+				// arbitrarily high and filtering out honest endpoints.
+				if h > n.perceivedBlockHeight && !qos.IsPlausibleBlockHeight(h, n.perceivedBlockHeight) {
+					n.logger.Warn().
+						Uint64("external_block", h).
+						Uint64("perceived_block", n.perceivedBlockHeight).
+						Msg("⚠️ ignoring implausible external block height (possible poisoned external source)")
+				} else if h > n.perceivedBlockHeight {
 					n.logger.Info().
 						Uint64("old_perceived", n.perceivedBlockHeight).
 						Uint64("external_block", h).

--- a/qos/noop/noop.go
+++ b/qos/noop/noop.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"math"
 	"net/http"
 	"sync"
 	"sync/atomic"
@@ -20,6 +19,7 @@ import (
 	qosobservations "github.com/pokt-network/path/observation/qos"
 	"github.com/pokt-network/path/protocol"
 	"github.com/pokt-network/path/qos"
+	"github.com/pokt-network/path/qos/selector"
 	qostypes "github.com/pokt-network/path/qos/types"
 	"github.com/pokt-network/path/reputation"
 )
@@ -50,10 +50,9 @@ type NoOpQoS struct {
 	// perceived block height before being filtered. 0 disables filtering.
 	syncAllowance atomic.Uint64
 
-	// maxOperatorShareBits holds a float64 (via math.Float64bits) for the per-operator
-	// (eTLD+1) concentration cap applied during selection. 0 disables the cap. Set
-	// dynamically from configuration via SetMaxOperatorShare.
-	maxOperatorShareBits atomic.Uint64
+	// maxOperatorShare is the per-operator (eTLD+1) concentration cap applied during
+	// selection. 0 disables the cap. Set dynamically via SetMaxOperatorShare.
+	maxOperatorShare selector.AtomicFloat64
 
 	// reputationSvc provides shared perceived block height across replicas via Redis.
 	// Set via SetReputationService; nil when reputation is disabled.
@@ -62,13 +61,13 @@ type NoOpQoS struct {
 
 // getMaxOperatorShare returns the configured per-operator concentration cap (0 = disabled).
 func (n *NoOpQoS) getMaxOperatorShare() float64 {
-	return math.Float64frombits(n.maxOperatorShareBits.Load())
+	return n.maxOperatorShare.Load()
 }
 
 // SetMaxOperatorShare dynamically sets the per-operator (eTLD+1) concentration cap used
 // during endpoint selection. A value <= 0 or >= 1 disables the cap (flat random pick).
 func (n *NoOpQoS) SetMaxOperatorShare(maxOperatorShare float64) {
-	n.maxOperatorShareBits.Store(math.Float64bits(maxOperatorShare))
+	n.maxOperatorShare.Store(maxOperatorShare)
 }
 
 // NewNoOpQoSService creates a new NoOp QoS service instance.

--- a/qos/noop/noop_test.go
+++ b/qos/noop/noop_test.go
@@ -210,6 +210,41 @@ func TestNoOpQoS_ConsumeExternalBlockHeight(t *testing.T) {
 	require.Equal(t, uint64(200), qos.GetPerceivedBlockNumber())
 }
 
+// TestNoOpQoS_ConsumeExternalBlockHeight_RejectsImplausible reproduces the Solana
+// slot-poisoning incident (2026-07-21): a mislabeled external source returned the
+// SLOT (~434M), which is ~22M above the real block height (~412M). Without a
+// plausibility guard the external-floor path would set perceived to the slot,
+// making every honest endpoint (reporting the real, lower height) look "behind"
+// and get filtered out. The guard must reject an external height that jumps more
+// than MaxBlockHeightJump above the current perceived, while still accepting a
+// normal (small) advance.
+func TestNoOpQoS_ConsumeExternalBlockHeight_RejectsImplausible(t *testing.T) {
+	qos := newTestQoS()
+
+	// Suppliers report the real block height.
+	const realHeight = 412_000_000
+	require.NoError(t, qos.UpdateFromExtractedData("ep1", &qostypes.ExtractedData{BlockHeight: realHeight}))
+
+	heights := make(chan int64, 5)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	qos.ConsumeExternalBlockHeight(ctx, heights, 1*time.Millisecond)
+	time.Sleep(10 * time.Millisecond)
+
+	// Implausible external height (the slot, ~22M above the real tip) must be ignored.
+	heights <- 434_000_000
+	time.Sleep(10 * time.Millisecond)
+	require.Equal(t, uint64(realHeight), qos.GetPerceivedBlockNumber(),
+		"an implausible external height (slot magnitude) must not poison perceived")
+
+	// A plausible advance (a few blocks ahead) is still applied — the floor keeps working.
+	heights <- realHeight + 5
+	time.Sleep(10 * time.Millisecond)
+	require.Equal(t, uint64(realHeight+5), qos.GetPerceivedBlockNumber(),
+		"a plausible external advance must still raise perceived")
+}
+
 func TestNoOpQoS_ConsumeExternalBlockHeight_SkipsWhenNoSuppliers(t *testing.T) {
 	qos := newTestQoS()
 	// perceivedBlockHeight is 0 — no suppliers have reported

--- a/qos/noop/redis_sync_test.go
+++ b/qos/noop/redis_sync_test.go
@@ -42,6 +42,13 @@ func (m *mockReputationSvc) SetPerceivedBlockNumber(_ context.Context, serviceID
 	return nil
 }
 
+func (m *mockReputationSvc) DeletePerceivedBlockNumber(_ context.Context, serviceID protocol.ServiceID) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	delete(m.perceivedBlock, serviceID)
+	return nil
+}
+
 func (m *mockReputationSvc) GetPerceivedBlockNumber(_ context.Context, serviceID protocol.ServiceID) uint64 {
 	m.mu.Lock()
 	defer m.mu.Unlock()

--- a/qos/noop/selector.go
+++ b/qos/noop/selector.go
@@ -76,12 +76,16 @@ func (fs *filteringSelector) Select(endpoints protocol.EndpointAddrList) (protoc
 
 	filtered := fs.filterValidEndpoints(endpoints)
 
+	// Apply the per-operator (eTLD+1) concentration cap when configured. Disabled
+	// (getMaxOperatorShare() <= 0 or >= 1) → byte-for-byte the prior flat random pick.
+	maxOperatorShare := fs.qos.getMaxOperatorShare()
+
 	if len(filtered) == 0 {
 		fs.logger.Warn().Msg("All endpoints failed block height validation, falling back to random selection")
-		return endpoints[rand.Intn(len(endpoints))], nil
+		return selector.SelectWithConcentrationCap(fs.logger, endpoints, maxOperatorShare), nil
 	}
 
-	return filtered[rand.Intn(len(filtered))], nil
+	return selector.SelectWithConcentrationCap(fs.logger, filtered, maxOperatorShare), nil
 }
 
 // SelectMultiple returns multiple endpoints after applying block-height filtering.

--- a/qos/noop/selector.go
+++ b/qos/noop/selector.go
@@ -82,10 +82,10 @@ func (fs *filteringSelector) Select(endpoints protocol.EndpointAddrList) (protoc
 
 	if len(filtered) == 0 {
 		fs.logger.Warn().Msg("All endpoints failed block height validation, falling back to random selection")
-		return selector.SelectWithConcentrationCap(fs.logger, endpoints, maxOperatorShare), nil
+		return selector.SelectWithConcentrationCap(endpoints, maxOperatorShare), nil
 	}
 
-	return selector.SelectWithConcentrationCap(fs.logger, filtered, maxOperatorShare), nil
+	return selector.SelectWithConcentrationCap(filtered, maxOperatorShare), nil
 }
 
 // SelectMultiple returns multiple endpoints after applying block-height filtering.

--- a/qos/noop/selector.go
+++ b/qos/noop/selector.go
@@ -82,10 +82,10 @@ func (fs *filteringSelector) Select(endpoints protocol.EndpointAddrList) (protoc
 
 	if len(filtered) == 0 {
 		fs.logger.Warn().Msg("All endpoints failed block height validation, falling back to random selection")
-		return selector.SelectWithConcentrationCap(endpoints, maxOperatorShare), nil
+		return selector.SelectWithConcentrationCap(fs.qos.serviceID, endpoints, maxOperatorShare), nil
 	}
 
-	return selector.SelectWithConcentrationCap(filtered, maxOperatorShare), nil
+	return selector.SelectWithConcentrationCap(fs.qos.serviceID, filtered, maxOperatorShare), nil
 }
 
 // SelectMultiple returns multiple endpoints after applying block-height filtering.

--- a/qos/selector/atomic_float64.go
+++ b/qos/selector/atomic_float64.go
@@ -1,0 +1,22 @@
+package selector
+
+import (
+	"math"
+	"sync/atomic"
+)
+
+// AtomicFloat64 is a lock-free float64 backed by an atomic uint64 (via math.Float64bits).
+// The zero value is 0.0 and ready to use. Must not be copied after first use (it embeds
+// atomic.Uint64) — hold it by pointer or as a field of a pointer-held struct.
+//
+// It exists to remove the repeated math.Float64bits/Float64frombits plumbing that each QoS
+// type would otherwise carry for its per-operator concentration cap.
+type AtomicFloat64 struct {
+	bits atomic.Uint64
+}
+
+// Load returns the current value.
+func (a *AtomicFloat64) Load() float64 { return math.Float64frombits(a.bits.Load()) }
+
+// Store sets the value.
+func (a *AtomicFloat64) Store(v float64) { a.bits.Store(math.Float64bits(v)) }

--- a/qos/selector/concentration_cap.go
+++ b/qos/selector/concentration_cap.go
@@ -3,6 +3,7 @@ package selector
 import (
 	"math/rand"
 
+	"github.com/pokt-network/path/metrics"
 	shannonmetrics "github.com/pokt-network/path/metrics/protocol/shannon"
 	"github.com/pokt-network/path/protocol"
 )
@@ -30,7 +31,11 @@ const concentrationCapEpsilon = 1e-9
 //
 // Endpoints whose eTLD+1 cannot be resolved are each treated as their own singleton
 // operator (never merged into one bucket — that would fabricate concentration).
+//
+// serviceID is used only to attribute the reshape metric emitted when the cap actually
+// alters the selection distribution.
 func SelectWithConcentrationCap(
+	serviceID protocol.ServiceID,
 	validEndpoints protocol.EndpointAddrList,
 	maxOperatorShare float64,
 ) protocol.EndpointAddr {
@@ -73,17 +78,25 @@ func SelectWithConcentrationCap(
 	// pick followed by a uniform pick within the operator then reproduces a flat random
 	// pick exactly — until the cap reshapes an over-cap operator's mass.
 	weights := make([]float64, m)
+	reshaped := false
 	if maxOperatorShare*float64(m) <= 1.0 {
 		// Infeasible (or exactly at the 1/M floor): no assignment can hold every operator
 		// under the cap, so the best achievable is uniform-over-operators (max share 1/M).
 		for i := range weights {
 			weights[i] = 1.0 / float64(m)
 		}
+		reshaped = true
 	} else {
 		for i, key := range operatorOrder {
 			weights[i] = float64(len(operatorEndpoints[key])) / float64(n)
 		}
-		waterFillToCap(weights, maxOperatorShare)
+		reshaped = waterFillToCap(weights, maxOperatorShare)
+	}
+
+	// Emit only when the cap actually changed the distribution — no-op selections (no
+	// operator over the cap) stay silent, so a nonzero rate means the cap is biting.
+	if reshaped {
+		metrics.RecordConcentrationCapReshaped(string(serviceID))
 	}
 
 	// Weighted pick of an operator, then uniform pick of an endpoint within it.
@@ -96,8 +109,10 @@ func SelectWithConcentrationCap(
 // under-cap weights, proportionally to their current weight, until no weight exceeds
 // the cap. The caller only invokes this when the cap is feasible (cap*len(weights) > 1),
 // so total mass is preserved (≈ 1); the underSum guard keeps it safe even if that ever
-// fails to hold. Operates in place.
-func waterFillToCap(weights []float64, maxShare float64) {
+// fails to hold. Operates in place. Returns true if it clamped at least one weight (i.e.
+// the cap actually reshaped the distribution).
+func waterFillToCap(weights []float64, maxShare float64) bool {
+	clamped := false
 	// At most len(weights) passes: each pass pins at least one new operator to the cap.
 	for pass := 0; pass < len(weights); pass++ {
 		var excess, underSum float64
@@ -112,8 +127,9 @@ func waterFillToCap(weights []float64, maxShare float64) {
 			}
 		}
 		if !anyOver {
-			return
+			return clamped
 		}
+		clamped = true
 		// No under-cap operator to absorb the excess (only reachable if the caller's
 		// feasibility guarantee is violated). Clamp what we can and stop rather than
 		// dividing by zero.
@@ -123,7 +139,7 @@ func waterFillToCap(weights []float64, maxShare float64) {
 					weights[i] = maxShare
 				}
 			}
-			return
+			return clamped
 		}
 		// Redistribute excess to the under-cap operators, proportional to their weight.
 		for i, w := range weights {
@@ -134,6 +150,7 @@ func waterFillToCap(weights []float64, maxShare float64) {
 			}
 		}
 	}
+	return clamped
 }
 
 // weightedPick returns an index chosen with probability proportional to weights[i].

--- a/qos/selector/concentration_cap.go
+++ b/qos/selector/concentration_cap.go
@@ -3,8 +3,6 @@ package selector
 import (
 	"math/rand"
 
-	"github.com/pokt-network/poktroll/pkg/polylog"
-
 	shannonmetrics "github.com/pokt-network/path/metrics/protocol/shannon"
 	"github.com/pokt-network/path/protocol"
 )
@@ -12,20 +10,6 @@ import (
 // concentrationCapEpsilon guards the water-filling loop against floating-point
 // rounding when comparing an operator's weight to the cap.
 const concentrationCapEpsilon = 1e-9
-
-// randSource abstracts the RNG so the same water-filling logic serves both the
-// global-random initial selection and the deterministically-seeded rebind selection.
-type randSource interface {
-	Intn(int) int
-	Float64() float64
-}
-
-// globalRandSource draws from the package-global math/rand — the source used by the
-// prior flat-random pick, so the disabled path stays byte-for-byte unchanged.
-type globalRandSource struct{}
-
-func (globalRandSource) Intn(n int) int   { return rand.Intn(n) }
-func (globalRandSource) Float64() float64 { return rand.Float64() }
 
 // SelectWithConcentrationCap picks one endpoint from validEndpoints, biased so that
 // no single operator (eTLD+1) exceeds maxOperatorShare of the selection probability.
@@ -41,38 +25,14 @@ func (globalRandSource) Float64() float64 { return rand.Float64() }
 // uniformly within that operator.
 //
 // The cap is DISABLED (byte-for-byte a flat random pick) when:
-//   - maxOperatorShare <= 0 or >= 1 (the canary A/B off-switch), or
+//   - maxOperatorShare <= 0 or >= 1 (the config off-switch), or
 //   - there are 0 or 1 endpoints.
 //
 // Endpoints whose eTLD+1 cannot be resolved are each treated as their own singleton
 // operator (never merged into one bucket — that would fabricate concentration).
 func SelectWithConcentrationCap(
-	logger polylog.Logger,
 	validEndpoints protocol.EndpointAddrList,
 	maxOperatorShare float64,
-) protocol.EndpointAddr {
-	_ = logger
-	return selectWithConcentrationCap(validEndpoints, maxOperatorShare, globalRandSource{})
-}
-
-// SelectWithConcentrationCapSeeded is a deterministic variant of
-// SelectWithConcentrationCap: given the same endpoint slice, cap, and seed it always
-// returns the same endpoint. Used by the WebSocket rebind path, which must spread
-// tied-best endpoints across operators while staying reproducible across replays and
-// pods (seed from a per-connection-stable value). The caller must pass validEndpoints
-// in a stable order (e.g. sorted) so the operator grouping is deterministic.
-func SelectWithConcentrationCapSeeded(
-	validEndpoints protocol.EndpointAddrList,
-	maxOperatorShare float64,
-	seed int64,
-) protocol.EndpointAddr {
-	return selectWithConcentrationCap(validEndpoints, maxOperatorShare, rand.New(rand.NewSource(seed))) //nolint:gosec // not security-sensitive; deterministic spread by design
-}
-
-func selectWithConcentrationCap(
-	validEndpoints protocol.EndpointAddrList,
-	maxOperatorShare float64,
-	r randSource,
 ) protocol.EndpointAddr {
 	n := len(validEndpoints)
 	if n == 0 {
@@ -81,16 +41,18 @@ func selectWithConcentrationCap(
 
 	// Disabled / trivial: preserve the exact prior behavior (flat random pick).
 	if n == 1 || maxOperatorShare <= 0 || maxOperatorShare >= 1 {
-		return validEndpoints[r.Intn(n)]
+		return validEndpoints[rand.Intn(n)]
 	}
 
-	// Group endpoints by operator (eTLD+1). Unresolvable eTLD+1 → singleton operator
-	// keyed by the endpoint address itself, so it can never be merged with another.
-	endpointTLDs := shannonmetrics.GetEndpointTLDs(validEndpoints)
+	// Group endpoints by operator (eTLD+1). The eTLD+1 is extracted inline (rather than via
+	// shannonmetrics.GetEndpointTLDs) to avoid materializing a throwaway map on this hot
+	// path — the map would be built and then read exactly once, in this same loop.
+	// Unresolvable eTLD+1 → singleton operator keyed by the endpoint address itself, so it
+	// can never be merged with another.
 	operatorEndpoints := make(map[string]protocol.EndpointAddrList)
-	operatorOrder := make([]string, 0)
+	operatorOrder := make([]string, 0, n)
 	for _, ep := range validEndpoints {
-		key := endpointTLDs[ep]
+		key := shannonmetrics.ExtractTLDFromEndpointAddr(string(ep))
 		if key == "" {
 			key = string(ep)
 		}
@@ -104,7 +66,7 @@ func selectWithConcentrationCap(
 	// Single operator: the cap has nothing to reshape. A flat random pick is a uniform
 	// pick within that one operator — identical, and cheaper.
 	if m == 1 {
-		return validEndpoints[r.Intn(n)]
+		return validEndpoints[rand.Intn(n)]
 	}
 
 	// Per-operator weights. Start from per-endpoint-uniform (n_i/N): a weighted operator
@@ -125,15 +87,16 @@ func selectWithConcentrationCap(
 	}
 
 	// Weighted pick of an operator, then uniform pick of an endpoint within it.
-	opIdx := weightedPick(weights, r)
+	opIdx := weightedPick(weights)
 	eps := operatorEndpoints[operatorOrder[opIdx]]
-	return eps[r.Intn(len(eps))]
+	return eps[rand.Intn(len(eps))]
 }
 
 // waterFillToCap clamps any weight above cap and redistributes the excess to the
 // under-cap weights, proportionally to their current weight, until no weight exceeds
-// the cap. Feasibility (cap*len(weights) > 1) is guaranteed by the caller, so the loop
-// always terminates with total mass preserved (≈ 1). Operates in place.
+// the cap. The caller only invokes this when the cap is feasible (cap*len(weights) > 1),
+// so total mass is preserved (≈ 1); the underSum guard keeps it safe even if that ever
+// fails to hold. Operates in place.
 func waterFillToCap(weights []float64, maxShare float64) {
 	// At most len(weights) passes: each pass pins at least one new operator to the cap.
 	for pass := 0; pass < len(weights); pass++ {
@@ -151,8 +114,18 @@ func waterFillToCap(weights []float64, maxShare float64) {
 		if !anyOver {
 			return
 		}
+		// No under-cap operator to absorb the excess (only reachable if the caller's
+		// feasibility guarantee is violated). Clamp what we can and stop rather than
+		// dividing by zero.
+		if underSum <= 0 {
+			for i, w := range weights {
+				if w > maxShare+concentrationCapEpsilon {
+					weights[i] = maxShare
+				}
+			}
+			return
+		}
 		// Redistribute excess to the under-cap operators, proportional to their weight.
-		// underSum > 0 is guaranteed by the caller's feasibility check (maxShare*m > 1).
 		for i, w := range weights {
 			if w > maxShare+concentrationCapEpsilon {
 				weights[i] = maxShare
@@ -163,15 +136,15 @@ func waterFillToCap(weights []float64, maxShare float64) {
 	}
 }
 
-// weightedPick returns an index chosen with probability proportional to weights[i],
-// drawing from the supplied RNG. Assumes weights sum to ~1 and are non-negative. Falls
-// back to the last index on floating-point shortfall.
-func weightedPick(weights []float64, r randSource) int {
+// weightedPick returns an index chosen with probability proportional to weights[i].
+// Assumes weights sum to ~1 and are non-negative. Falls back to the last index on
+// floating-point shortfall.
+func weightedPick(weights []float64) int {
 	var total float64
 	for _, w := range weights {
 		total += w
 	}
-	target := r.Float64() * total
+	target := rand.Float64() * total
 	var cum float64
 	for i, w := range weights {
 		cum += w

--- a/qos/selector/concentration_cap.go
+++ b/qos/selector/concentration_cap.go
@@ -13,6 +13,20 @@ import (
 // rounding when comparing an operator's weight to the cap.
 const concentrationCapEpsilon = 1e-9
 
+// randSource abstracts the RNG so the same water-filling logic serves both the
+// global-random initial selection and the deterministically-seeded rebind selection.
+type randSource interface {
+	Intn(int) int
+	Float64() float64
+}
+
+// globalRandSource draws from the package-global math/rand — the source used by the
+// prior flat-random pick, so the disabled path stays byte-for-byte unchanged.
+type globalRandSource struct{}
+
+func (globalRandSource) Intn(n int) int   { return rand.Intn(n) }
+func (globalRandSource) Float64() float64 { return rand.Float64() }
+
 // SelectWithConcentrationCap picks one endpoint from validEndpoints, biased so that
 // no single operator (eTLD+1) exceeds maxOperatorShare of the selection probability.
 //
@@ -37,6 +51,29 @@ func SelectWithConcentrationCap(
 	validEndpoints protocol.EndpointAddrList,
 	maxOperatorShare float64,
 ) protocol.EndpointAddr {
+	_ = logger
+	return selectWithConcentrationCap(validEndpoints, maxOperatorShare, globalRandSource{})
+}
+
+// SelectWithConcentrationCapSeeded is a deterministic variant of
+// SelectWithConcentrationCap: given the same endpoint slice, cap, and seed it always
+// returns the same endpoint. Used by the WebSocket rebind path, which must spread
+// tied-best endpoints across operators while staying reproducible across replays and
+// pods (seed from a per-connection-stable value). The caller must pass validEndpoints
+// in a stable order (e.g. sorted) so the operator grouping is deterministic.
+func SelectWithConcentrationCapSeeded(
+	validEndpoints protocol.EndpointAddrList,
+	maxOperatorShare float64,
+	seed int64,
+) protocol.EndpointAddr {
+	return selectWithConcentrationCap(validEndpoints, maxOperatorShare, rand.New(rand.NewSource(seed))) //nolint:gosec // not security-sensitive; deterministic spread by design
+}
+
+func selectWithConcentrationCap(
+	validEndpoints protocol.EndpointAddrList,
+	maxOperatorShare float64,
+	r randSource,
+) protocol.EndpointAddr {
 	n := len(validEndpoints)
 	if n == 0 {
 		return protocol.EndpointAddr("")
@@ -44,7 +81,7 @@ func SelectWithConcentrationCap(
 
 	// Disabled / trivial: preserve the exact prior behavior (flat random pick).
 	if n == 1 || maxOperatorShare <= 0 || maxOperatorShare >= 1 {
-		return validEndpoints[rand.Intn(n)]
+		return validEndpoints[r.Intn(n)]
 	}
 
 	// Group endpoints by operator (eTLD+1). Unresolvable eTLD+1 → singleton operator
@@ -67,7 +104,7 @@ func SelectWithConcentrationCap(
 	// Single operator: the cap has nothing to reshape. A flat random pick is a uniform
 	// pick within that one operator — identical, and cheaper.
 	if m == 1 {
-		return validEndpoints[rand.Intn(n)]
+		return validEndpoints[r.Intn(n)]
 	}
 
 	// Per-operator weights. Start from per-endpoint-uniform (n_i/N): a weighted operator
@@ -88,9 +125,9 @@ func SelectWithConcentrationCap(
 	}
 
 	// Weighted pick of an operator, then uniform pick of an endpoint within it.
-	opIdx := weightedPick(weights)
+	opIdx := weightedPick(weights, r)
 	eps := operatorEndpoints[operatorOrder[opIdx]]
-	return eps[rand.Intn(len(eps))]
+	return eps[r.Intn(len(eps))]
 }
 
 // waterFillToCap clamps any weight above cap and redistributes the excess to the
@@ -126,19 +163,19 @@ func waterFillToCap(weights []float64, maxShare float64) {
 	}
 }
 
-// weightedPick returns an index chosen with probability proportional to weights[i].
-// Assumes weights sum to ~1 and are non-negative. Falls back to the last index on
-// floating-point shortfall.
-func weightedPick(weights []float64) int {
+// weightedPick returns an index chosen with probability proportional to weights[i],
+// drawing from the supplied RNG. Assumes weights sum to ~1 and are non-negative. Falls
+// back to the last index on floating-point shortfall.
+func weightedPick(weights []float64, r randSource) int {
 	var total float64
 	for _, w := range weights {
 		total += w
 	}
-	r := rand.Float64() * total
+	target := r.Float64() * total
 	var cum float64
 	for i, w := range weights {
 		cum += w
-		if r < cum {
+		if target < cum {
 			return i
 		}
 	}

--- a/qos/selector/concentration_cap.go
+++ b/qos/selector/concentration_cap.go
@@ -1,0 +1,146 @@
+package selector
+
+import (
+	"math/rand"
+
+	"github.com/pokt-network/poktroll/pkg/polylog"
+
+	shannonmetrics "github.com/pokt-network/path/metrics/protocol/shannon"
+	"github.com/pokt-network/path/protocol"
+)
+
+// concentrationCapEpsilon guards the water-filling loop against floating-point
+// rounding when comparing an operator's weight to the cap.
+const concentrationCapEpsilon = 1e-9
+
+// SelectWithConcentrationCap picks one endpoint from validEndpoints, biased so that
+// no single operator (eTLD+1) exceeds maxOperatorShare of the selection probability.
+//
+// Below the cap, behavior is identical to a flat random pick (share still tracks an
+// operator's endpoint-count). Only the probability mass that a dominant operator holds
+// *above* the cap is redistributed — proportionally, via water-filling — to the
+// under-cap operators. This bounds the blast radius of any single operator failing
+// (e.g. a supplier that holds most of a service's endpoints) without over-correcting
+// toward thin operators the way a two-stage uniform pick would.
+//
+// Selection is two-step: pick an operator by its (capped) weight, then pick an endpoint
+// uniformly within that operator.
+//
+// The cap is DISABLED (byte-for-byte a flat random pick) when:
+//   - maxOperatorShare <= 0 or >= 1 (the canary A/B off-switch), or
+//   - there are 0 or 1 endpoints.
+//
+// Endpoints whose eTLD+1 cannot be resolved are each treated as their own singleton
+// operator (never merged into one bucket — that would fabricate concentration).
+func SelectWithConcentrationCap(
+	logger polylog.Logger,
+	validEndpoints protocol.EndpointAddrList,
+	maxOperatorShare float64,
+) protocol.EndpointAddr {
+	n := len(validEndpoints)
+	if n == 0 {
+		return protocol.EndpointAddr("")
+	}
+
+	// Disabled / trivial: preserve the exact prior behavior (flat random pick).
+	if n == 1 || maxOperatorShare <= 0 || maxOperatorShare >= 1 {
+		return validEndpoints[rand.Intn(n)]
+	}
+
+	// Group endpoints by operator (eTLD+1). Unresolvable eTLD+1 → singleton operator
+	// keyed by the endpoint address itself, so it can never be merged with another.
+	endpointTLDs := shannonmetrics.GetEndpointTLDs(validEndpoints)
+	operatorEndpoints := make(map[string]protocol.EndpointAddrList)
+	operatorOrder := make([]string, 0)
+	for _, ep := range validEndpoints {
+		key := endpointTLDs[ep]
+		if key == "" {
+			key = string(ep)
+		}
+		if _, seen := operatorEndpoints[key]; !seen {
+			operatorOrder = append(operatorOrder, key)
+		}
+		operatorEndpoints[key] = append(operatorEndpoints[key], ep)
+	}
+
+	m := len(operatorOrder)
+	// Single operator: the cap has nothing to reshape. A flat random pick is a uniform
+	// pick within that one operator — identical, and cheaper.
+	if m == 1 {
+		return validEndpoints[rand.Intn(n)]
+	}
+
+	// Per-operator weights. Start from per-endpoint-uniform (n_i/N): a weighted operator
+	// pick followed by a uniform pick within the operator then reproduces a flat random
+	// pick exactly — until the cap reshapes an over-cap operator's mass.
+	weights := make([]float64, m)
+	if maxOperatorShare*float64(m) <= 1.0 {
+		// Infeasible (or exactly at the 1/M floor): no assignment can hold every operator
+		// under the cap, so the best achievable is uniform-over-operators (max share 1/M).
+		for i := range weights {
+			weights[i] = 1.0 / float64(m)
+		}
+	} else {
+		for i, key := range operatorOrder {
+			weights[i] = float64(len(operatorEndpoints[key])) / float64(n)
+		}
+		waterFillToCap(weights, maxOperatorShare)
+	}
+
+	// Weighted pick of an operator, then uniform pick of an endpoint within it.
+	opIdx := weightedPick(weights)
+	eps := operatorEndpoints[operatorOrder[opIdx]]
+	return eps[rand.Intn(len(eps))]
+}
+
+// waterFillToCap clamps any weight above cap and redistributes the excess to the
+// under-cap weights, proportionally to their current weight, until no weight exceeds
+// the cap. Feasibility (cap*len(weights) > 1) is guaranteed by the caller, so the loop
+// always terminates with total mass preserved (≈ 1). Operates in place.
+func waterFillToCap(weights []float64, maxShare float64) {
+	// At most len(weights) passes: each pass pins at least one new operator to the cap.
+	for pass := 0; pass < len(weights); pass++ {
+		var excess, underSum float64
+		anyOver := false
+		for _, w := range weights {
+			switch {
+			case w > maxShare+concentrationCapEpsilon:
+				excess += w - maxShare
+				anyOver = true
+			case w < maxShare-concentrationCapEpsilon:
+				underSum += w
+			}
+		}
+		if !anyOver {
+			return
+		}
+		// Redistribute excess to the under-cap operators, proportional to their weight.
+		// underSum > 0 is guaranteed by the caller's feasibility check (maxShare*m > 1).
+		for i, w := range weights {
+			if w > maxShare+concentrationCapEpsilon {
+				weights[i] = maxShare
+			} else if w < maxShare-concentrationCapEpsilon {
+				weights[i] = w + excess*(w/underSum)
+			}
+		}
+	}
+}
+
+// weightedPick returns an index chosen with probability proportional to weights[i].
+// Assumes weights sum to ~1 and are non-negative. Falls back to the last index on
+// floating-point shortfall.
+func weightedPick(weights []float64) int {
+	var total float64
+	for _, w := range weights {
+		total += w
+	}
+	r := rand.Float64() * total
+	var cum float64
+	for i, w := range weights {
+		cum += w
+		if r < cum {
+			return i
+		}
+	}
+	return len(weights) - 1
+}

--- a/qos/selector/concentration_cap.go
+++ b/qos/selector/concentration_cap.go
@@ -49,54 +49,61 @@ func SelectWithConcentrationCap(
 		return validEndpoints[rand.Intn(n)]
 	}
 
-	// Group endpoints by operator (eTLD+1). The eTLD+1 is extracted inline (rather than via
-	// shannonmetrics.GetEndpointTLDs) to avoid materializing a throwaway map on this hot
-	// path — the map would be built and then read exactly once, in this same loop.
-	// Unresolvable eTLD+1 → singleton operator keyed by the endpoint address itself, so it
-	// can never be merged with another.
-	operatorEndpoints := make(map[string]protocol.EndpointAddrList)
-	operatorOrder := make([]string, 0, n)
-	for _, ep := range validEndpoints {
-		key := shannonmetrics.ExtractTLDFromEndpointAddr(string(ep))
-		if key == "" {
-			key = string(ep)
+	// Phase 1 — cheap pass: resolve each endpoint's operator (eTLD+1) once, count endpoints
+	// per operator into an int map (no per-operator slices), and remember each endpoint's
+	// key so Phase 2 never has to resolve it again. This is enough to decide whether the cap
+	// does anything: the common case — no single operator over the cap — exits here with a
+	// flat random pick, never building the per-operator grouping or the weight vector.
+	// Unresolvable eTLD+1 → singleton operator keyed by the endpoint address (operatorKey).
+	keys := make([]string, n)
+	counts := make(map[string]int)
+	maxCount := 0
+	for i, ep := range validEndpoints {
+		k := operatorKey(ep)
+		keys[i] = k
+		counts[k]++
+		if counts[k] > maxCount {
+			maxCount = counts[k]
 		}
-		if _, seen := operatorEndpoints[key]; !seen {
-			operatorOrder = append(operatorOrder, key)
-		}
-		operatorEndpoints[key] = append(operatorEndpoints[key], ep)
 	}
+	m := len(counts)
 
-	m := len(operatorOrder)
-	// Single operator: the cap has nothing to reshape. A flat random pick is a uniform
-	// pick within that one operator — identical, and cheaper.
-	if m == 1 {
+	// The cap reshapes only when some operator exceeds it (n_i > cap·N) or the pool is too
+	// concentrated for the cap to be satisfiable (cap·m ≤ 1 → uniform-over-operators). A
+	// single operator, or a dominant share already at/under the cap, is a no-op: the capped
+	// weighted pick would reduce exactly to a flat random pick, so take that directly.
+	infeasible := maxOperatorShare*float64(m) <= 1.0
+	if m == 1 || (!infeasible && float64(maxCount) <= maxOperatorShare*float64(n)) {
 		return validEndpoints[rand.Intn(n)]
 	}
 
-	// Per-operator weights. Start from per-endpoint-uniform (n_i/N): a weighted operator
-	// pick followed by a uniform pick within the operator then reproduces a flat random
-	// pick exactly — until the cap reshapes an over-cap operator's mass.
+	// Phase 2 — reshape. Build the per-operator endpoint grouping (reusing the keys resolved
+	// in Phase 1) and the capped weights. The distribution is actually being altered here,
+	// so record it.
+	metrics.RecordConcentrationCapReshaped(string(serviceID))
+	operatorEndpoints := make(map[string]protocol.EndpointAddrList, m)
+	operatorOrder := make([]string, 0, m)
+	for i, ep := range validEndpoints {
+		k := keys[i]
+		if _, seen := operatorEndpoints[k]; !seen {
+			operatorOrder = append(operatorOrder, k)
+		}
+		operatorEndpoints[k] = append(operatorEndpoints[k], ep)
+	}
+
 	weights := make([]float64, m)
-	reshaped := false
-	if maxOperatorShare*float64(m) <= 1.0 {
-		// Infeasible (or exactly at the 1/M floor): no assignment can hold every operator
-		// under the cap, so the best achievable is uniform-over-operators (max share 1/M).
+	if infeasible {
+		// No assignment can hold every operator under the cap → best achievable is
+		// uniform-over-operators (max share 1/m).
 		for i := range weights {
 			weights[i] = 1.0 / float64(m)
 		}
-		reshaped = true
 	} else {
+		// Per-endpoint-uniform (n_i/N) start, then water-fill the over-cap mass down.
 		for i, key := range operatorOrder {
 			weights[i] = float64(len(operatorEndpoints[key])) / float64(n)
 		}
-		reshaped = waterFillToCap(weights, maxOperatorShare)
-	}
-
-	// Emit only when the cap actually changed the distribution — no-op selections (no
-	// operator over the cap) stay silent, so a nonzero rate means the cap is biting.
-	if reshaped {
-		metrics.RecordConcentrationCapReshaped(string(serviceID))
+		waterFillToCap(weights, maxOperatorShare)
 	}
 
 	// Weighted pick of an operator, then uniform pick of an endpoint within it.
@@ -105,14 +112,22 @@ func SelectWithConcentrationCap(
 	return eps[rand.Intn(len(eps))]
 }
 
+// operatorKey returns the operator bucket for an endpoint: its eTLD+1, or the endpoint
+// address itself when the eTLD+1 cannot be resolved (so unresolvable endpoints stay
+// singletons and are never merged, which would fabricate concentration).
+func operatorKey(ep protocol.EndpointAddr) string {
+	if k := shannonmetrics.ExtractTLDFromEndpointAddr(string(ep)); k != "" {
+		return k
+	}
+	return string(ep)
+}
+
 // waterFillToCap clamps any weight above cap and redistributes the excess to the
 // under-cap weights, proportionally to their current weight, until no weight exceeds
-// the cap. The caller only invokes this when the cap is feasible (cap*len(weights) > 1),
-// so total mass is preserved (≈ 1); the underSum guard keeps it safe even if that ever
-// fails to hold. Operates in place. Returns true if it clamped at least one weight (i.e.
-// the cap actually reshaped the distribution).
-func waterFillToCap(weights []float64, maxShare float64) bool {
-	clamped := false
+// the cap. The caller only invokes this when the cap is feasible (cap*len(weights) > 1)
+// and some weight is over the cap, so total mass is preserved (≈ 1); the underSum guard
+// keeps it safe even if that ever fails to hold. Operates in place.
+func waterFillToCap(weights []float64, maxShare float64) {
 	// At most len(weights) passes: each pass pins at least one new operator to the cap.
 	for pass := 0; pass < len(weights); pass++ {
 		var excess, underSum float64
@@ -127,9 +142,8 @@ func waterFillToCap(weights []float64, maxShare float64) bool {
 			}
 		}
 		if !anyOver {
-			return clamped
+			return
 		}
-		clamped = true
 		// No under-cap operator to absorb the excess (only reachable if the caller's
 		// feasibility guarantee is violated). Clamp what we can and stop rather than
 		// dividing by zero.
@@ -139,7 +153,7 @@ func waterFillToCap(weights []float64, maxShare float64) bool {
 					weights[i] = maxShare
 				}
 			}
-			return clamped
+			return
 		}
 		// Redistribute excess to the under-cap operators, proportional to their weight.
 		for i, w := range weights {
@@ -150,7 +164,6 @@ func waterFillToCap(weights []float64, maxShare float64) bool {
 			}
 		}
 	}
-	return clamped
 }
 
 // weightedPick returns an index chosen with probability proportional to weights[i].

--- a/qos/selector/concentration_cap.go
+++ b/qos/selector/concentration_cap.go
@@ -112,6 +112,49 @@ func SelectWithConcentrationCap(
 	return eps[rand.Intn(len(eps))]
 }
 
+// SelectOperatorUniform picks one endpoint so that every operator (eTLD+1) present is equally
+// likely, then an endpoint uniformly within the chosen operator. Unlike
+// SelectWithConcentrationCap — which is endpoint-count-weighted and only trims the mass a
+// dominant operator holds *above* the cap — this gives each operator an identical share
+// regardless of how many endpoints it runs. It is the strongest per-operator spread, used
+// for the WebSocket rebind path where distributing connections across providers matters more
+// than matching endpoint capacity.
+//
+// Trade-off: a thin operator receives the same share as a large one, so a single-endpoint
+// operator absorbs a full 1/m of the load. Callers that cannot tolerate overloading a small
+// provider should use the concentration cap instead.
+//
+// Endpoints whose eTLD+1 cannot be resolved are each their own singleton operator (via
+// operatorKey), never merged. serviceID is currently unused but kept for signature symmetry
+// with SelectWithConcentrationCap and future metric attribution.
+func SelectOperatorUniform(
+	serviceID protocol.ServiceID,
+	validEndpoints protocol.EndpointAddrList,
+) protocol.EndpointAddr {
+	_ = serviceID
+	n := len(validEndpoints)
+	if n == 0 {
+		return protocol.EndpointAddr("")
+	}
+	if n == 1 {
+		return validEndpoints[0]
+	}
+
+	operatorEndpoints := make(map[string]protocol.EndpointAddrList)
+	operatorOrder := make([]string, 0)
+	for _, ep := range validEndpoints {
+		k := operatorKey(ep)
+		if _, seen := operatorEndpoints[k]; !seen {
+			operatorOrder = append(operatorOrder, k)
+		}
+		operatorEndpoints[k] = append(operatorEndpoints[k], ep)
+	}
+
+	// Uniform over operators, then uniform within the chosen operator.
+	eps := operatorEndpoints[operatorOrder[rand.Intn(len(operatorOrder))]]
+	return eps[rand.Intn(len(eps))]
+}
+
 // operatorKey returns the operator bucket for an endpoint: its eTLD+1, or the endpoint
 // address itself when the eTLD+1 cannot be resolved (so unresolvable endpoints stay
 // singletons and are never merged, which would fabricate concentration).

--- a/qos/selector/concentration_cap_test.go
+++ b/qos/selector/concentration_cap_test.go
@@ -1,0 +1,161 @@
+package selector
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/pokt-network/poktroll/pkg/polylog/polyzero"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pokt-network/path/protocol"
+)
+
+// makeOperatorPool builds an endpoint list where operator i (eTLD+1 opN.example) owns
+// keyCounts[i] distinct endpoints. Endpoint addresses use the production
+// "supplier-https://host" format so shannonmetrics.GetEndpointTLDs resolves the eTLD+1.
+func makeOperatorPool(keyCounts []int) (protocol.EndpointAddrList, []string) {
+	var eps protocol.EndpointAddrList
+	operators := make([]string, len(keyCounts))
+	for i, count := range keyCounts {
+		// Use a distinct registrable domain per operator: op0.tech, op1.tech, ...
+		domain := fmt.Sprintf("op%d.tech", i)
+		operators[i] = domain
+		for k := 0; k < count; k++ {
+			eps = append(eps, protocol.EndpointAddr(
+				fmt.Sprintf("pokt1op%dkey%d-https://node%d.%s", i, k, k, domain),
+			))
+		}
+	}
+	return eps, operators
+}
+
+// operatorShares runs the selector N times and returns each operator's observed
+// selection share, keyed by the operator's eTLD+1.
+func operatorShares(
+	t *testing.T,
+	eps protocol.EndpointAddrList,
+	maxShare float64,
+	draws int,
+) map[string]float64 {
+	t.Helper()
+	logger := polyzero.NewLogger(polyzero.WithOutput(os.Stderr))
+	counts := map[string]int{}
+	for i := 0; i < draws; i++ {
+		sel := SelectWithConcentrationCap(logger, eps, maxShare)
+		require.NotEmpty(t, sel, "selector returned empty endpoint")
+		require.Contains(t, eps, sel, "selector returned an endpoint not in the pool")
+		counts[operatorOf(string(sel))]++
+	}
+	shares := map[string]float64{}
+	for op, c := range counts {
+		shares[op] = float64(c) / float64(draws)
+	}
+	return shares
+}
+
+// operatorOf extracts the "opN.tech" eTLD+1 from a test endpoint address of the form
+// "pokt1opNkeyK-https://nodeK.opN.tech" — the last two dot-separated segments.
+func operatorOf(addr string) string {
+	segments := strings.Split(addr, ".")
+	if len(segments) < 2 {
+		return addr
+	}
+	return segments[len(segments)-2] + "." + segments[len(segments)-1]
+}
+
+func TestSelectWithConcentrationCap_CapsDominantOperator(t *testing.T) {
+	// One 10-key operator + three 1-key operators. Flat random would give the big
+	// operator 10/13 ≈ 0.77. Cap at 0.4 must pull it down to ~0.40; the three
+	// singletons absorb the redistributed remainder (~0.20 each).
+	eps, ops := makeOperatorPool([]int{10, 1, 1, 1})
+	shares := operatorShares(t, eps, 0.4, 200_000)
+
+	big := ops[0]
+	require.InDelta(t, 0.40, shares[big], 0.02,
+		"dominant operator should be capped near 0.40, got %.3f", shares[big])
+	for _, op := range ops[1:] {
+		require.InDelta(t, 0.20, shares[op], 0.02,
+			"singleton operator %s should absorb remainder near 0.20, got %.3f", op, shares[op])
+	}
+}
+
+func TestSelectWithConcentrationCap_NoOpBelowCap(t *testing.T) {
+	// Operators 2/2/1/1 keys → max operator share 2/6 ≈ 0.33, below the 0.5 cap.
+	// Distribution must stay statistically identical to a flat random pick: each
+	// endpoint ≈ 1/6, so each operator's share ≈ keys/6.
+	eps, ops := makeOperatorPool([]int{2, 2, 1, 1})
+	shares := operatorShares(t, eps, 0.5, 200_000)
+
+	expected := map[string]float64{ops[0]: 2.0 / 6, ops[1]: 2.0 / 6, ops[2]: 1.0 / 6, ops[3]: 1.0 / 6}
+	for op, exp := range expected {
+		require.InDelta(t, exp, shares[op], 0.02,
+			"below-cap distribution should match flat random for %s: want %.3f got %.3f", op, exp, shares[op])
+	}
+}
+
+func TestSelectWithConcentrationCap_Disabled(t *testing.T) {
+	// maxShare <= 0 and >= 1 disable the cap → flat random over endpoints (key-weighted).
+	// A 3-key operator + 1-key operator → big operator ≈ 0.75.
+	eps, ops := makeOperatorPool([]int{3, 1})
+	for _, disabled := range []float64{0, 1.0, -0.5, 1.5} {
+		shares := operatorShares(t, eps, disabled, 100_000)
+		require.InDelta(t, 0.75, shares[ops[0]], 0.02,
+			"disabled cap (%.1f) should be flat/key-weighted, got %.3f", disabled, shares[ops[0]])
+	}
+}
+
+func TestSelectWithConcentrationCap_FeasibilityFloor(t *testing.T) {
+	// 2 operators, cap 0.4 < 1/M (0.5) → infeasible. Result must be uniform-over-
+	// operators (~0.5/0.5), NOT the key-weighted 0.75/0.25. No panic, no hang.
+	eps, ops := makeOperatorPool([]int{3, 1})
+	shares := operatorShares(t, eps, 0.4, 200_000)
+	require.InDelta(t, 0.5, shares[ops[0]], 0.02, "infeasible cap → uniform over operators")
+	require.InDelta(t, 0.5, shares[ops[1]], 0.02, "infeasible cap → uniform over operators")
+}
+
+func TestSelectWithConcentrationCap_SingleAndEmpty(t *testing.T) {
+	logger := polyzero.NewLogger(polyzero.WithOutput(os.Stderr))
+
+	// Empty input → empty result, no panic.
+	require.Empty(t, SelectWithConcentrationCap(logger, protocol.EndpointAddrList{}, 0.4))
+
+	// Single endpoint → that endpoint, cap irrelevant.
+	one := protocol.EndpointAddrList{"pokt1solo-https://node.solo.tech"}
+	require.Equal(t, one[0], SelectWithConcentrationCap(logger, one, 0.4))
+
+	// Single operator with many keys → always returns one of its keys.
+	eps, _ := makeOperatorPool([]int{5})
+	sel := SelectWithConcentrationCap(logger, eps, 0.4)
+	require.Contains(t, eps, sel)
+}
+
+func TestSelectWithConcentrationCap_UnresolvableStaySeparate(t *testing.T) {
+	// Two endpoints with unresolvable eTLD+1 must be treated as two singleton operators,
+	// not merged into one bucket (which would fabricate concentration). With a 0.6 cap
+	// and two singletons, each should get ~0.5 — not one of them dominating.
+	logger := polyzero.NewLogger(polyzero.WithOutput(os.Stderr))
+	eps := protocol.EndpointAddrList{"garbage-addr-one", "garbage-addr-two"}
+	counts := map[string]int{}
+	for i := 0; i < 50_000; i++ {
+		counts[string(SelectWithConcentrationCap(logger, eps, 0.6))]++
+	}
+	require.InDelta(t, 0.5, float64(counts["garbage-addr-one"])/50_000, 0.03,
+		"unresolvable endpoints must not be merged")
+}
+
+func TestWaterFillToCap_PreservesMassAndCaps(t *testing.T) {
+	// Direct unit test of the water-filling core: mass is preserved and no weight
+	// exceeds the cap when feasible.
+	weights := []float64{0.7, 0.1, 0.1, 0.1} // one operator over a 0.4 cap
+	waterFillToCap(weights, 0.4)
+
+	var total float64
+	for _, w := range weights {
+		require.LessOrEqual(t, w, 0.4+concentrationCapEpsilon, "no weight may exceed the cap")
+		total += w
+	}
+	require.InDelta(t, 1.0, total, 1e-9, "water-filling must preserve total mass")
+	require.InDelta(t, 0.4, weights[0], 1e-9, "over-cap weight clamped to cap")
+}

--- a/qos/selector/concentration_cap_test.go
+++ b/qos/selector/concentration_cap_test.go
@@ -2,12 +2,9 @@ package selector
 
 import (
 	"fmt"
-	"hash/fnv"
-	"os"
 	"strings"
 	"testing"
 
-	"github.com/pokt-network/poktroll/pkg/polylog/polyzero"
 	"github.com/stretchr/testify/require"
 
 	"github.com/pokt-network/path/protocol"
@@ -41,10 +38,9 @@ func operatorShares(
 	draws int,
 ) map[string]float64 {
 	t.Helper()
-	logger := polyzero.NewLogger(polyzero.WithOutput(os.Stderr))
 	counts := map[string]int{}
 	for i := 0; i < draws; i++ {
-		sel := SelectWithConcentrationCap(logger, eps, maxShare)
+		sel := SelectWithConcentrationCap(eps, maxShare)
 		require.NotEmpty(t, sel, "selector returned empty endpoint")
 		require.Contains(t, eps, sel, "selector returned an endpoint not in the pool")
 		counts[operatorOf(string(sel))]++
@@ -117,18 +113,17 @@ func TestSelectWithConcentrationCap_FeasibilityFloor(t *testing.T) {
 }
 
 func TestSelectWithConcentrationCap_SingleAndEmpty(t *testing.T) {
-	logger := polyzero.NewLogger(polyzero.WithOutput(os.Stderr))
 
 	// Empty input → empty result, no panic.
-	require.Empty(t, SelectWithConcentrationCap(logger, protocol.EndpointAddrList{}, 0.4))
+	require.Empty(t, SelectWithConcentrationCap(protocol.EndpointAddrList{}, 0.4))
 
 	// Single endpoint → that endpoint, cap irrelevant.
 	one := protocol.EndpointAddrList{"pokt1solo-https://node.solo.tech"}
-	require.Equal(t, one[0], SelectWithConcentrationCap(logger, one, 0.4))
+	require.Equal(t, one[0], SelectWithConcentrationCap(one, 0.4))
 
 	// Single operator with many keys → always returns one of its keys.
 	eps, _ := makeOperatorPool([]int{5})
-	sel := SelectWithConcentrationCap(logger, eps, 0.4)
+	sel := SelectWithConcentrationCap(eps, 0.4)
 	require.Contains(t, eps, sel)
 }
 
@@ -136,57 +131,30 @@ func TestSelectWithConcentrationCap_UnresolvableStaySeparate(t *testing.T) {
 	// Two endpoints with unresolvable eTLD+1 must be treated as two singleton operators,
 	// not merged into one bucket (which would fabricate concentration). With a 0.6 cap
 	// and two singletons, each should get ~0.5 — not one of them dominating.
-	logger := polyzero.NewLogger(polyzero.WithOutput(os.Stderr))
 	eps := protocol.EndpointAddrList{"garbage-addr-one", "garbage-addr-two"}
 	counts := map[string]int{}
 	for i := 0; i < 50_000; i++ {
-		counts[string(SelectWithConcentrationCap(logger, eps, 0.6))]++
+		counts[string(SelectWithConcentrationCap(eps, 0.6))]++
 	}
 	require.InDelta(t, 0.5, float64(counts["garbage-addr-one"])/50_000, 0.03,
 		"unresolvable endpoints must not be merged")
 }
 
-func TestSelectWithConcentrationCapSeeded_Deterministic(t *testing.T) {
-	eps, _ := makeOperatorPool([]int{10, 1, 1, 1})
-
-	// Same (endpoints, cap, seed) → same endpoint, every time.
-	for _, seed := range []int64{0, 1, 7, 42, 1 << 40} {
-		first := SelectWithConcentrationCapSeeded(eps, 0.4, seed)
-		for i := 0; i < 50; i++ {
-			require.Equal(t, first, SelectWithConcentrationCapSeeded(eps, 0.4, seed),
-				"seeded selection must be deterministic for seed %d", seed)
-		}
-	}
-}
-
-func TestSelectWithConcentrationCapSeeded_SpreadRespectsCap(t *testing.T) {
-	// Across many distinct seeds the seeded variant must obey the same cap as the random
-	// one: the 10-key operator converges near 0.40, not its 0.77 key-share. Seeds are
-	// hashed (mirroring the real per-connection seedAddr) to avoid sequential-seed bias.
-	eps, ops := makeOperatorPool([]int{10, 1, 1, 1})
-	counts := map[string]int{}
-	const draws = 200_000
-	for i := 0; i < draws; i++ {
-		h := fnv.New64a()
-		_, _ = fmt.Fprintf(h, "origin-%d", i)
-		sel := SelectWithConcentrationCapSeeded(eps, 0.4, int64(h.Sum64()))
-		counts[operatorOf(string(sel))]++
-	}
-	require.InDelta(t, 0.40, float64(counts[ops[0]])/float64(draws), 0.02,
-		"seeded spread should cap the dominant operator near 0.40")
-}
-
 func TestWaterFillToCap_PreservesMassAndCaps(t *testing.T) {
 	// Direct unit test of the water-filling core: mass is preserved and no weight
-	// exceeds the cap when feasible.
-	weights := []float64{0.7, 0.1, 0.1, 0.1} // one operator over a 0.4 cap
-	waterFillToCap(weights, 0.4)
-
-	var total float64
-	for _, w := range weights {
-		require.LessOrEqual(t, w, 0.4+concentrationCapEpsilon, "no weight may exceed the cap")
-		total += w
+	// exceeds the cap when feasible. Covers both a single-pass clamp and a multi-pass
+	// cascade (redistribution pushes a second operator over the cap).
+	cases := [][]float64{
+		{0.7, 0.1, 0.1, 0.1},   // single pass: one operator over a 0.4 cap
+		{0.7, 0.28, 0.01, 0.01}, // multi-pass: redistribution pushes op[1] over 0.4
 	}
-	require.InDelta(t, 1.0, total, 1e-9, "water-filling must preserve total mass")
-	require.InDelta(t, 0.4, weights[0], 1e-9, "over-cap weight clamped to cap")
+	for _, weights := range cases {
+		waterFillToCap(weights, 0.4)
+		var total float64
+		for _, w := range weights {
+			require.LessOrEqual(t, w, 0.4+concentrationCapEpsilon, "no weight may exceed the cap")
+			total += w
+		}
+		require.InDelta(t, 1.0, total, 1e-9, "water-filling must preserve total mass")
+	}
 }

--- a/qos/selector/concentration_cap_test.go
+++ b/qos/selector/concentration_cap_test.go
@@ -40,7 +40,7 @@ func operatorShares(
 	t.Helper()
 	counts := map[string]int{}
 	for i := 0; i < draws; i++ {
-		sel := SelectWithConcentrationCap(eps, maxShare)
+		sel := SelectWithConcentrationCap("test", eps, maxShare)
 		require.NotEmpty(t, sel, "selector returned empty endpoint")
 		require.Contains(t, eps, sel, "selector returned an endpoint not in the pool")
 		counts[operatorOf(string(sel))]++
@@ -115,15 +115,15 @@ func TestSelectWithConcentrationCap_FeasibilityFloor(t *testing.T) {
 func TestSelectWithConcentrationCap_SingleAndEmpty(t *testing.T) {
 
 	// Empty input → empty result, no panic.
-	require.Empty(t, SelectWithConcentrationCap(protocol.EndpointAddrList{}, 0.4))
+	require.Empty(t, SelectWithConcentrationCap("test", protocol.EndpointAddrList{}, 0.4))
 
 	// Single endpoint → that endpoint, cap irrelevant.
 	one := protocol.EndpointAddrList{"pokt1solo-https://node.solo.tech"}
-	require.Equal(t, one[0], SelectWithConcentrationCap(one, 0.4))
+	require.Equal(t, one[0], SelectWithConcentrationCap("test", one, 0.4))
 
 	// Single operator with many keys → always returns one of its keys.
 	eps, _ := makeOperatorPool([]int{5})
-	sel := SelectWithConcentrationCap(eps, 0.4)
+	sel := SelectWithConcentrationCap("test", eps, 0.4)
 	require.Contains(t, eps, sel)
 }
 
@@ -134,7 +134,7 @@ func TestSelectWithConcentrationCap_UnresolvableStaySeparate(t *testing.T) {
 	eps := protocol.EndpointAddrList{"garbage-addr-one", "garbage-addr-two"}
 	counts := map[string]int{}
 	for i := 0; i < 50_000; i++ {
-		counts[string(SelectWithConcentrationCap(eps, 0.6))]++
+		counts[string(SelectWithConcentrationCap("test", eps, 0.6))]++
 	}
 	require.InDelta(t, 0.5, float64(counts["garbage-addr-one"])/50_000, 0.03,
 		"unresolvable endpoints must not be merged")

--- a/qos/selector/concentration_cap_test.go
+++ b/qos/selector/concentration_cap_test.go
@@ -2,6 +2,7 @@ package selector
 
 import (
 	"fmt"
+	"hash/fnv"
 	"os"
 	"strings"
 	"testing"
@@ -143,6 +144,36 @@ func TestSelectWithConcentrationCap_UnresolvableStaySeparate(t *testing.T) {
 	}
 	require.InDelta(t, 0.5, float64(counts["garbage-addr-one"])/50_000, 0.03,
 		"unresolvable endpoints must not be merged")
+}
+
+func TestSelectWithConcentrationCapSeeded_Deterministic(t *testing.T) {
+	eps, _ := makeOperatorPool([]int{10, 1, 1, 1})
+
+	// Same (endpoints, cap, seed) → same endpoint, every time.
+	for _, seed := range []int64{0, 1, 7, 42, 1 << 40} {
+		first := SelectWithConcentrationCapSeeded(eps, 0.4, seed)
+		for i := 0; i < 50; i++ {
+			require.Equal(t, first, SelectWithConcentrationCapSeeded(eps, 0.4, seed),
+				"seeded selection must be deterministic for seed %d", seed)
+		}
+	}
+}
+
+func TestSelectWithConcentrationCapSeeded_SpreadRespectsCap(t *testing.T) {
+	// Across many distinct seeds the seeded variant must obey the same cap as the random
+	// one: the 10-key operator converges near 0.40, not its 0.77 key-share. Seeds are
+	// hashed (mirroring the real per-connection seedAddr) to avoid sequential-seed bias.
+	eps, ops := makeOperatorPool([]int{10, 1, 1, 1})
+	counts := map[string]int{}
+	const draws = 200_000
+	for i := 0; i < draws; i++ {
+		h := fnv.New64a()
+		_, _ = fmt.Fprintf(h, "origin-%d", i)
+		sel := SelectWithConcentrationCapSeeded(eps, 0.4, int64(h.Sum64()))
+		counts[operatorOf(string(sel))]++
+	}
+	require.InDelta(t, 0.40, float64(counts[ops[0]])/float64(draws), 0.02,
+		"seeded spread should cap the dominant operator near 0.40")
 }
 
 func TestWaterFillToCap_PreservesMassAndCaps(t *testing.T) {

--- a/qos/selector/operator_uniform_test.go
+++ b/qos/selector/operator_uniform_test.go
@@ -1,0 +1,54 @@
+package selector
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/pokt-network/path/protocol"
+)
+
+// TestSelectOperatorUniform_EqualPerOperator verifies each operator gets ~1/m of selections
+// regardless of endpoint count: op0 owns 8 of 10 endpoints yet still lands ~1/3, unlike the
+// endpoint-count-weighted concentration cap (which would give it ~80%).
+func TestSelectOperatorUniform_EqualPerOperator(t *testing.T) {
+	eps, operators := makeOperatorPool([]int{8, 1, 1})
+
+	counts := map[string]int{}
+	const draws = 3000
+	for i := 0; i < draws; i++ {
+		sel := SelectOperatorUniform("test", eps)
+		require.NotEmpty(t, sel)
+		require.Contains(t, eps, sel)
+		counts[operatorOf(string(sel))]++
+	}
+
+	for _, op := range operators {
+		share := float64(counts[op]) / float64(draws)
+		require.InDelta(t, 1.0/3.0, share, 0.05, "operator %s share %.3f should be ~1/3", op, share)
+	}
+}
+
+// TestSelectOperatorUniform_WithinOperatorUniform verifies that within the chosen operator,
+// endpoints are picked uniformly — op0's two endpoints each land ~half of op0's share.
+func TestSelectOperatorUniform_WithinOperatorUniform(t *testing.T) {
+	eps, _ := makeOperatorPool([]int{2, 2})
+
+	counts := map[string]int{}
+	const draws = 4000
+	for i := 0; i < draws; i++ {
+		counts[string(SelectOperatorUniform("test", eps))]++
+	}
+	// 2 operators × 2 endpoints each → every endpoint ~1/4.
+	for _, ep := range eps {
+		require.InDelta(t, 0.25, float64(counts[string(ep)])/float64(draws), 0.05, "endpoint %s", ep)
+	}
+}
+
+// TestSelectOperatorUniform_SingleAndEmpty covers boundaries.
+func TestSelectOperatorUniform_SingleAndEmpty(t *testing.T) {
+	require.Empty(t, SelectOperatorUniform("test", protocol.EndpointAddrList{}))
+
+	one, _ := makeOperatorPool([]int{1})
+	require.Equal(t, one[0], SelectOperatorUniform("test", one))
+}

--- a/qos/solana/concentration_cap_test.go
+++ b/qos/solana/concentration_cap_test.go
@@ -1,0 +1,30 @@
+package solana
+
+import (
+	"testing"
+
+	"github.com/pokt-network/poktroll/pkg/polylog/polyzero"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSetMaxOperatorShare_RoundTrip verifies the per-operator concentration cap round-trips
+// through the atomic float64-bits storage on the Solana EndpointStore (promoted onto QoS),
+// and that the Solana QoS satisfies the SetMaxOperatorShare interface used by cmd/qos.go.
+func TestSetMaxOperatorShare_RoundTrip(t *testing.T) {
+	logger := polyzero.NewLogger()
+	qos := NewSimpleQoSInstance(logger, "solana")
+
+	// Default: disabled (0).
+	require.Equal(t, 0.0, qos.getMaxOperatorShare())
+
+	// Satisfies the setter interface cmd/qos.go asserts.
+	var _ interface{ SetMaxOperatorShare(float64) } = qos
+
+	for _, v := range []float64{0.4, 0.5, 0.75, 0.999} {
+		qos.SetMaxOperatorShare(v)
+		require.Equal(t, v, qos.getMaxOperatorShare())
+	}
+
+	qos.SetMaxOperatorShare(0)
+	require.Equal(t, 0.0, qos.getMaxOperatorShare())
+}

--- a/qos/solana/extractor.go
+++ b/qos/solana/extractor.go
@@ -56,20 +56,22 @@ func (e *SolanaDataExtractor) ExtractBlockHeight(request []byte, response []byte
 		return 0, fmt.Errorf("response missing result field")
 	}
 
-	// Get blockHeight from result
-	// Note: Solana returns blockHeight as a number, or we might also check absoluteSlot
+	// Get blockHeight from result.
+	//
+	// We deliberately do NOT fall back to absoluteSlot. absoluteSlot is the SLOT, which runs
+	// ~5% HIGHER than block height (skipped slots), so substituting it poisons the perceived
+	// block height: Solana consensus is max-based (see state.go — perceived only ever rises),
+	// so a single slot-valued observation lifts perceived above the true chain tip, after
+	// which every endpoint reporting the correct (lower) block height looks "behind", and the
+	// external getBlockHeight floor — which also only raises perceived — cannot pull it back
+	// down. Solana's getEpochInfo always includes blockHeight; a response without a usable
+	// numeric blockHeight is skipped rather than silently downgraded to a slot.
 	blockHeight := gjson.GetBytes(response, "result.blockHeight")
 	if blockHeight.Exists() && blockHeight.Type == gjson.Number {
 		return blockHeight.Int(), nil
 	}
 
-	// Try absoluteSlot as fallback (some responses use this)
-	absoluteSlot := gjson.GetBytes(response, "result.absoluteSlot")
-	if absoluteSlot.Exists() && absoluteSlot.Type == gjson.Number {
-		return absoluteSlot.Int(), nil
-	}
-
-	return 0, fmt.Errorf("could not extract block height from response")
+	return 0, fmt.Errorf("could not extract block height: getEpochInfo result missing numeric blockHeight field")
 }
 
 // ExtractChainID extracts the cluster identifier from a Solana response.

--- a/qos/solana/extractor_test.go
+++ b/qos/solana/extractor_test.go
@@ -47,6 +47,20 @@ func TestSolanaDataExtractor_ExtractBlockHeight(t *testing.T) {
 			expectError:   false,
 		},
 		{
+			// Regression guard: a getEpochInfo missing blockHeight must NOT be downgraded to
+			// absoluteSlot (the slot is ~5% higher and poisons the max-based perceived height).
+			name: "absoluteSlot only (no blockHeight) must error, not fall back to slot",
+			response: `{
+				"jsonrpc": "2.0",
+				"id": 1,
+				"result": {
+					"absoluteSlot": 434334985,
+					"epoch": 1005
+				}
+			}`,
+			expectError: true,
+		},
+		{
 			name:        "error response",
 			response:    `{"jsonrpc":"2.0","id":1,"error":{"code":-32600,"message":"Invalid Request"}}`,
 			expectError: true,

--- a/qos/solana/redis_sync_test.go
+++ b/qos/solana/redis_sync_test.go
@@ -44,6 +44,13 @@ func (m *mockReputationSvc) SetPerceivedBlockNumber(_ context.Context, serviceID
 	return nil
 }
 
+func (m *mockReputationSvc) DeletePerceivedBlockNumber(_ context.Context, serviceID protocol.ServiceID) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	delete(m.perceivedBlock, serviceID)
+	return nil
+}
+
 func (m *mockReputationSvc) GetPerceivedBlockNumber(_ context.Context, serviceID protocol.ServiceID) uint64 {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -321,4 +328,25 @@ func TestSolana_ConsumeExternalBlockHeight_RejectsImplausible(t *testing.T) {
 	time.Sleep(100 * time.Millisecond)
 	assert.Equal(t, uint64(realHeight+5), qos.GetPerceivedBlockNumber(),
 		"a plausible external advance must still raise perceived")
+}
+
+// TestSolana_ResetPerceivedBlockHeight verifies the chain-state admin reset clears the
+// perceived height both in-memory and in Redis, so a stuck/poisoned value (which the
+// max-only consensus and external floor cannot lower) can be recovered.
+func TestSolana_ResetPerceivedBlockHeight(t *testing.T) {
+	qos := newTestSolanaQoS()
+	mock := newMockReputationSvc()
+	qos.SetReputationService(mock)
+
+	// Seed a stuck/poisoned perceived height in-memory and in the shared store.
+	qos.serviceStateLock.Lock()
+	qos.perceivedBlockHeight = 434_000_000
+	qos.serviceStateLock.Unlock()
+	require.NoError(t, mock.SetPerceivedBlockNumber(context.Background(), testSolanaServiceID, 434_000_000))
+	require.Equal(t, uint64(434_000_000), mock.getBlock(testSolanaServiceID))
+
+	require.NoError(t, qos.ResetPerceivedBlockHeight(context.Background()))
+
+	assert.Equal(t, uint64(0), qos.GetPerceivedBlockNumber(), "in-memory perceived must be cleared")
+	assert.Equal(t, uint64(0), mock.getBlock(testSolanaServiceID), "Redis perceived must be deleted")
 }

--- a/qos/solana/redis_sync_test.go
+++ b/qos/solana/redis_sync_test.go
@@ -281,3 +281,44 @@ func TestSolana_ConsumeExternalBlockHeight_WritesToRedis(t *testing.T) {
 	assert.Equal(t, uint64(300), qos.GetPerceivedBlockNumber())
 	assert.Equal(t, uint64(300), mock.getBlock(testSolanaServiceID))
 }
+
+// TestSolana_ConsumeExternalBlockHeight_RejectsImplausible reproduces the actual
+// 2026-07-21 incident: the configured external source (publicnode getBlockHeight)
+// returned the SLOT (~434M), ~22M above the real block height (~412M). The
+// external-floor path had no plausibility guard, so it wrote the slot straight
+// into perceived every poll, tracking the live slot and re-poisoning within
+// seconds of any manual reset. Honest endpoints reporting the real (lower) height
+// then failed the sync check and were filtered/cooled. The guard must reject the
+// implausible jump while still applying a normal advance.
+func TestSolana_ConsumeExternalBlockHeight_RejectsImplausible(t *testing.T) {
+	qos := newTestSolanaQoS()
+	mock := newMockReputationSvc()
+	qos.SetReputationService(mock)
+
+	// Suppliers report the real Solana block height.
+	const realHeight = 412_000_000
+	qos.serviceStateLock.Lock()
+	qos.perceivedBlockHeight = realHeight
+	qos.serviceStateLock.Unlock()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	heights := make(chan int64, 5)
+	qos.ConsumeExternalBlockHeight(ctx, heights, 1*time.Millisecond)
+	time.Sleep(10 * time.Millisecond)
+
+	// The slot (~22M above the real tip) must be rejected — not written locally or to Redis.
+	heights <- 434_000_000
+	time.Sleep(100 * time.Millisecond)
+	assert.Equal(t, uint64(realHeight), qos.GetPerceivedBlockNumber(),
+		"an implausible external height (slot magnitude) must not poison perceived")
+	assert.NotEqual(t, uint64(434_000_000), mock.getBlock(testSolanaServiceID),
+		"an implausible external height must not be written to Redis for other replicas")
+
+	// A plausible advance is still applied.
+	heights <- realHeight + 5
+	time.Sleep(100 * time.Millisecond)
+	assert.Equal(t, uint64(realHeight+5), qos.GetPerceivedBlockNumber(),
+		"a plausible external advance must still raise perceived")
+}

--- a/qos/solana/solana.go
+++ b/qos/solana/solana.go
@@ -194,6 +194,23 @@ func (q *QoS) GetPerceivedBlockNumber() uint64 {
 	return q.perceivedBlockHeight
 }
 
+// ResetPerceivedBlockHeight clears the perceived block height (in-memory + Redis) so it
+// rebuilds from fresh endpoint observations. Used by the chain-state admin reset to
+// recover from a poisoned/stuck perceived height — the max-based consensus and the
+// external floor only ever RAISE perceived, so a too-high value (e.g. a slot-poisoned
+// height) cannot self-correct. Must be invoked on each pod, since the perceived floor is
+// per-pod in-memory state (mirrors the per-pod circuit-breaker clear).
+func (q *QoS) ResetPerceivedBlockHeight(ctx context.Context) error {
+	q.serviceStateLock.Lock()
+	q.perceivedBlockHeight = 0
+	q.serviceStateLock.Unlock()
+
+	if q.reputationSvc != nil {
+		return q.reputationSvc.DeletePerceivedBlockNumber(ctx, q.ServiceState.serviceID)
+	}
+	return nil
+}
+
 // ConsumeExternalBlockHeight consumes block heights from an external fetcher channel
 // and uses them as a floor for perceivedBlockHeight. This ensures that if all session
 // endpoints are behind the real chain tip, the perceived block is corrected.

--- a/qos/solana/solana.go
+++ b/qos/solana/solana.go
@@ -241,7 +241,20 @@ func (q *QoS) ConsumeExternalBlockHeight(ctx context.Context, heights <-chan int
 						Msg("External block floor skipped — no suppliers have reported yet")
 					continue
 				}
-				if h > q.perceivedBlockHeight {
+				// Guard the external floor the same way the endpoint path is guarded
+				// (see line ~150): an external source must not raise perceived more
+				// than MaxBlockHeightJump above the current value. This blocks a
+				// misbehaving/mislabeled source (e.g. a Solana provider returning the
+				// SLOT ~5% above the real block height for getBlockHeight) from
+				// poisoning perceived arbitrarily high and filtering out honest
+				// endpoints — the external-floor path has no plausibility check
+				// otherwise, unlike the endpoint observation path.
+				if h > q.perceivedBlockHeight && !qos.IsPlausibleBlockHeight(h, q.perceivedBlockHeight) {
+					q.logger.Warn().
+						Uint64("external_block", h).
+						Uint64("perceived_block", q.perceivedBlockHeight).
+						Msg("⚠️ ignoring implausible external block height (possible poisoned external source)")
+				} else if h > q.perceivedBlockHeight {
 					q.logger.Info().
 						Uint64("old_perceived", q.perceivedBlockHeight).
 						Uint64("external_block", h).

--- a/qos/solana/store.go
+++ b/qos/solana/store.go
@@ -86,7 +86,7 @@ func (es *EndpointStore) Select(allAvailableEndpoints protocol.EndpointAddrList)
 	// cap when configured. Disabled (getMaxOperatorShare() <= 0 or >= 1) → byte-for-byte
 	// the prior flat random pick.
 	// TODO_FUTURE: consider ranking filtered endpoints, e.g. based on latency, rather than randomization.
-	return selector.SelectWithConcentrationCap(logger, filteredEndpointsAddr, es.getMaxOperatorShare()), nil
+	return selector.SelectWithConcentrationCap(filteredEndpointsAddr, es.getMaxOperatorShare()), nil
 }
 
 // SelectMultiple returns multiple endpoint addresses from the list of valid endpoints.

--- a/qos/solana/store.go
+++ b/qos/solana/store.go
@@ -6,6 +6,7 @@ import (
 	"math/rand"
 	"sort"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/pokt-network/poktroll/pkg/polylog"
@@ -34,6 +35,23 @@ type EndpointStore struct {
 
 	endpointsMu sync.RWMutex
 	endpoints   map[protocol.EndpointAddr]endpoint
+
+	// maxOperatorShareBits holds a float64 (via math.Float64bits) for the per-operator
+	// (eTLD+1) concentration cap. 0 (the zero value) disables the cap. Set dynamically
+	// from configuration via QoS.SetMaxOperatorShare.
+	maxOperatorShareBits atomic.Uint64
+}
+
+// getMaxOperatorShare returns the configured per-operator concentration cap (0 = disabled).
+func (es *EndpointStore) getMaxOperatorShare() float64 {
+	return math.Float64frombits(es.maxOperatorShareBits.Load())
+}
+
+// SetMaxOperatorShare dynamically sets the per-operator (eTLD+1) concentration cap used
+// during endpoint selection. A value <= 0 or >= 1 disables the cap (flat random pick).
+// Promoted to the Solana QoS via its embedded *EndpointStore.
+func (es *EndpointStore) SetMaxOperatorShare(maxOperatorShare float64) {
+	es.maxOperatorShareBits.Store(math.Float64bits(maxOperatorShare))
 }
 
 // Select returns a random endpoint address from the list of valid endpoints.
@@ -64,8 +82,11 @@ func (es *EndpointStore) Select(allAvailableEndpoints protocol.EndpointAddrList)
 		return picked[0], nil
 	}
 
+	// Select from the valid candidates, applying the per-operator (eTLD+1) concentration
+	// cap when configured. Disabled (getMaxOperatorShare() <= 0 or >= 1) → byte-for-byte
+	// the prior flat random pick.
 	// TODO_FUTURE: consider ranking filtered endpoints, e.g. based on latency, rather than randomization.
-	return filteredEndpointsAddr[rand.Intn(len(filteredEndpointsAddr))], nil
+	return selector.SelectWithConcentrationCap(logger, filteredEndpointsAddr, es.getMaxOperatorShare()), nil
 }
 
 // SelectMultiple returns multiple endpoint addresses from the list of valid endpoints.

--- a/qos/solana/store.go
+++ b/qos/solana/store.go
@@ -6,7 +6,6 @@ import (
 	"math/rand"
 	"sort"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	"github.com/pokt-network/poktroll/pkg/polylog"
@@ -36,22 +35,21 @@ type EndpointStore struct {
 	endpointsMu sync.RWMutex
 	endpoints   map[protocol.EndpointAddr]endpoint
 
-	// maxOperatorShareBits holds a float64 (via math.Float64bits) for the per-operator
-	// (eTLD+1) concentration cap. 0 (the zero value) disables the cap. Set dynamically
-	// from configuration via QoS.SetMaxOperatorShare.
-	maxOperatorShareBits atomic.Uint64
+	// maxOperatorShare is the per-operator (eTLD+1) concentration cap. 0 (the zero value)
+	// disables the cap. Set dynamically from configuration via QoS.SetMaxOperatorShare.
+	maxOperatorShare selector.AtomicFloat64
 }
 
 // getMaxOperatorShare returns the configured per-operator concentration cap (0 = disabled).
 func (es *EndpointStore) getMaxOperatorShare() float64 {
-	return math.Float64frombits(es.maxOperatorShareBits.Load())
+	return es.maxOperatorShare.Load()
 }
 
 // SetMaxOperatorShare dynamically sets the per-operator (eTLD+1) concentration cap used
 // during endpoint selection. A value <= 0 or >= 1 disables the cap (flat random pick).
 // Promoted to the Solana QoS via its embedded *EndpointStore.
 func (es *EndpointStore) SetMaxOperatorShare(maxOperatorShare float64) {
-	es.maxOperatorShareBits.Store(math.Float64bits(maxOperatorShare))
+	es.maxOperatorShare.Store(maxOperatorShare)
 }
 
 // Select returns a random endpoint address from the list of valid endpoints.
@@ -86,7 +84,7 @@ func (es *EndpointStore) Select(allAvailableEndpoints protocol.EndpointAddrList)
 	// cap when configured. Disabled (getMaxOperatorShare() <= 0 or >= 1) → byte-for-byte
 	// the prior flat random pick.
 	// TODO_FUTURE: consider ranking filtered endpoints, e.g. based on latency, rather than randomization.
-	return selector.SelectWithConcentrationCap(filteredEndpointsAddr, es.getMaxOperatorShare()), nil
+	return selector.SelectWithConcentrationCap(es.serviceState.serviceID, filteredEndpointsAddr, es.getMaxOperatorShare()), nil
 }
 
 // SelectMultiple returns multiple endpoint addresses from the list of valid endpoints.

--- a/reputation/key.go
+++ b/reputation/key.go
@@ -21,13 +21,18 @@ type KeyBuilder interface {
 // If the granularity is invalid or empty, it defaults to per-endpoint.
 func NewKeyBuilder(granularity string) KeyBuilder {
 	switch granularity {
+	case KeyGranularityURL:
+		return &URLKeyBuilder{}
 	case KeyGranularityDomain:
 		return &DomainKeyBuilder{}
 	case KeyGranularitySupplier:
 		return &SupplierKeyBuilder{}
-	default:
-		// Default to per-endpoint (finest granularity)
+	case KeyGranularityEndpoint:
 		return &EndpointKeyBuilder{}
+	default:
+		// Empty or unrecognized granularity falls back to the shipped default (per-URL):
+		// shared-backend failures are attributed to the URL, not duplicated per supplier.
+		return &URLKeyBuilder{}
 	}
 }
 
@@ -39,6 +44,27 @@ type EndpointKeyBuilder struct{}
 // BuildKey creates a key using the full endpoint address and RPC type.
 func (b *EndpointKeyBuilder) BuildKey(serviceID protocol.ServiceID, endpointAddr protocol.EndpointAddr, rpcType sharedtypes.RPCType) EndpointKey {
 	return NewEndpointKey(serviceID, endpointAddr, rpcType)
+}
+
+// URLKeyBuilder creates keys with per-URL granularity.
+// All suppliers that front the exact same backend URL share a score, tracked per RPC type.
+// Key format: serviceID:endpointURL (e.g., eth:https://rm-01.eu.nodefleet.net)
+// This drops the supplier address from the key so an exact URL match — i.e. the same
+// physical backend behind multiple staked supplier addresses — is scored (and cooled) once
+// rather than once per supplier. It keeps distinct URLs separate (no dilution across an
+// operator's other backends, unlike per-domain).
+type URLKeyBuilder struct{}
+
+// BuildKey creates a key using the URL extracted from the endpoint address and RPC type.
+// If the URL cannot be extracted, it falls back to the full endpoint address (which
+// degrades safely to per-endpoint granularity for that one malformed address).
+func (b *URLKeyBuilder) BuildKey(serviceID protocol.ServiceID, endpointAddr protocol.EndpointAddr, rpcType sharedtypes.RPCType) EndpointKey {
+	endpointURL, err := endpointAddr.GetURL()
+	if err != nil {
+		// Fallback to full endpoint address if URL extraction fails
+		return NewEndpointKey(serviceID, endpointAddr, rpcType)
+	}
+	return NewEndpointKey(serviceID, protocol.EndpointAddr(endpointURL), rpcType)
 }
 
 // DomainKeyBuilder creates keys with per-domain granularity.

--- a/reputation/key.go
+++ b/reputation/key.go
@@ -48,7 +48,7 @@ func (b *EndpointKeyBuilder) BuildKey(serviceID protocol.ServiceID, endpointAddr
 
 // URLKeyBuilder creates keys with per-URL granularity.
 // All suppliers that front the exact same backend URL share a score, tracked per RPC type.
-// Key format: serviceID:endpointURL (e.g., eth:https://rm-01.eu.nodefleet.net)
+// Key format: serviceID:endpointURL (e.g., eth:https://rm-01.eu.example.com)
 // This drops the supplier address from the key so an exact URL match — i.e. the same
 // physical backend behind multiple staked supplier addresses — is scored (and cooled) once
 // rather than once per supplier. It keeps distinct URLs separate (no dilution across an
@@ -69,7 +69,7 @@ func (b *URLKeyBuilder) BuildKey(serviceID protocol.ServiceID, endpointAddr prot
 
 // DomainKeyBuilder creates keys with per-domain granularity.
 // All endpoints from the same hosting domain share a score, tracked per RPC type.
-// Key format: serviceID:domain:rpcType (e.g., eth:nodefleet.net:json_rpc)
+// Key format: serviceID:domain:rpcType (e.g., eth:example.com:json_rpc)
 type DomainKeyBuilder struct{}
 
 // BuildKey creates a key using the domain extracted from the endpoint URL and RPC type.
@@ -83,7 +83,7 @@ func (b *DomainKeyBuilder) BuildKey(serviceID protocol.ServiceID, endpointAddr p
 		return NewEndpointKey(serviceID, endpointAddr, rpcType)
 	}
 
-	// Extract domain from URL (e.g., nodefleet.net from https://rm-01.eu.nodefleet.net)
+	// Extract domain from URL (e.g., example.com from https://rm-01.eu.example.com)
 	domain, err := shannonmetrics.ExtractDomainOrHost(endpointURL)
 	if err != nil {
 		// Fallback to full endpoint address if domain extraction fails

--- a/reputation/key_test.go
+++ b/reputation/key_test.go
@@ -105,7 +105,7 @@ func TestKeyBuilder_PerSupplier_SameSupplierDifferentURLs(t *testing.T) {
 	require.Equal(t, "eth:pokt1abc123:json_rpc", key1.String())
 }
 
-func TestKeyBuilder_DefaultsToPerEndpoint(t *testing.T) {
+func TestKeyBuilder_DefaultsToPerURL(t *testing.T) {
 	tests := []struct {
 		name        string
 		granularity string
@@ -120,16 +120,81 @@ func TestKeyBuilder_DefaultsToPerEndpoint(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			builder := NewKeyBuilder(tt.granularity)
-			require.IsType(t, &EndpointKeyBuilder{}, builder)
+			require.IsType(t, &URLKeyBuilder{}, builder)
 
-			// Should behave like per-endpoint
+			// Should behave like per-URL: supplier address dropped from the key.
 			serviceID := protocol.ServiceID("eth")
 			endpointAddr := protocol.EndpointAddr("pokt1abc-https://node.com")
 
 			key := builder.BuildKey(serviceID, endpointAddr, sharedtypes.RPCType_JSON_RPC)
-			require.Equal(t, "eth:pokt1abc-https://node.com:json_rpc", key.String())
+			require.Equal(t, "eth:https://node.com:json_rpc", key.String())
 		})
 	}
+}
+
+func TestKeyBuilder_PerURL(t *testing.T) {
+	builder := NewKeyBuilder(KeyGranularityURL)
+	require.IsType(t, &URLKeyBuilder{}, builder)
+
+	serviceID := protocol.ServiceID("eth")
+	endpointAddr := protocol.EndpointAddr("pokt1abc123-https://rm-01.eu.nodefleet.net")
+
+	key := builder.BuildKey(serviceID, endpointAddr, sharedtypes.RPCType_JSON_RPC)
+
+	require.Equal(t, serviceID, key.ServiceID)
+	// Supplier stripped; keyed on the URL.
+	require.Equal(t, protocol.EndpointAddr("https://rm-01.eu.nodefleet.net"), key.EndpointAddr)
+	require.Equal(t, "eth:https://rm-01.eu.nodefleet.net:json_rpc", key.String())
+}
+
+// TestKeyBuilder_PerURL_SameURLDifferentSuppliers is the core behavior: two distinct staked
+// supplier addresses fronting the EXACT same backend URL collapse to one reputation key, so
+// the shared backend's failures (and cooldown) are attributed once instead of once per
+// supplier.
+func TestKeyBuilder_PerURL_SameURLDifferentSuppliers(t *testing.T) {
+	builder := NewKeyBuilder(KeyGranularityURL)
+	serviceID := protocol.ServiceID("eth")
+
+	// Same URL, different supplier addresses (one operator, several staked suppliers).
+	ep1 := protocol.EndpointAddr("pokt1abc123-https://rm-01.eu.nodefleet.net")
+	ep2 := protocol.EndpointAddr("pokt1xyz789-https://rm-01.eu.nodefleet.net")
+
+	key1 := builder.BuildKey(serviceID, ep1, sharedtypes.RPCType_JSON_RPC)
+	key2 := builder.BuildKey(serviceID, ep2, sharedtypes.RPCType_JSON_RPC)
+
+	require.Equal(t, key1, key2, "same exact URL must produce the same key regardless of supplier")
+	require.Equal(t, "eth:https://rm-01.eu.nodefleet.net:json_rpc", key1.String())
+}
+
+// TestKeyBuilder_PerURL_DistinctURLsStaySeparate verifies per-URL does NOT dilute across an
+// operator's distinct backends (the failure mode of per-domain): two different URLs on the
+// same domain get separate keys, so one bad backend is never masked by the operator's
+// healthy ones.
+func TestKeyBuilder_PerURL_DistinctURLsStaySeparate(t *testing.T) {
+	builder := NewKeyBuilder(KeyGranularityURL)
+	serviceID := protocol.ServiceID("eth")
+
+	// Same supplier/domain, different backend URLs.
+	ep1 := protocol.EndpointAddr("pokt1abc-https://rm-01.eu.nodefleet.net")
+	ep2 := protocol.EndpointAddr("pokt1abc-https://rm-02.eu.nodefleet.net")
+
+	key1 := builder.BuildKey(serviceID, ep1, sharedtypes.RPCType_JSON_RPC)
+	key2 := builder.BuildKey(serviceID, ep2, sharedtypes.RPCType_JSON_RPC)
+
+	require.NotEqual(t, key1, key2, "distinct URLs must stay separate — no per-domain dilution")
+}
+
+// TestKeyBuilder_PerURL_RPCTypeSeparation verifies the same URL is still scored separately
+// per RPC type (json_rpc vs websocket), matching the other builders.
+func TestKeyBuilder_PerURL_RPCTypeSeparation(t *testing.T) {
+	builder := NewKeyBuilder(KeyGranularityURL)
+	serviceID := protocol.ServiceID("eth")
+	ep := protocol.EndpointAddr("pokt1abc-https://node.example.com")
+
+	jsonKey := builder.BuildKey(serviceID, ep, sharedtypes.RPCType_JSON_RPC)
+	wsKey := builder.BuildKey(serviceID, ep, sharedtypes.RPCType_WEBSOCKET)
+
+	require.NotEqual(t, jsonKey, wsKey, "same URL under different RPC types must be scored separately")
 }
 
 // =============================================================================

--- a/reputation/key_test.go
+++ b/reputation/key_test.go
@@ -32,23 +32,23 @@ func TestKeyBuilder_PerDomain(t *testing.T) {
 	require.IsType(t, &DomainKeyBuilder{}, builder)
 
 	serviceID := protocol.ServiceID("eth")
-	endpointAddr := protocol.EndpointAddr("pokt1abc123-https://rm-01.eu.nodefleet.net")
+	endpointAddr := protocol.EndpointAddr("pokt1abc123-https://rm-01.eu.example.com")
 
 	key := builder.BuildKey(serviceID, endpointAddr, sharedtypes.RPCType_JSON_RPC)
 
 	require.Equal(t, serviceID, key.ServiceID)
-	// Should extract domain: nodefleet.net
-	require.Equal(t, protocol.EndpointAddr("nodefleet.net"), key.EndpointAddr)
-	require.Equal(t, "eth:nodefleet.net:json_rpc", key.String())
+	// Should extract domain: example.com
+	require.Equal(t, protocol.EndpointAddr("example.com"), key.EndpointAddr)
+	require.Equal(t, "eth:example.com:json_rpc", key.String())
 }
 
 func TestKeyBuilder_PerDomain_SameDomainDifferentSubdomains(t *testing.T) {
 	builder := NewKeyBuilder(KeyGranularityDomain)
 
 	serviceID := protocol.ServiceID("eth")
-	endpoint1 := protocol.EndpointAddr("pokt1abc123-https://rm-01.eu.nodefleet.net")
-	endpoint2 := protocol.EndpointAddr("pokt1xyz789-https://rm-02.us.nodefleet.net")
-	endpoint3 := protocol.EndpointAddr("pokt1def456-https://api.nodefleet.net:8545")
+	endpoint1 := protocol.EndpointAddr("pokt1abc123-https://rm-01.eu.example.com")
+	endpoint2 := protocol.EndpointAddr("pokt1xyz789-https://rm-02.us.example.com")
+	endpoint3 := protocol.EndpointAddr("pokt1def456-https://api.example.com:8545")
 
 	key1 := builder.BuildKey(serviceID, endpoint1, sharedtypes.RPCType_JSON_RPC)
 	key2 := builder.BuildKey(serviceID, endpoint2, sharedtypes.RPCType_JSON_RPC)
@@ -57,14 +57,14 @@ func TestKeyBuilder_PerDomain_SameDomainDifferentSubdomains(t *testing.T) {
 	// All should produce the same key (same domain)
 	require.Equal(t, key1, key2, "Same domain should produce same key")
 	require.Equal(t, key1, key3, "Same domain should produce same key")
-	require.Equal(t, "eth:nodefleet.net:json_rpc", key1.String())
+	require.Equal(t, "eth:example.com:json_rpc", key1.String())
 }
 
 func TestKeyBuilder_PerDomain_DifferentDomains(t *testing.T) {
 	builder := NewKeyBuilder(KeyGranularityDomain)
 
 	serviceID := protocol.ServiceID("eth")
-	endpoint1 := protocol.EndpointAddr("pokt1abc-https://node.nodefleet.net")
+	endpoint1 := protocol.EndpointAddr("pokt1abc-https://node.example.com")
 	endpoint2 := protocol.EndpointAddr("pokt1xyz-https://relay.pokt.network")
 
 	key1 := builder.BuildKey(serviceID, endpoint1, sharedtypes.RPCType_JSON_RPC)
@@ -72,7 +72,7 @@ func TestKeyBuilder_PerDomain_DifferentDomains(t *testing.T) {
 
 	// Different domains should produce different keys
 	require.NotEqual(t, key1, key2)
-	require.Equal(t, "eth:nodefleet.net:json_rpc", key1.String())
+	require.Equal(t, "eth:example.com:json_rpc", key1.String())
 	require.Equal(t, "eth:pokt.network:json_rpc", key2.String())
 }
 
@@ -137,14 +137,14 @@ func TestKeyBuilder_PerURL(t *testing.T) {
 	require.IsType(t, &URLKeyBuilder{}, builder)
 
 	serviceID := protocol.ServiceID("eth")
-	endpointAddr := protocol.EndpointAddr("pokt1abc123-https://rm-01.eu.nodefleet.net")
+	endpointAddr := protocol.EndpointAddr("pokt1abc123-https://rm-01.eu.example.com")
 
 	key := builder.BuildKey(serviceID, endpointAddr, sharedtypes.RPCType_JSON_RPC)
 
 	require.Equal(t, serviceID, key.ServiceID)
 	// Supplier stripped; keyed on the URL.
-	require.Equal(t, protocol.EndpointAddr("https://rm-01.eu.nodefleet.net"), key.EndpointAddr)
-	require.Equal(t, "eth:https://rm-01.eu.nodefleet.net:json_rpc", key.String())
+	require.Equal(t, protocol.EndpointAddr("https://rm-01.eu.example.com"), key.EndpointAddr)
+	require.Equal(t, "eth:https://rm-01.eu.example.com:json_rpc", key.String())
 }
 
 // TestKeyBuilder_PerURL_SameURLDifferentSuppliers is the core behavior: two distinct staked
@@ -156,14 +156,14 @@ func TestKeyBuilder_PerURL_SameURLDifferentSuppliers(t *testing.T) {
 	serviceID := protocol.ServiceID("eth")
 
 	// Same URL, different supplier addresses (one operator, several staked suppliers).
-	ep1 := protocol.EndpointAddr("pokt1abc123-https://rm-01.eu.nodefleet.net")
-	ep2 := protocol.EndpointAddr("pokt1xyz789-https://rm-01.eu.nodefleet.net")
+	ep1 := protocol.EndpointAddr("pokt1abc123-https://rm-01.eu.example.com")
+	ep2 := protocol.EndpointAddr("pokt1xyz789-https://rm-01.eu.example.com")
 
 	key1 := builder.BuildKey(serviceID, ep1, sharedtypes.RPCType_JSON_RPC)
 	key2 := builder.BuildKey(serviceID, ep2, sharedtypes.RPCType_JSON_RPC)
 
 	require.Equal(t, key1, key2, "same exact URL must produce the same key regardless of supplier")
-	require.Equal(t, "eth:https://rm-01.eu.nodefleet.net:json_rpc", key1.String())
+	require.Equal(t, "eth:https://rm-01.eu.example.com:json_rpc", key1.String())
 }
 
 // TestKeyBuilder_PerURL_DistinctURLsStaySeparate verifies per-URL does NOT dilute across an
@@ -175,8 +175,8 @@ func TestKeyBuilder_PerURL_DistinctURLsStaySeparate(t *testing.T) {
 	serviceID := protocol.ServiceID("eth")
 
 	// Same supplier/domain, different backend URLs.
-	ep1 := protocol.EndpointAddr("pokt1abc-https://rm-01.eu.nodefleet.net")
-	ep2 := protocol.EndpointAddr("pokt1abc-https://rm-02.eu.nodefleet.net")
+	ep1 := protocol.EndpointAddr("pokt1abc-https://rm-01.eu.example.com")
+	ep2 := protocol.EndpointAddr("pokt1abc-https://rm-02.eu.example.com")
 
 	key1 := builder.BuildKey(serviceID, ep1, sharedtypes.RPCType_JSON_RPC)
 	key2 := builder.BuildKey(serviceID, ep2, sharedtypes.RPCType_JSON_RPC)
@@ -338,10 +338,10 @@ func TestKeyBuilder_EmptyEndpointAddr(t *testing.T) {
 func TestKeyBuilder_GranularityComparison(t *testing.T) {
 	serviceID := protocol.ServiceID("eth")
 	// Two endpoints from same supplier, same domain
-	supplier1Endpoint1 := protocol.EndpointAddr("pokt1supplier1-https://rm-01.nodefleet.net")
-	supplier1Endpoint2 := protocol.EndpointAddr("pokt1supplier1-https://rm-02.nodefleet.net")
+	supplier1Endpoint1 := protocol.EndpointAddr("pokt1supplier1-https://rm-01.example.com")
+	supplier1Endpoint2 := protocol.EndpointAddr("pokt1supplier1-https://rm-02.example.com")
 	// Endpoint from different supplier, same domain
-	supplier2SameDomain := protocol.EndpointAddr("pokt1supplier2-https://rm-03.nodefleet.net")
+	supplier2SameDomain := protocol.EndpointAddr("pokt1supplier2-https://rm-03.example.com")
 	// Endpoint from different supplier, different domain
 	supplier2DiffDomain := protocol.EndpointAddr("pokt1supplier2-https://relay.pokt.network")
 
@@ -510,8 +510,8 @@ func TestKeyBuilder_DomainSameURLDifferentRPCTypes(t *testing.T) {
 	builder := NewKeyBuilder(KeyGranularityDomain)
 
 	// Different suppliers, same domain, different RPC types
-	endpoint1 := protocol.EndpointAddr("pokt1abc-https://rm-01.nodefleet.net")
-	endpoint2 := protocol.EndpointAddr("pokt1xyz-https://rm-02.nodefleet.net")
+	endpoint1 := protocol.EndpointAddr("pokt1abc-https://rm-01.example.com")
+	endpoint2 := protocol.EndpointAddr("pokt1xyz-https://rm-02.example.com")
 
 	// JSON-RPC keys
 	jsonKey1 := builder.BuildKey(serviceID, endpoint1, sharedtypes.RPCType_JSON_RPC)
@@ -529,8 +529,8 @@ func TestKeyBuilder_DomainSameURLDifferentRPCTypes(t *testing.T) {
 	require.NotEqual(t, jsonKey1, wsKey1, "Same domain with different RPC types should produce different keys")
 
 	// Verify key format includes RPC type
-	require.Equal(t, "eth:nodefleet.net:json_rpc", jsonKey1.String())
-	require.Equal(t, "eth:nodefleet.net:websocket", wsKey1.String())
+	require.Equal(t, "eth:example.com:json_rpc", jsonKey1.String())
+	require.Equal(t, "eth:example.com:websocket", wsKey1.String())
 }
 
 func TestKeyBuilder_SupplierSameSupplierDifferentRPCTypes(t *testing.T) {

--- a/reputation/rate_cooldown_test.go
+++ b/reputation/rate_cooldown_test.go
@@ -1,0 +1,197 @@
+package reputation
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	sharedtypes "github.com/pokt-network/poktroll/x/shared/types"
+	"github.com/stretchr/testify/require"
+)
+
+// newRateTestService builds a reputation service backed by the in-memory mock store,
+// with the standard defaults (InitialScore 80, MinThreshold 30). The rate-cooldown
+// constants (CriticalRateThreshold=0.30, CriticalRateMinObservations=20, alpha=0.05)
+// are package constants, so these tests exercise the shipped defaults directly.
+func newRateTestService(t *testing.T) (*service, context.Context) {
+	t.Helper()
+	ctx := context.Background()
+	store := newMockStorage()
+	t.Cleanup(func() { _ = store.Close() })
+
+	config := Config{Enabled: true, InitialScore: 80, MinThreshold: 30}
+	config.HydrateDefaults()
+
+	svcIface := NewService(config, store)
+	require.NoError(t, svcIface.Start(ctx))
+	t.Cleanup(func() { _ = svcIface.Stop() })
+
+	return svcIface.(*service), ctx
+}
+
+// TestRateCooldown_VolumeIndependence_TheBug is the core test: it reproduces the exact
+// "each success helps them, so bad QoS can't be filtered" scenario and proves the rate
+// detector closes it.
+//
+// Pattern: strictly alternating critical, success, critical, success... (a sustained 50%
+// critical rate). Under the consecutive-strike system this NEVER trips: each success
+// decays 3 strikes, so a critical (+1) followed by a success (-3, floored at 0) keeps
+// CriticalStrikes pinned at 0/1 — it can never climb to the threshold of 5. A high-volume
+// endpoint bleeding this steady rate is therefore invisible to the burst filter no matter
+// how long it runs. The rate detector, keyed on the sustained RATE rather than a
+// success-refillable counter, must cool it down.
+func TestRateCooldown_VolumeIndependence_TheBug(t *testing.T) {
+	svc, ctx := newRateTestService(t)
+	key := NewEndpointKey("eth", "chronic-bad", sharedtypes.RPCType_JSON_RPC)
+
+	for i := 0; i < 60; i++ {
+		if i%2 == 0 {
+			require.NoError(t, svc.RecordSignal(ctx, key, NewCriticalErrorSignal("5xx", 100*time.Millisecond)))
+		} else {
+			require.NoError(t, svc.RecordSignal(ctx, key, NewSuccessSignal(100*time.Millisecond)))
+		}
+	}
+
+	score, err := svc.GetScore(ctx, key)
+	require.NoError(t, err)
+
+	// The endpoint is cooled down...
+	require.True(t, score.IsInCooldown(), "sustained 50%% critical rate must trip the rate cooldown")
+	// ...and it was NOT the burst-strike path: strikes never reached the threshold,
+	// proving the RATE detector fired where the counter-based one structurally cannot.
+	require.Less(t, score.CriticalStrikes, DefaultStrikeThreshold,
+		"burst strikes must stay below threshold on alternating C/S — the cooldown here came from the rate detector, not the strike counter")
+}
+
+// TestRateCooldown_HealthyEndpointNeverTrips verifies a high-volume endpoint with only a
+// tiny, well-spaced critical rate (~2.5%) is never cooled — the rate EWMA decays back down
+// between rare failures and stays far below the threshold. This is the false-positive guard:
+// serving lots of good traffic must not, on its own, put an endpoint at risk.
+func TestRateCooldown_HealthyEndpointNeverTrips(t *testing.T) {
+	svc, ctx := newRateTestService(t)
+	key := NewEndpointKey("eth", "healthy-highvol", sharedtypes.RPCType_JSON_RPC)
+
+	// 200 requests, one critical every 40 (2.5% rate), rest fast successes.
+	for i := 0; i < 200; i++ {
+		if i%40 == 0 {
+			require.NoError(t, svc.RecordSignal(ctx, key, NewCriticalErrorSignal("blip", 100*time.Millisecond)))
+		} else {
+			require.NoError(t, svc.RecordSignal(ctx, key, NewSuccessSignal(50*time.Millisecond)))
+		}
+	}
+
+	score, err := svc.GetScore(ctx, key)
+	require.NoError(t, err)
+	require.False(t, score.IsInCooldown(), "a healthy 2.5%% critical rate must never trip the rate cooldown")
+	require.Less(t, score.RecentCriticalRate, CriticalRateThreshold,
+		"EWMA must stay well below threshold for a healthy endpoint")
+}
+
+// TestRateCooldown_NoTripOnTinySample verifies the minimum-observations guard: an endpoint
+// whose very first signals are critical is not cooled on a tiny, statistically-meaningless
+// sample. (Kept below the burst threshold so this isolates the rate path, not the strike
+// path.)
+func TestRateCooldown_NoTripOnTinySample(t *testing.T) {
+	svc, ctx := newRateTestService(t)
+	key := NewEndpointKey("eth", "fresh", sharedtypes.RPCType_JSON_RPC)
+
+	// 3 criticals as the first 3 signals: EWMA is still low and total observations (3)
+	// are far under CriticalRateMinObservations (20).
+	for i := 0; i < 3; i++ {
+		require.NoError(t, svc.RecordSignal(ctx, key, NewCriticalErrorSignal("early", 100*time.Millisecond)))
+	}
+
+	score, err := svc.GetScore(ctx, key)
+	require.NoError(t, err)
+	require.False(t, score.IsInCooldown(), "must not cool an endpoint on a tiny early sample")
+	require.Less(t, score.CriticalStrikes, DefaultStrikeThreshold, "burst path must not have fired either")
+}
+
+// TestRateCooldown_EWMATracksAndPersists verifies the RecentCriticalRate EWMA is actually
+// updated on the score (and therefore written to storage — mockStorage round-trips the
+// Score by value, exercising the same field the Redis serializer persists). A run of
+// criticals below the min-observations gate should raise the EWMA without yet tripping.
+func TestRateCooldown_EWMATracksAndPersists(t *testing.T) {
+	svc, ctx := newRateTestService(t)
+	key := NewEndpointKey("eth", "ewma", sharedtypes.RPCType_JSON_RPC)
+
+	// A few criticals raise the EWMA above zero; kept under both the burst threshold and
+	// the min-observations gate so nothing trips and the EWMA is observable.
+	for i := 0; i < 4; i++ {
+		require.NoError(t, svc.RecordSignal(ctx, key, NewCriticalErrorSignal("x", 100*time.Millisecond)))
+	}
+
+	score, err := svc.GetScore(ctx, key)
+	require.NoError(t, err)
+	require.Greater(t, score.RecentCriticalRate, 0.0, "EWMA must reflect observed criticals")
+	require.Less(t, score.RecentCriticalRate, CriticalRateThreshold, "should not have tripped yet")
+	require.False(t, score.IsInCooldown())
+}
+
+// TestRateCooldown_EscalatesOnRepeatTrips verifies the escalating backoff: a persistently
+// bad endpoint that re-trips shortly after its previous cooldown gets a longer bench each
+// time (base one session → double → …), while a one-off trip only costs the base.
+func TestRateCooldown_EscalatesOnRepeatTrips(t *testing.T) {
+	svc, ctx := newRateTestService(t)
+	key := NewEndpointKey("eth", "repeat-offender", sharedtypes.RPCType_JSON_RPC)
+
+	// feedUntilTrip drives a sustained high critical rate until the trip counter advances,
+	// then returns the cooldown duration that trip produced.
+	feedUntilTrip := func(wantCount int) time.Duration {
+		for i := 0; i < 400; i++ {
+			if i%2 == 0 {
+				require.NoError(t, svc.RecordSignal(ctx, key, NewCriticalErrorSignal("5xx", 100*time.Millisecond)))
+			} else {
+				require.NoError(t, svc.RecordSignal(ctx, key, NewSuccessSignal(100*time.Millisecond)))
+			}
+			s, err := svc.GetScore(ctx, key)
+			require.NoError(t, err)
+			if s.RateCooldownCount == wantCount {
+				return s.CooldownRemaining()
+			}
+		}
+		t.Fatalf("endpoint never reached rate-cooldown trip #%d", wantCount)
+		return 0
+	}
+
+	first := feedUntilTrip(1)
+	second := feedUntilTrip(2)
+
+	// First trip ≈ one session (base); second ≈ double. Assert the second is materially
+	// longer (allow slack for the microseconds of elapsed wall-clock in the loop).
+	require.InDelta(t, DefaultRateCooldown.Minutes(), first.Minutes(), 1.0,
+		"first trip should bench for ~one base session")
+	require.Greater(t, second, first+10*time.Minute,
+		"a repeat offender must be benched materially longer than the first offense")
+}
+
+// TestRateCooldown_ResetsAfterTrip verifies the EWMA is reset when the cooldown fires, so a
+// recovered endpoint must re-accumulate sustained failures to trip again rather than
+// re-flapping on its first post-cooldown request.
+func TestRateCooldown_ResetsAfterTrip(t *testing.T) {
+	svc, ctx := newRateTestService(t)
+	key := NewEndpointKey("eth", "reset", sharedtypes.RPCType_JSON_RPC)
+
+	// Drive it to a trip with a sustained high rate. End on a success so the final EWMA
+	// update after the reset is a decay (0 * (1-a) + a*0 = 0), leaving it at exactly 0.
+	tripped := false
+	for i := 0; i < 60 && !tripped; i++ {
+		if i%2 == 0 {
+			require.NoError(t, svc.RecordSignal(ctx, key, NewCriticalErrorSignal("5xx", 100*time.Millisecond)))
+		} else {
+			require.NoError(t, svc.RecordSignal(ctx, key, NewSuccessSignal(100*time.Millisecond)))
+		}
+		s, err := svc.GetScore(ctx, key)
+		require.NoError(t, err)
+		tripped = s.IsInCooldown()
+	}
+	require.True(t, tripped, "expected the endpoint to trip within the sustained run")
+
+	// Feed one success (a non-critical): EWMA decays from its post-reset value toward 0 and
+	// must remain below threshold — no immediate re-trip.
+	require.NoError(t, svc.RecordSignal(ctx, key, NewSuccessSignal(100*time.Millisecond)))
+	score, err := svc.GetScore(ctx, key)
+	require.NoError(t, err)
+	require.Less(t, score.RecentCriticalRate, CriticalRateThreshold,
+		"EWMA must be reset low after a trip so the endpoint does not immediately re-flap")
+}

--- a/reputation/rate_cooldown_test.go
+++ b/reputation/rate_cooldown_test.go
@@ -63,6 +63,36 @@ func TestRateCooldown_VolumeIndependence_TheBug(t *testing.T) {
 		"burst strikes must stay below threshold on alternating C/S — the cooldown here came from the rate detector, not the strike counter")
 }
 
+// TestRateCooldown_HealthCheckSignalsExcluded verifies that a sustained CRITICAL rate made
+// up entirely of health-check probes does NOT trip the rate cooldown — a hard bench must
+// reflect user experience, not a strict/flaky probe (e.g. a Solana getBlockHeight sync check
+// failing an endpoint that serves user reads at 99.8%). The same critical rate from user
+// traffic WOULD trip it (see TestRateCooldown_VolumeIndependence_TheBug), so this isolates
+// the health-check exclusion.
+func TestRateCooldown_HealthCheckSignalsExcluded(t *testing.T) {
+	svc, ctx := newRateTestService(t)
+	key := NewEndpointKey("solana", "probe-fails-users-fine", sharedtypes.RPCType_JSON_RPC)
+
+	// 60 signals at a 50% critical rate — but every one is a health-check probe.
+	for i := 0; i < 60; i++ {
+		var sig Signal
+		if i%2 == 0 {
+			sig = NewCriticalErrorSignal("getBlockHeight sync check", 100*time.Millisecond)
+		} else {
+			sig = NewSuccessSignal(100 * time.Millisecond)
+		}
+		sig.IsHealthCheck = true
+		require.NoError(t, svc.RecordSignal(ctx, key, sig))
+	}
+
+	score, err := svc.GetScore(ctx, key)
+	require.NoError(t, err)
+	require.False(t, score.IsInCooldown(),
+		"health-check-only critical rate must NOT trip the rate cooldown")
+	require.Equal(t, 0.0, score.RecentCriticalRate,
+		"health-check signals must not move the user-traffic critical-rate EWMA")
+}
+
 // TestRateCooldown_HealthyEndpointNeverTrips verifies a high-volume endpoint with only a
 // tiny, well-spaced critical rate (~2.5%) is never cooled — the rate EWMA decays back down
 // between rare failures and stays far below the threshold. This is the false-positive guard:

--- a/reputation/rate_cooldown_test.go
+++ b/reputation/rate_cooldown_test.go
@@ -157,12 +157,14 @@ func TestRateCooldown_EscalatesOnRepeatTrips(t *testing.T) {
 	first := feedUntilTrip(1)
 	second := feedUntilTrip(2)
 
-	// First trip ≈ one session (base); second ≈ double. Assert the second is materially
-	// longer (allow slack for the microseconds of elapsed wall-clock in the loop).
+	// Linear escalation: first ≈ base (10m), second ≈ 2× base (20m). Allow slack for the
+	// microseconds of elapsed wall-clock in the loop.
 	require.InDelta(t, DefaultRateCooldown.Minutes(), first.Minutes(), 1.0,
-		"first trip should bench for ~one base session")
-	require.Greater(t, second, first+10*time.Minute,
-		"a repeat offender must be benched materially longer than the first offense")
+		"first trip should bench for ~the base cooldown")
+	require.InDelta(t, (2 * DefaultRateCooldown).Minutes(), second.Minutes(), 1.5,
+		"second consecutive trip should bench for ~2× the base (linear escalation)")
+	require.Greater(t, second, first,
+		"a repeat offender must be benched longer than the first offense")
 }
 
 // TestRateCooldown_ResetsAfterTrip verifies the EWMA is reset when the cooldown fires, so a

--- a/reputation/reputation.go
+++ b/reputation/reputation.go
@@ -295,7 +295,7 @@ const (
 
 	// KeyGranularityURL scores all suppliers that share the exact same backend URL together,
 	// tracked per RPC type. Key format: serviceID:endpointURL (e.g.,
-	// eth:https://rm-01.eu.nodefleet.net). Identical to per-endpoint for URLs served by a
+	// eth:https://rm-01.eu.example.com). Identical to per-endpoint for URLs served by a
 	// single supplier; it only differs when multiple staked supplier addresses point at the
 	// same URL (one operator running several suppliers on one backend). Because an exact URL
 	// match means the same physical backend, its failures are shared: one bad backend is
@@ -306,7 +306,7 @@ const (
 	KeyGranularityURL = "per-url"
 
 	// KeyGranularityDomain scores all endpoints from the same hosting domain together.
-	// Key format: serviceID:domain (e.g., eth:nodefleet.net)
+	// Key format: serviceID:domain (e.g., eth:example.com)
 	// Use when a hosting provider's overall reliability matters.
 	KeyGranularityDomain = "per-domain"
 

--- a/reputation/reputation.go
+++ b/reputation/reputation.go
@@ -78,8 +78,25 @@ type Score struct {
 
 	// CooldownUntil is when the endpoint's cooldown period ends.
 	// Endpoints in cooldown are excluded from selection even if their score is above threshold.
-	// Set when CriticalStrikes exceeds StrikeThreshold.
+	// Set when CriticalStrikes exceeds StrikeThreshold, or when RecentCriticalRate exceeds
+	// CriticalRateThreshold (the volume-independent rate detector).
 	CooldownUntil time.Time
+
+	// RecentCriticalRate is an exponentially-weighted moving average (EWMA) of the
+	// per-request critical/fatal indicator (1.0 on a critical or fatal error, 0.0
+	// otherwise). Unlike CriticalStrikes — which decays 3-per-success and therefore only
+	// fires on a BURST of clustered failures — this tracks the sustained RATE of critical
+	// errors independent of success volume, so a high-traffic endpoint that bleeds a steady
+	// fraction of 5xx/transport errors (and refills its strike budget with successes) can
+	// still be cooled down. See CriticalRateThreshold / CriticalRateEWMAAlpha.
+	RecentCriticalRate float64
+
+	// RateCooldownCount counts consecutive rate-cooldown trips for escalating backoff. Each
+	// trip that lands shortly after a prior cooldown doubles the duration (base
+	// DefaultRateCooldown = 1 session, capped at DefaultMaxCooldown); it resets to a single
+	// fresh session once the endpoint has run clean for longer than DefaultMaxCooldown.
+	// Mirrors the consecutive-strike system's exponential backoff, for the rate detector.
+	RateCooldownCount int
 
 	// IsArchival indicates whether the endpoint has passed archival health checks.
 	// When true, the endpoint can serve historical blockchain data.
@@ -231,6 +248,46 @@ const (
 	// ~25%). Deliberately deceptive suppliers that pass some requests still
 	// can't instantly wipe their strike history with a single success.
 	DefaultStrikeDecayPerSuccess = 3
+)
+
+// Rate-based cooldown constants drive a volume-INDEPENDENT chronic-failure detector.
+//
+// The consecutive-strike system above decays 3 strikes per success, so it only fires on a
+// BURST of clustered criticals. A high-volume endpoint that serves a steady fraction of
+// critical/fatal errors refills its strike budget with successes as fast as it spends it
+// and is never cooled — the "each success helps them, so bad QoS can't be filtered" case.
+// These constants trip a cooldown on the sustained critical RATE (an EWMA of the
+// critical/fatal indicator) regardless of how much successful traffic the endpoint serves.
+const (
+	// CriticalRateEWMAAlpha is the smoothing factor for Score.RecentCriticalRate.
+	// Effective memory ≈ 1/alpha requests, so 0.05 ≈ a 20-request window: long enough that
+	// a brief cluster on an otherwise-healthy endpoint decays away before it can trip, short
+	// enough to react to a genuinely sustained failure rate.
+	CriticalRateEWMAAlpha = 0.05
+
+	// CriticalRateThreshold is the sustained critical/fatal rate (0..1) at or above which an
+	// endpoint is cooled down. 0.30 = 30% of requests failing critically — unambiguously
+	// broken. Deliberately conservative for the first rollout so healthy endpoints are never
+	// penalized; lower it (e.g. 0.20 / 0.15) once canary data shows the false-positive rate
+	// is safe. The consecutive-strike system still catches bursts below this rate.
+	CriticalRateThreshold = 0.30
+
+	// CriticalRateMinObservations is the minimum lifetime observations (successes + errors)
+	// before the rate detector may trip. The EWMA is meaningless on the first few samples,
+	// so a brand-new endpoint is never cooled on a tiny sample.
+	CriticalRateMinObservations = 20
+
+	// DefaultRateCooldown is the BASE cooldown on the first sustained-critical-rate trip:
+	// one Shannon session (~20 min). Repeat trips that land shortly after a prior cooldown
+	// escalate (see Score.RateCooldownCount) — 20m → 40m → … capped at DefaultMaxCooldown
+	// (1h) — so a genuinely broken endpoint is benched progressively longer while a one-off
+	// transient spike costs only a single session.
+	DefaultRateCooldown = 20 * time.Minute
+
+	// DefaultRateCooldownMaxExponent caps the escalation exponent to avoid runaway shifts /
+	// int64 overflow. The duration is clamped to DefaultMaxCooldown well before this bound
+	// (20m << 2 already exceeds 1h), so this is only a safety backstop.
+	DefaultRateCooldownMaxExponent = 4
 )
 
 // Key granularity options determine how endpoints are grouped for scoring.

--- a/reputation/reputation.go
+++ b/reputation/reputation.go
@@ -418,6 +418,12 @@ type ReputationService interface {
 	// Returns 0 if no block number has been stored yet.
 	GetPerceivedBlockNumber(ctx context.Context, serviceID protocol.ServiceID) uint64
 
+	// DeletePerceivedBlockNumber removes the shared perceived block number for a service
+	// so it can be rebuilt from fresh endpoint observations. Used by the chain-state admin
+	// reset to recover from a poisoned/stuck perceived height — the max-wins Set path
+	// cannot lower a too-high value, so an explicit delete is required.
+	DeletePerceivedBlockNumber(ctx context.Context, serviceID protocol.ServiceID) error
+
 	// SetEndpointBlockHeight stores a single endpoint's block height for cross-replica sync.
 	// Called from UpdateFromExtractedData when a health check reports an endpoint's block height.
 	SetEndpointBlockHeight(ctx context.Context, serviceID protocol.ServiceID, endpointAddr protocol.EndpointAddr, blockHeight uint64) error

--- a/reputation/reputation.go
+++ b/reputation/reputation.go
@@ -91,11 +91,10 @@ type Score struct {
 	// still be cooled down. See CriticalRateThreshold / CriticalRateEWMAAlpha.
 	RecentCriticalRate float64
 
-	// RateCooldownCount counts consecutive rate-cooldown trips for escalating backoff. Each
-	// trip that lands shortly after a prior cooldown doubles the duration (base
-	// DefaultRateCooldown = 1 session, capped at DefaultMaxCooldown); it resets to a single
-	// fresh session once the endpoint has run clean for longer than DefaultMaxCooldown.
-	// Mirrors the consecutive-strike system's exponential backoff, for the rate detector.
+	// RateCooldownCount counts consecutive rate-cooldown trips for escalating backoff. The Nth
+	// consecutive trip benches for N × DefaultRateCooldown (linear: 10m, 20m, 30m, …), capped
+	// at DefaultMaxCooldown; it resets to 1 once the endpoint has run clean for longer than
+	// DefaultMaxCooldown. Mirrors the strike system's escalation, for the rate detector.
 	RateCooldownCount int
 
 	// IsArchival indicates whether the endpoint has passed archival health checks.
@@ -277,17 +276,12 @@ const (
 	// so a brand-new endpoint is never cooled on a tiny sample.
 	CriticalRateMinObservations = 20
 
-	// DefaultRateCooldown is the BASE cooldown on the first sustained-critical-rate trip:
-	// one Shannon session (~20 min). Repeat trips that land shortly after a prior cooldown
-	// escalate (see Score.RateCooldownCount) — 20m → 40m → … capped at DefaultMaxCooldown
-	// (1h) — so a genuinely broken endpoint is benched progressively longer while a one-off
-	// transient spike costs only a single session.
-	DefaultRateCooldown = 20 * time.Minute
-
-	// DefaultRateCooldownMaxExponent caps the escalation exponent to avoid runaway shifts /
-	// int64 overflow. The duration is clamped to DefaultMaxCooldown well before this bound
-	// (20m << 2 already exceeds 1h), so this is only a safety backstop.
-	DefaultRateCooldownMaxExponent = 4
+	// DefaultRateCooldown is the base (and per-step) cooldown for a sustained-critical-rate
+	// trip. Escalation is LINEAR: the Nth consecutive trip benches for N × this, capped at
+	// DefaultMaxCooldown — i.e. 10m → 20m → 30m → 40m → 50m → 1h. At 10 minutes the first
+	// offense sits under one Shannon session (~20 min), so a transient spike recovers within
+	// the same session; only a persistent offender ramps toward a full hour.
+	DefaultRateCooldown = 10 * time.Minute
 )
 
 // Key granularity options determine how endpoints are grouped for scoring.

--- a/reputation/reputation.go
+++ b/reputation/reputation.go
@@ -295,8 +295,21 @@ const (
 const (
 	// KeyGranularityEndpoint scores each endpoint URL separately (the finest granularity).
 	// Key format: serviceID:supplierAddr-endpointURL
-	// This is the default behavior.
+	// Every (supplier, URL) pair is scored independently, so two suppliers that front the
+	// exact same backend URL accumulate — and recover from — reputation separately.
 	KeyGranularityEndpoint = "per-endpoint"
+
+	// KeyGranularityURL scores all suppliers that share the exact same backend URL together,
+	// tracked per RPC type. Key format: serviceID:endpointURL (e.g.,
+	// eth:https://rm-01.eu.nodefleet.net). Identical to per-endpoint for URLs served by a
+	// single supplier; it only differs when multiple staked supplier addresses point at the
+	// same URL (one operator running several suppliers on one backend). Because an exact URL
+	// match means the same physical backend, its failures are shared: one bad backend is
+	// penalized (and cooled) once across every supplier fronting it, instead of each supplier
+	// having to independently prove the shared infrastructure is broken. Unlike per-domain,
+	// it does NOT merge an operator's distinct URLs, so a single bad backend is never diluted
+	// by the operator's healthy ones. This is the default.
+	KeyGranularityURL = "per-url"
 
 	// KeyGranularityDomain scores all endpoints from the same hosting domain together.
 	// Key format: serviceID:domain (e.g., eth:nodefleet.net)
@@ -961,7 +974,7 @@ func DefaultConfig() Config {
 		MinThreshold:    DefaultMinThreshold,
 		RecoveryTimeout: DefaultRecoveryTimeout,
 		StorageType:     "memory",
-		KeyGranularity:  KeyGranularityEndpoint,
+		KeyGranularity:  KeyGranularityURL,
 		SyncConfig:      DefaultSyncConfig(),
 		Latency:         DefaultLatencyConfig(),
 	}
@@ -1007,7 +1020,7 @@ func (c *Config) HydrateDefaults() {
 		c.StorageType = "memory"
 	}
 	if c.KeyGranularity == "" {
-		c.KeyGranularity = KeyGranularityEndpoint
+		c.KeyGranularity = KeyGranularityURL
 	}
 	c.SyncConfig.HydrateDefaults()
 	c.Latency.HydrateDefaults()

--- a/reputation/reputation_test.go
+++ b/reputation/reputation_test.go
@@ -109,7 +109,7 @@ func TestConfig_HydrateDefaults(t *testing.T) {
 			expectedInit:        InitialScore,
 			expectedMin:         DefaultMinThreshold,
 			expectedType:        "memory",
-			expectedGranularity: KeyGranularityEndpoint,
+			expectedGranularity: KeyGranularityURL,
 		},
 		{
 			name: "custom values preserved",
@@ -132,7 +132,7 @@ func TestConfig_HydrateDefaults(t *testing.T) {
 			expectedInit:        75,
 			expectedMin:         DefaultMinThreshold,
 			expectedType:        "memory",
-			expectedGranularity: KeyGranularityEndpoint,
+			expectedGranularity: KeyGranularityURL,
 		},
 		{
 			name: "per-domain granularity preserved",
@@ -166,7 +166,7 @@ func TestDefaultConfig(t *testing.T) {
 	require.Equal(t, DefaultMinThreshold, config.MinThreshold)
 	require.Equal(t, DefaultRecoveryTimeout, config.RecoveryTimeout)
 	require.Equal(t, "memory", config.StorageType)
-	require.Equal(t, KeyGranularityEndpoint, config.KeyGranularity)
+	require.Equal(t, KeyGranularityURL, config.KeyGranularity)
 
 	// Verify SyncConfig defaults are included
 	require.Equal(t, DefaultRefreshInterval, config.SyncConfig.RefreshInterval)
@@ -386,14 +386,14 @@ func TestService_KeyBuilderForService(t *testing.T) {
 			expectedBuilderTyp: &DomainKeyBuilder{},
 		},
 		{
-			name:               "empty defaults to per-endpoint",
+			name:               "empty defaults to per-url",
 			keyGranularity:     "",
-			expectedBuilderTyp: &EndpointKeyBuilder{},
+			expectedBuilderTyp: &URLKeyBuilder{},
 		},
 		{
-			name:               "invalid defaults to per-endpoint",
+			name:               "invalid defaults to per-url",
 			keyGranularity:     "invalid-value",
-			expectedBuilderTyp: &EndpointKeyBuilder{},
+			expectedBuilderTyp: &URLKeyBuilder{},
 		},
 	}
 

--- a/reputation/service.go
+++ b/reputation/service.go
@@ -926,6 +926,16 @@ func (s *service) SetPerceivedBlockNumber(ctx context.Context, serviceID protoco
 	return s.storage.SetPerceivedBlockNumber(ctx, serviceID, blockNumber)
 }
 
+// DeletePerceivedBlockNumber removes the shared perceived block number for a service so
+// it can be rebuilt from fresh endpoint observations. Used by the chain-state admin reset.
+func (s *service) DeletePerceivedBlockNumber(ctx context.Context, serviceID protocol.ServiceID) error {
+	if s.storage == nil {
+		return nil // No storage configured, skip
+	}
+
+	return s.storage.DeletePerceivedBlockNumber(ctx, serviceID)
+}
+
 // GetPerceivedBlockNumber retrieves the shared perceived block number for a service.
 // Returns the maximum block number observed across all replicas.
 // Returns 0 if no block number has been stored yet or if storage is unavailable.

--- a/reputation/service.go
+++ b/reputation/service.go
@@ -173,53 +173,60 @@ func (s *service) RecordSignal(ctx context.Context, key EndpointKey, signal Sign
 	// fast as it spends it and is never cooled — exactly the high-volume "can't be filtered"
 	// case. Track an EWMA of the critical indicator so a sustained critical RATE trips a
 	// cooldown regardless of success volume.
-	criticalIndicator := 0.0
-	if signal.Type == SignalTypeCriticalError || signal.Type == SignalTypeFatalError {
-		criticalIndicator = 1.0
-	}
-	score.RecentCriticalRate = score.RecentCriticalRate*(1-CriticalRateEWMAAlpha) + CriticalRateEWMAAlpha*criticalIndicator
-
-	// Trip only once the sample is meaningful, and only to EXTEND (never shorten) any
-	// cooldown the strike system already set.
-	if score.RecentCriticalRate >= CriticalRateThreshold &&
-		(score.SuccessCount+score.ErrorCount) >= CriticalRateMinObservations {
-		trippedRate := score.RecentCriticalRate
-
-		// Escalating backoff: a repeat trip that lands within DefaultMaxCooldown of the
-		// previous cooldown's end doubles the duration; an endpoint that has since run clean
-		// for longer than that starts fresh at one session. Mirrors the strike system's
-		// exponential backoff so a persistently broken endpoint is benched progressively
-		// longer while a one-off transient spike costs only a single session.
-		prevCooldownUntil := score.CooldownUntil
-		if !prevCooldownUntil.IsZero() && time.Since(prevCooldownUntil) < DefaultMaxCooldown {
-			score.RateCooldownCount++
-		} else {
-			score.RateCooldownCount = 1
+	//
+	// Health-check signals are EXCLUDED from this detector (they still moved the additive
+	// score above). A hard bench must reflect what USERS experience: a strict or flaky probe
+	// (e.g. a Solana getBlockHeight sync check) can fail an endpoint that serves user reads
+	// perfectly, and must not be able to cool it out of rotation on its own.
+	if !signal.IsHealthCheck {
+		criticalIndicator := 0.0
+		if signal.Type == SignalTypeCriticalError || signal.Type == SignalTypeFatalError {
+			criticalIndicator = 1.0
 		}
-		// Linear escalation: 10m, 20m, 30m, 40m, 50m, then capped at DefaultMaxCooldown (1h).
-		// The first offense (10m) is under one Shannon session (~20m) so a transient spike
-		// recovers within the session; only a persistent offender ramps toward a full hour.
-		cooldownDuration := DefaultRateCooldown * time.Duration(score.RateCooldownCount)
-		if cooldownDuration > DefaultMaxCooldown {
-			cooldownDuration = DefaultMaxCooldown
-		}
+		score.RecentCriticalRate = score.RecentCriticalRate*(1-CriticalRateEWMAAlpha) + CriticalRateEWMAAlpha*criticalIndicator
 
-		rateCooldownUntil := time.Now().Add(cooldownDuration)
-		if rateCooldownUntil.After(score.CooldownUntil) {
-			score.CooldownUntil = rateCooldownUntil
-		}
-		// Reset the EWMA so the endpoint starts clean after the cooldown and must
-		// re-accumulate sustained failures to trip again (no immediate re-flap on the first
-		// post-cooldown request).
-		score.RecentCriticalRate = 0
-		metrics.RecordReputationRateCooldown(string(key.ServiceID))
-		if s.logger != nil {
-			s.logger.Warn().
-				Str("endpoint", key.String()).
-				Float64("critical_rate", trippedRate).
-				Int("rate_cooldown_count", score.RateCooldownCount).
-				Dur("cooldown_duration", cooldownDuration).
-				Msg("[RATE_COOLDOWN] Endpoint cooled down due to sustained critical error rate (volume-independent)")
+		// Trip only once the sample is meaningful, and only to EXTEND (never shorten) any
+		// cooldown the strike system already set.
+		if score.RecentCriticalRate >= CriticalRateThreshold &&
+			(score.SuccessCount+score.ErrorCount) >= CriticalRateMinObservations {
+			trippedRate := score.RecentCriticalRate
+
+			// Escalating backoff: a repeat trip that lands within DefaultMaxCooldown of the
+			// previous cooldown's end doubles the duration; an endpoint that has since run clean
+			// for longer than that starts fresh at one session. Mirrors the strike system's
+			// exponential backoff so a persistently broken endpoint is benched progressively
+			// longer while a one-off transient spike costs only a single session.
+			prevCooldownUntil := score.CooldownUntil
+			if !prevCooldownUntil.IsZero() && time.Since(prevCooldownUntil) < DefaultMaxCooldown {
+				score.RateCooldownCount++
+			} else {
+				score.RateCooldownCount = 1
+			}
+			// Linear escalation: 10m, 20m, 30m, 40m, 50m, then capped at DefaultMaxCooldown (1h).
+			// The first offense (10m) is under one Shannon session (~20m) so a transient spike
+			// recovers within the session; only a persistent offender ramps toward a full hour.
+			cooldownDuration := DefaultRateCooldown * time.Duration(score.RateCooldownCount)
+			if cooldownDuration > DefaultMaxCooldown {
+				cooldownDuration = DefaultMaxCooldown
+			}
+
+			rateCooldownUntil := time.Now().Add(cooldownDuration)
+			if rateCooldownUntil.After(score.CooldownUntil) {
+				score.CooldownUntil = rateCooldownUntil
+			}
+			// Reset the EWMA so the endpoint starts clean after the cooldown and must
+			// re-accumulate sustained failures to trip again (no immediate re-flap on the first
+			// post-cooldown request).
+			score.RecentCriticalRate = 0
+			metrics.RecordReputationRateCooldown(string(key.ServiceID))
+			if s.logger != nil {
+				s.logger.Warn().
+					Str("endpoint", key.String()).
+					Float64("critical_rate", trippedRate).
+					Int("rate_cooldown_count", score.RateCooldownCount).
+					Dur("cooldown_duration", cooldownDuration).
+					Msg("[RATE_COOLDOWN] Endpoint cooled down due to sustained critical error rate (volume-independent)")
+			}
 		}
 	}
 

--- a/reputation/service.go
+++ b/reputation/service.go
@@ -165,6 +165,65 @@ func (s *service) RecordSignal(ctx context.Context, key EndpointKey, signal Sign
 		}
 	}
 
+	// Rate-based cooldown: a volume-INDEPENDENT chronic-failure detector.
+	//
+	// The consecutive-strike block above decays 3 strikes per success, so it only ever fires
+	// on a BURST of clustered criticals. An endpoint that serves a steady fraction of
+	// critical/fatal errors alongside heavy successful traffic refills its strike budget as
+	// fast as it spends it and is never cooled — exactly the high-volume "can't be filtered"
+	// case. Track an EWMA of the critical indicator so a sustained critical RATE trips a
+	// cooldown regardless of success volume.
+	criticalIndicator := 0.0
+	if signal.Type == SignalTypeCriticalError || signal.Type == SignalTypeFatalError {
+		criticalIndicator = 1.0
+	}
+	score.RecentCriticalRate = score.RecentCriticalRate*(1-CriticalRateEWMAAlpha) + CriticalRateEWMAAlpha*criticalIndicator
+
+	// Trip only once the sample is meaningful, and only to EXTEND (never shorten) any
+	// cooldown the strike system already set.
+	if score.RecentCriticalRate >= CriticalRateThreshold &&
+		(score.SuccessCount+score.ErrorCount) >= CriticalRateMinObservations {
+		trippedRate := score.RecentCriticalRate
+
+		// Escalating backoff: a repeat trip that lands within DefaultMaxCooldown of the
+		// previous cooldown's end doubles the duration; an endpoint that has since run clean
+		// for longer than that starts fresh at one session. Mirrors the strike system's
+		// exponential backoff so a persistently broken endpoint is benched progressively
+		// longer while a one-off transient spike costs only a single session.
+		prevCooldownUntil := score.CooldownUntil
+		if !prevCooldownUntil.IsZero() && time.Since(prevCooldownUntil) < DefaultMaxCooldown {
+			score.RateCooldownCount++
+		} else {
+			score.RateCooldownCount = 1
+		}
+		exponent := score.RateCooldownCount - 1
+		if exponent > DefaultRateCooldownMaxExponent {
+			exponent = DefaultRateCooldownMaxExponent
+		}
+		cooldownDuration := DefaultRateCooldown * time.Duration(1<<exponent)
+		if cooldownDuration > DefaultMaxCooldown {
+			cooldownDuration = DefaultMaxCooldown
+		}
+
+		rateCooldownUntil := time.Now().Add(cooldownDuration)
+		if rateCooldownUntil.After(score.CooldownUntil) {
+			score.CooldownUntil = rateCooldownUntil
+		}
+		// Reset the EWMA so the endpoint starts clean after the cooldown and must
+		// re-accumulate sustained failures to trip again (no immediate re-flap on the first
+		// post-cooldown request).
+		score.RecentCriticalRate = 0
+		metrics.RecordReputationRateCooldown(string(key.ServiceID))
+		if s.logger != nil {
+			s.logger.Warn().
+				Str("endpoint", key.String()).
+				Float64("critical_rate", trippedRate).
+				Int("rate_cooldown_count", score.RateCooldownCount).
+				Dur("cooldown_duration", cooldownDuration).
+				Msg("[RATE_COOLDOWN] Endpoint cooled down due to sustained critical error rate (volume-independent)")
+		}
+	}
+
 	// Update latency metrics if signal includes latency data
 	if signal.Latency > 0 {
 		score.LatencyMetrics.UpdateLatency(signal.Latency)

--- a/reputation/service.go
+++ b/reputation/service.go
@@ -196,11 +196,10 @@ func (s *service) RecordSignal(ctx context.Context, key EndpointKey, signal Sign
 		} else {
 			score.RateCooldownCount = 1
 		}
-		exponent := score.RateCooldownCount - 1
-		if exponent > DefaultRateCooldownMaxExponent {
-			exponent = DefaultRateCooldownMaxExponent
-		}
-		cooldownDuration := DefaultRateCooldown * time.Duration(1<<exponent)
+		// Linear escalation: 10m, 20m, 30m, 40m, 50m, then capped at DefaultMaxCooldown (1h).
+		// The first offense (10m) is under one Shannon session (~20m) so a transient spike
+		// recovers within the session; only a persistent offender ramps toward a full hour.
+		cooldownDuration := DefaultRateCooldown * time.Duration(score.RateCooldownCount)
 		if cooldownDuration > DefaultMaxCooldown {
 			cooldownDuration = DefaultMaxCooldown
 		}

--- a/reputation/service_test.go
+++ b/reputation/service_test.go
@@ -150,6 +150,16 @@ func (m *mockStorage) GetPerceivedBlockNumber(_ context.Context, serviceID proto
 	return m.perceivedBlocks[string(serviceID)], nil
 }
 
+func (m *mockStorage) DeletePerceivedBlockNumber(_ context.Context, serviceID protocol.ServiceID) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.closed {
+		return ErrStorageClosed
+	}
+	delete(m.perceivedBlocks, string(serviceID))
+	return nil
+}
+
 func (m *mockStorage) SetEndpointBlockHeight(_ context.Context, serviceID protocol.ServiceID, endpointAddr protocol.EndpointAddr, blockHeight uint64) error {
 	return nil
 }

--- a/reputation/signals.go
+++ b/reputation/signals.go
@@ -61,6 +61,14 @@ type Signal struct {
 	// Reason provides additional context for the signal.
 	Reason string
 
+	// IsHealthCheck marks a signal that originated from an active health-check probe rather
+	// than real user traffic. Health checks still move the additive score (soft
+	// deprioritization), but they are excluded from the volume-independent rate-cooldown
+	// detector: a hard bench must reflect what USERS actually experience, not a probe that can
+	// be stricter than user impact (e.g. a Solana getBlockHeight sync check failing an
+	// endpoint that serves reads at 99.8% success). Set by the health-check executor.
+	IsHealthCheck bool
+
 	// Metadata holds additional signal-specific data.
 	Metadata map[string]string
 }

--- a/reputation/storage.go
+++ b/reputation/storage.go
@@ -51,6 +51,12 @@ type Storage interface {
 	// Returns 0 if no block number has been stored yet.
 	GetPerceivedBlockNumber(ctx context.Context, serviceID protocol.ServiceID) (uint64, error)
 
+	// DeletePerceivedBlockNumber removes the stored perceived block number for a
+	// service so it can be rebuilt from fresh endpoint observations. Used by the
+	// chain-state admin reset to recover from a poisoned/stuck perceived height
+	// (the max-wins Set path cannot lower a too-high value).
+	DeletePerceivedBlockNumber(ctx context.Context, serviceID protocol.ServiceID) error
+
 	// SetEndpointBlockHeight stores a single endpoint's block height for a service.
 	// Uses HSET on a Redis hash keyed by service ID, with endpoint address as field.
 	SetEndpointBlockHeight(ctx context.Context, serviceID protocol.ServiceID, endpointAddr protocol.EndpointAddr, blockHeight uint64) error

--- a/reputation/storage/memory.go
+++ b/reputation/storage/memory.go
@@ -265,6 +265,21 @@ func (m *MemoryStorage) GetPerceivedBlockNumber(ctx context.Context, serviceID p
 	return m.perceivedBlocks[string(serviceID)], nil
 }
 
+// DeletePerceivedBlockNumber removes the perceived block number for a service so it
+// can be rebuilt from fresh endpoint observations (the max-wins Set path cannot lower
+// a stuck value). Used by the chain-state admin reset.
+func (m *MemoryStorage) DeletePerceivedBlockNumber(ctx context.Context, serviceID protocol.ServiceID) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if m.closed {
+		return reputation.ErrStorageClosed
+	}
+
+	delete(m.perceivedBlocks, string(serviceID))
+	return nil
+}
+
 // SetEndpointBlockHeight stores a single endpoint's block height for a service.
 func (m *MemoryStorage) SetEndpointBlockHeight(ctx context.Context, serviceID protocol.ServiceID, endpointAddr protocol.EndpointAddr, blockHeight uint64) error {
 	m.mu.Lock()

--- a/reputation/storage/redis.go
+++ b/reputation/storage/redis.go
@@ -477,6 +477,17 @@ func (s *RedisStorage) GetPerceivedBlockNumber(ctx context.Context, serviceID pr
 	return blockNumber, nil
 }
 
+// DeletePerceivedBlockNumber removes the perceived block number key for a service.
+// After deletion the value is rebuilt from fresh endpoint observations; the max-wins
+// Set path cannot lower a stuck/poisoned value, so an explicit delete is the only way
+// to recover. Used by the chain-state admin reset.
+func (s *RedisStorage) DeletePerceivedBlockNumber(ctx context.Context, serviceID protocol.ServiceID) error {
+	if err := s.client.Del(ctx, s.perceivedBlockKey(serviceID)).Err(); err != nil {
+		return fmt.Errorf("failed to delete perceived block number: %w", err)
+	}
+	return nil
+}
+
 // endpointBlocksKey returns the Redis key for storing per-endpoint block heights.
 func (s *RedisStorage) endpointBlocksKey(serviceID protocol.ServiceID) string {
 	return fmt.Sprintf("%schain_state:%s:endpoint_blocks", s.keyPrefix, serviceID)

--- a/reputation/storage/redis.go
+++ b/reputation/storage/redis.go
@@ -37,14 +37,16 @@ type RedisStorage struct {
 
 // Redis hash field names
 const (
-	fieldValue           = "value"
-	fieldLastUpdated     = "last_updated"
-	fieldSuccessCount    = "success_count"
-	fieldErrorCount      = "error_count"
-	fieldCriticalStrikes = "critical_strikes"
-	fieldCooldownUntil   = "cooldown_until"
-	fieldIsArchival      = "is_archival"
-	fieldArchivalExpires = "archival_expires_at"
+	fieldValue              = "value"
+	fieldLastUpdated        = "last_updated"
+	fieldSuccessCount       = "success_count"
+	fieldErrorCount         = "error_count"
+	fieldCriticalStrikes    = "critical_strikes"
+	fieldCooldownUntil      = "cooldown_until"
+	fieldIsArchival         = "is_archival"
+	fieldArchivalExpires    = "archival_expires_at"
+	fieldRecentCriticalRate = "recent_critical_rate"
+	fieldRateCooldownCount  = "rate_cooldown_count"
 )
 
 // perceivedBlockTTL bounds how long a perceived block-height entry lives in
@@ -193,14 +195,16 @@ func (r *RedisStorage) Set(ctx context.Context, key reputation.EndpointKey, scor
 	}
 
 	fields := map[string]interface{}{
-		fieldValue:           strconv.FormatFloat(score.Value, 'f', -1, 64),
-		fieldLastUpdated:     strconv.FormatInt(score.LastUpdated.Unix(), 10),
-		fieldSuccessCount:    strconv.FormatInt(score.SuccessCount, 10),
-		fieldErrorCount:      strconv.FormatInt(score.ErrorCount, 10),
-		fieldCriticalStrikes: strconv.Itoa(score.CriticalStrikes),
-		fieldCooldownUntil:   strconv.FormatInt(score.CooldownUntil.Unix(), 10),
-		fieldIsArchival:      isArchivalStr,
-		fieldArchivalExpires: strconv.FormatInt(score.ArchivalExpiresAt.Unix(), 10),
+		fieldValue:              strconv.FormatFloat(score.Value, 'f', -1, 64),
+		fieldLastUpdated:        strconv.FormatInt(score.LastUpdated.Unix(), 10),
+		fieldSuccessCount:       strconv.FormatInt(score.SuccessCount, 10),
+		fieldErrorCount:         strconv.FormatInt(score.ErrorCount, 10),
+		fieldCriticalStrikes:    strconv.Itoa(score.CriticalStrikes),
+		fieldCooldownUntil:      strconv.FormatInt(score.CooldownUntil.Unix(), 10),
+		fieldIsArchival:         isArchivalStr,
+		fieldArchivalExpires:    strconv.FormatInt(score.ArchivalExpiresAt.Unix(), 10),
+		fieldRecentCriticalRate: strconv.FormatFloat(score.RecentCriticalRate, 'f', -1, 64),
+		fieldRateCooldownCount:  strconv.Itoa(score.RateCooldownCount),
 	}
 
 	pipe := r.client.Pipeline()
@@ -236,14 +240,16 @@ func (r *RedisStorage) SetMultiple(ctx context.Context, scores map[reputation.En
 		}
 
 		fields := map[string]interface{}{
-			fieldValue:           strconv.FormatFloat(score.Value, 'f', -1, 64),
-			fieldLastUpdated:     strconv.FormatInt(score.LastUpdated.Unix(), 10),
-			fieldSuccessCount:    strconv.FormatInt(score.SuccessCount, 10),
-			fieldErrorCount:      strconv.FormatInt(score.ErrorCount, 10),
-			fieldCriticalStrikes: strconv.Itoa(score.CriticalStrikes),
-			fieldCooldownUntil:   strconv.FormatInt(score.CooldownUntil.Unix(), 10),
-			fieldIsArchival:      isArchivalStr,
-			fieldArchivalExpires: strconv.FormatInt(score.ArchivalExpiresAt.Unix(), 10),
+			fieldValue:              strconv.FormatFloat(score.Value, 'f', -1, 64),
+			fieldLastUpdated:        strconv.FormatInt(score.LastUpdated.Unix(), 10),
+			fieldSuccessCount:       strconv.FormatInt(score.SuccessCount, 10),
+			fieldErrorCount:         strconv.FormatInt(score.ErrorCount, 10),
+			fieldCriticalStrikes:    strconv.Itoa(score.CriticalStrikes),
+			fieldCooldownUntil:      strconv.FormatInt(score.CooldownUntil.Unix(), 10),
+			fieldIsArchival:         isArchivalStr,
+			fieldArchivalExpires:    strconv.FormatInt(score.ArchivalExpiresAt.Unix(), 10),
+			fieldRecentCriticalRate: strconv.FormatFloat(score.RecentCriticalRate, 'f', -1, 64),
+			fieldRateCooldownCount:  strconv.Itoa(score.RateCooldownCount),
 		}
 
 		pipe.HSet(ctx, redisKey, fields)
@@ -368,6 +374,24 @@ func (r *RedisStorage) parseScore(data map[string]string) (reputation.Score, err
 		if ts > 0 {
 			score.CooldownUntil = time.Unix(ts, 0)
 		}
+	}
+
+	// Parse the rate-based cooldown EWMA (for multi-instance coordination and
+	// restart survival). Absent field (older records) leaves it at 0.0.
+	if v, ok := data[fieldRecentCriticalRate]; ok {
+		rate, err := strconv.ParseFloat(v, 64)
+		if err != nil {
+			return score, fmt.Errorf("invalid recent_critical_rate: %w", err)
+		}
+		score.RecentCriticalRate = rate
+	}
+
+	if v, ok := data[fieldRateCooldownCount]; ok {
+		count, err := strconv.Atoi(v)
+		if err != nil {
+			return score, fmt.Errorf("invalid rate_cooldown_count: %w", err)
+		}
+		score.RateCooldownCount = count
 	}
 
 	// Parse archival fields (for multi-instance coordination)

--- a/router/operational_endpoints.go
+++ b/router/operational_endpoints.go
@@ -2,6 +2,7 @@ package router
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"strings"
 
@@ -274,5 +275,43 @@ func (r *router) handleCircuitBreakerClear(w http.ResponseWriter, req *http.Requ
 		"service_id":      serviceID,
 		"cleared_domains": count,
 		"message":         "circuit breaker state cleared (in-memory + Redis)",
+	})
+}
+
+// handleChainStateClear handles POST /admin/chain-state/clear/{serviceId}
+// Resets the perceived block height (in-memory + Redis) for the given service so it
+// rebuilds from fresh endpoint observations. This is the only way to recover a
+// stuck/too-high perceived height: the max-based consensus and the external floor only
+// ever RAISE perceived, so a poisoned value cannot self-correct.
+//
+// Like the circuit-breaker clear, this must be called on EACH pod, since the perceived
+// floor is per-pod in-memory state.
+func (r *router) handleChainStateClear(w http.ResponseWriter, req *http.Request) {
+	if r.chainStateAdmin == nil {
+		http.Error(w, `{"error":"chain state admin not configured"}`, http.StatusServiceUnavailable)
+		return
+	}
+
+	serviceID := strings.TrimPrefix(req.URL.Path, "/admin/chain-state/clear/")
+	if serviceID == "" {
+		http.Error(w, `{"error":"service ID required: POST /admin/chain-state/clear/{serviceId}"}`, http.StatusBadRequest)
+		return
+	}
+
+	found, err := r.chainStateAdmin.ResetChainState(req.Context(), serviceID)
+	if err != nil {
+		http.Error(w, fmt.Sprintf(`{"error":%q}`, err.Error()), http.StatusInternalServerError)
+		return
+	}
+	if !found {
+		http.Error(w, fmt.Sprintf(`{"error":"service %q not found or has no perceived block height to reset"}`, serviceID), http.StatusNotFound)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_ = json.NewEncoder(w).Encode(map[string]interface{}{
+		"service_id": serviceID,
+		"message":    "chain state cleared (perceived block height reset, in-memory + Redis)",
 	})
 }

--- a/router/router.go
+++ b/router/router.go
@@ -37,9 +37,18 @@ type (
 		healthChecker                 *health.Checker
 		circuitBreakerAdmin           CircuitBreakerAdmin
 		chainStateAdmin               ChainStateAdmin
+		staticResponses               StaticResponseResolver
 	}
 	gatewayHandler interface {
 		HandleServiceRequest(context.Context, *http.Request, http.ResponseWriter)
+	}
+	// StaticResponseResolver returns a fixed response configured for a service's request
+	// path and method, bypassing the relay pipeline. ok=false means no static route applies
+	// and the request should be relayed normally. The returned headers always include
+	// Content-Type and are safe to write directly onto the response. May be nil, in which
+	// case no static routes are served.
+	StaticResponseResolver interface {
+		ResolveStaticResponse(serviceID, path, method string) (body []byte, statusCode int, headers map[string]string, ok bool)
 	}
 	disqualifiedEndpointsReporter interface {
 		ReportEndpointStatus(protocol.ServiceID, *http.Request) (devtools.DisqualifiedEndpointResponse, error)
@@ -67,6 +76,7 @@ func NewRouter(
 	config config.RouterConfig,
 	circuitBreakerAdmin CircuitBreakerAdmin,
 	chainStateAdmin ChainStateAdmin,
+	staticResponses StaticResponseResolver,
 ) *router {
 	r := &router{
 		logger: logger.With("package", "router"),
@@ -79,6 +89,7 @@ func NewRouter(
 		healthChecker:                 healthChecker,
 		circuitBreakerAdmin:           circuitBreakerAdmin,
 		chainStateAdmin:               chainStateAdmin,
+		staticResponses:               staticResponses,
 	}
 	r.handleRoutes()
 	return r
@@ -116,8 +127,10 @@ func (r *router) handleRoutes() {
 	// POST /admin/chain-state/clear/{serviceId} - resets perceived block height (in-memory + Redis)
 	r.mux.HandleFunc("POST /admin/chain-state/clear/", r.handleChainStateClear)
 
-	// requestHandlerFn defines the middleware chain for all service requests
-	requestHandlerFn := r.corsMiddleware(r.removeGrovePortalPrefixMiddleware(r.handleServiceRequest))
+	// requestHandlerFn defines the middleware chain for all service requests.
+	// staticResponseMiddleware runs after the prefix strip (so it sees the cleaned path)
+	// and before the relay handler, short-circuiting any configured static route.
+	requestHandlerFn := r.corsMiddleware(r.removeGrovePortalPrefixMiddleware(r.staticResponseMiddleware(r.handleServiceRequest)))
 
 	// */v1/ - handles service requests with trailing slash, including REST services with additional path segments
 	r.mux.HandleFunc(gateway.APIVersionPrefix+"/", requestHandlerFn)
@@ -232,6 +245,39 @@ func (r *router) removeGrovePortalPrefixMiddleware(next http.HandlerFunc) http.H
 		}
 
 		next(w, req)
+	}
+}
+
+// staticResponseMiddleware serves a configured fixed response for a service+path+method,
+// short-circuiting the relay pipeline. It runs on the cleaned request path (after the
+// API-version and portal-app-id prefixes are stripped) so a config path like "/identity"
+// matches regardless of the portal prefix. WebSocket upgrades are never intercepted — they
+// connect at the relay root, and a static route matches an exact non-root path only.
+// A nil resolver (not configured, or in tests) is a pass-through.
+func (r *router) staticResponseMiddleware(next http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, req *http.Request) {
+		if r.staticResponses == nil || req.Header.Get("Upgrade") != "" {
+			next(w, req)
+			return
+		}
+
+		serviceID := req.Header.Get(request.HTTPHeaderTargetServiceID)
+		body, statusCode, headers, ok := r.staticResponses.ResolveStaticResponse(serviceID, req.URL.Path, req.Method)
+		if !ok {
+			next(w, req)
+			return
+		}
+
+		for k, v := range headers {
+			w.Header().Set(k, v)
+		}
+		w.WriteHeader(statusCode)
+		if _, err := w.Write(body); err != nil {
+			r.logger.Warn().Err(err).
+				Str("service_id", serviceID).
+				Str("path", req.URL.Path).
+				Msg("failed to write static response body")
+		}
 	}
 }
 

--- a/router/router.go
+++ b/router/router.go
@@ -36,6 +36,7 @@ type (
 		disqualifiedEndpointsReporter disqualifiedEndpointsReporter
 		healthChecker                 *health.Checker
 		circuitBreakerAdmin           CircuitBreakerAdmin
+		chainStateAdmin               ChainStateAdmin
 	}
 	gatewayHandler interface {
 		HandleServiceRequest(context.Context, *http.Request, http.ResponseWriter)
@@ -46,6 +47,12 @@ type (
 	// CircuitBreakerAdmin allows clearing circuit breaker state via admin endpoints.
 	CircuitBreakerAdmin interface {
 		ClearService(ctx context.Context, serviceID string) int
+	}
+	// ChainStateAdmin allows resetting per-service chain state (perceived block height)
+	// via admin endpoints. found=false means unknown service or a QoS type without a
+	// perceived block height; err is non-nil only if the reset itself failed.
+	ChainStateAdmin interface {
+		ResetChainState(ctx context.Context, serviceID string) (found bool, err error)
 	}
 )
 
@@ -59,6 +66,7 @@ func NewRouter(
 	healthChecker *health.Checker,
 	config config.RouterConfig,
 	circuitBreakerAdmin CircuitBreakerAdmin,
+	chainStateAdmin ChainStateAdmin,
 ) *router {
 	r := &router{
 		logger: logger.With("package", "router"),
@@ -70,6 +78,7 @@ func NewRouter(
 		disqualifiedEndpointsReporter: disqualifiedEndpointsReporter,
 		healthChecker:                 healthChecker,
 		circuitBreakerAdmin:           circuitBreakerAdmin,
+		chainStateAdmin:               chainStateAdmin,
 	}
 	r.handleRoutes()
 	return r
@@ -103,6 +112,9 @@ func (r *router) handleRoutes() {
 
 	// POST /admin/circuit-breaker/clear/{serviceId} - clears circuit breaker state (in-memory + Redis)
 	r.mux.HandleFunc("POST /admin/circuit-breaker/clear/", r.handleCircuitBreakerClear)
+
+	// POST /admin/chain-state/clear/{serviceId} - resets perceived block height (in-memory + Redis)
+	r.mux.HandleFunc("POST /admin/chain-state/clear/", r.handleChainStateClear)
 
 	// requestHandlerFn defines the middleware chain for all service requests
 	requestHandlerFn := r.corsMiddleware(r.removeGrovePortalPrefixMiddleware(r.handleServiceRequest))

--- a/router/router.go
+++ b/router/router.go
@@ -250,7 +250,7 @@ func (r *router) removeGrovePortalPrefixMiddleware(next http.HandlerFunc) http.H
 
 // staticResponseMiddleware serves a configured fixed response for a service+path+method,
 // short-circuiting the relay pipeline. It runs on the cleaned request path (after the
-// API-version and portal-app-id prefixes are stripped) so a config path like "/identity"
+// API-version and portal-app-id prefixes are stripped) so a config path like "/example"
 // matches regardless of the portal prefix. WebSocket upgrades are never intercepted — they
 // connect at the relay root, and a static route matches an exact non-root path only.
 // A nil resolver (not configured, or in tests) is a pass-through.

--- a/router/router_test.go
+++ b/router/router_test.go
@@ -31,6 +31,7 @@ func newTestRouter(t *testing.T) (*router, *MockgatewayHandler, *httptest.Server
 		config.RouterConfig{},
 		nil, // no circuit breaker in tests
 		nil, // no chain state admin in tests
+		nil, // no static responses in tests
 	)
 	ts := httptest.NewServer(r.mux)
 	t.Cleanup(ts.Close)

--- a/router/router_test.go
+++ b/router/router_test.go
@@ -30,6 +30,7 @@ func newTestRouter(t *testing.T) (*router, *MockgatewayHandler, *httptest.Server
 		&health.Checker{},
 		config.RouterConfig{},
 		nil, // no circuit breaker in tests
+		nil, // no chain state admin in tests
 	)
 	ts := httptest.NewServer(r.mux)
 	t.Cleanup(ts.Close)

--- a/router/static_response_test.go
+++ b/router/static_response_test.go
@@ -53,8 +53,8 @@ func Test_staticResponse_ServedOnMatch(t *testing.T) {
 	resolver := stubStaticResolver{
 		fn: func(serviceID, path, method string) ([]byte, int, map[string]string, bool) {
 			c.Equal("solana", serviceID)
-			c.Equal("/identity", path, "middleware must resolve on the cleaned path")
-			return []byte("0xPAYOUT"), http.StatusOK, map[string]string{
+			c.Equal("/example", path, "middleware must resolve on the cleaned path")
+			return []byte("example-body"), http.StatusOK, map[string]string{
 				"Content-Type": "text/plain; charset=utf-8",
 				"X-Test":       "1",
 			}, true
@@ -63,7 +63,7 @@ func Test_staticResponse_ServedOnMatch(t *testing.T) {
 	// No gateway EXPECT: a static hit must never reach the relay handler.
 	_, ts := newStaticTestRouter(t, resolver)
 
-	req, err := http.NewRequest(http.MethodGet, ts.URL+"/v1/identity", nil)
+	req, err := http.NewRequest(http.MethodGet, ts.URL+"/v1/example", nil)
 	c.NoError(err)
 	req.Header.Set(request.HTTPHeaderTargetServiceID, "solana")
 
@@ -74,7 +74,7 @@ func Test_staticResponse_ServedOnMatch(t *testing.T) {
 	body, err := io.ReadAll(resp.Body)
 	c.NoError(err)
 	c.Equal(http.StatusOK, resp.StatusCode)
-	c.Equal("0xPAYOUT", string(body))
+	c.Equal("example-body", string(body))
 	c.Equal("1", resp.Header.Get("X-Test"))
 	c.Equal("text/plain; charset=utf-8", resp.Header.Get("Content-Type"))
 }
@@ -130,7 +130,7 @@ func Test_staticResponse_WebSocketUpgradeBypasses(t *testing.T) {
 		},
 	)
 
-	req, err := http.NewRequest(http.MethodGet, ts.URL+"/v1/identity", nil)
+	req, err := http.NewRequest(http.MethodGet, ts.URL+"/v1/example", nil)
 	c.NoError(err)
 	req.Header.Set(request.HTTPHeaderTargetServiceID, "solana")
 	req.Header.Set("Upgrade", "websocket")

--- a/router/static_response_test.go
+++ b/router/static_response_test.go
@@ -1,0 +1,145 @@
+package router
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/pokt-network/poktroll/pkg/polylog/polyzero"
+	"github.com/stretchr/testify/require"
+	gomock "go.uber.org/mock/gomock"
+
+	"github.com/pokt-network/path/config"
+	"github.com/pokt-network/path/health"
+	"github.com/pokt-network/path/request"
+)
+
+// stubStaticResolver is a test StaticResponseResolver driven by a function.
+type stubStaticResolver struct {
+	fn func(serviceID, path, method string) ([]byte, int, map[string]string, bool)
+}
+
+func (s stubStaticResolver) ResolveStaticResponse(serviceID, path, method string) ([]byte, int, map[string]string, bool) {
+	return s.fn(serviceID, path, method)
+}
+
+func newStaticTestRouter(t *testing.T, resolver StaticResponseResolver) (*MockgatewayHandler, *httptest.Server) {
+	ctrl := gomock.NewController(t)
+	mockGateway := NewMockgatewayHandler(ctrl)
+	mockDisq := NewMockdisqualifiedEndpointsReporter(ctrl)
+
+	r := NewRouter(
+		polyzero.NewLogger(),
+		mockGateway,
+		mockDisq,
+		&health.Checker{},
+		config.RouterConfig{},
+		nil,
+		nil,
+		resolver,
+	)
+	ts := httptest.NewServer(r.mux)
+	t.Cleanup(ts.Close)
+	return mockGateway, ts
+}
+
+// Test_staticResponse_ServedOnMatch verifies a matching static route is served directly with
+// its configured status/body/headers and the relay handler is never invoked.
+func Test_staticResponse_ServedOnMatch(t *testing.T) {
+	c := require.New(t)
+
+	resolver := stubStaticResolver{
+		fn: func(serviceID, path, method string) ([]byte, int, map[string]string, bool) {
+			c.Equal("solana", serviceID)
+			c.Equal("/identity", path, "middleware must resolve on the cleaned path")
+			return []byte("0xPAYOUT"), http.StatusOK, map[string]string{
+				"Content-Type": "text/plain; charset=utf-8",
+				"X-Test":       "1",
+			}, true
+		},
+	}
+	// No gateway EXPECT: a static hit must never reach the relay handler.
+	_, ts := newStaticTestRouter(t, resolver)
+
+	req, err := http.NewRequest(http.MethodGet, ts.URL+"/v1/identity", nil)
+	c.NoError(err)
+	req.Header.Set(request.HTTPHeaderTargetServiceID, "solana")
+
+	resp, err := (&http.Client{}).Do(req)
+	c.NoError(err)
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	c.NoError(err)
+	c.Equal(http.StatusOK, resp.StatusCode)
+	c.Equal("0xPAYOUT", string(body))
+	c.Equal("1", resp.Header.Get("X-Test"))
+	c.Equal("text/plain; charset=utf-8", resp.Header.Get("Content-Type"))
+}
+
+// Test_staticResponse_RelaysOnNoMatch verifies a non-matching path falls through to the
+// relay handler unchanged.
+func Test_staticResponse_RelaysOnNoMatch(t *testing.T) {
+	c := require.New(t)
+
+	resolver := stubStaticResolver{
+		fn: func(serviceID, path, method string) ([]byte, int, map[string]string, bool) {
+			return nil, 0, nil, false
+		},
+	}
+	mockGateway, ts := newStaticTestRouter(t, resolver)
+	mockGateway.EXPECT().HandleServiceRequest(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, _ *http.Request, w http.ResponseWriter) {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("relayed"))
+		},
+	)
+
+	req, err := http.NewRequest(http.MethodGet, ts.URL+"/v1/not-static", nil)
+	c.NoError(err)
+	req.Header.Set(request.HTTPHeaderTargetServiceID, "solana")
+
+	resp, err := (&http.Client{}).Do(req)
+	c.NoError(err)
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	c.NoError(err)
+	c.Equal("relayed", string(body))
+}
+
+// Test_staticResponse_WebSocketUpgradeBypasses verifies a WebSocket upgrade is never
+// intercepted by a static route — it must reach the relay handler even when the path would
+// otherwise match.
+func Test_staticResponse_WebSocketUpgradeBypasses(t *testing.T) {
+	c := require.New(t)
+
+	resolver := stubStaticResolver{
+		fn: func(serviceID, path, method string) ([]byte, int, map[string]string, bool) {
+			t.Errorf("resolver must not be consulted for an upgrade request")
+			return []byte("static"), http.StatusOK, nil, true
+		},
+	}
+	mockGateway, ts := newStaticTestRouter(t, resolver)
+	mockGateway.EXPECT().HandleServiceRequest(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, _ *http.Request, w http.ResponseWriter) {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("relayed"))
+		},
+	)
+
+	req, err := http.NewRequest(http.MethodGet, ts.URL+"/v1/identity", nil)
+	c.NoError(err)
+	req.Header.Set(request.HTTPHeaderTargetServiceID, "solana")
+	req.Header.Set("Upgrade", "websocket")
+
+	resp, err := (&http.Client{}).Do(req)
+	c.NoError(err)
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	c.NoError(err)
+	c.Equal("relayed", string(body))
+}


### PR DESCRIPTION
## Summary

Consolidates the operator-concentration + reputation-hardening work that has been running and validated in production (both environments) into `main`. 24 commits, primarily in `qos/`, `reputation/`, `router/`, and `gateway/`.

**Recommend squash-merge.**

## What's included

### Per-operator concentration cap
- Bounds the fraction of a service's endpoint selections any single operator (registrable domain / eTLD+1) may receive; excess is water-filled across the other valid operators. Limits blast radius when one operator holds most of the pool and degrades.
- Config-driven, ships on by default (`max_operator_share: 0.65`); extended to EVM, Cosmos, Solana, and NoOp; two-phase (skips grouping when it can't reshape) with reshape observability.

### Reputation
- **Per-URL key granularity (default)**: suppliers fronting the exact same backend URL are scored/cooled once, instead of each having to independently prove a shared backend is broken. Keeps distinct URLs separate (no cross-backend dilution).
- **Volume-independent rate cooldown** for chronic critical failures, with linear escalation (10-minute steps) and a sub-session first offense.
- **Pool-collapse guard**: never filter a service down to zero endpoints.
- Health-check signals excluded from the rate-cooldown detector; fixed double-counting of health-check relays in `path_relays_total`.

### Health checks
- **Backend-URL dedup**: fire one relay per unique backend URL (rotating representative) and fan the backend-derived result to the other suppliers on that URL. Cuts health-check relay volume ~2.5–3× and sharpens instability detection. Config-gated, default on.

### WebSocket
- Operator-uniform rebind strategy (default on) and rotate rebind across operators when the concentration cap is engaged; rebind-trigger metric; extracted and unit-tested the rebind policy.

### QoS / Solana
- Stop poisoning perceived block height with the slot value; `getEpochInfo` external source for Solana.
- Plausibility-guard the external block-height floor across all QoS.

### Router / ops / metrics
- Config-driven static per-service responses (fixed body served directly by the gateway for a configured path, bypassing the relay).
- Admin chain-state reset endpoint.
- Counter for relay retry-exhaustion 500s (closes the gateway-vs-edge blind spot).

## Testing
- Unit tests across all touched packages; `go build ./...` clean.
- Validated in production on both environments prior to this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
