### PR TITLE
WebSocket idle-connection reaper + hedge-path data race fix

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -274,6 +274,24 @@ Rebinds land on `path_websocket_rebind_total{trigger="admin"}`, distinct from `r
 - `stall` — the staleness watchdog saw no subscription data past the threshold; escapes the bound **backend URL**.
 - `session_expired` — PATH noticed the bound session had ended while the supplier kept streaming. Without this a connection is stranded outside the session indefinitely: unsigned endpoint→client frames need no session so data keeps flowing, and the staleness watchdog stays quiet *because* it is flowing. Measured at 21% of live connections before the fix. Watch for `Endpoints = 0` with a blank Mean Score but nonzero WS msg/s on the supplier-quality panel — that combination is the tell.
 
+**Idle-connection reaper** (`websocket_idle_timeout`, default `30m`)
+
+A connection that has **never established a subscription** and has **sent no client frame** for the threshold is closed with **1000 (Normal Closure)**. Nothing else reaped it: ping/pong keeps a socket alive for as long as the peer answers, and the staleness watchdog arms only on connections that *have* a subscription — a quiet subscription-less connection was assumed to be a WebSocket JSON-RPC client between requests.
+
+Measured 2026-08-04: five services (`eth-sepolia-testnet` 134 conns, `blast` 40, `sei` 23, `moonbeam` 22, `bera` 22) held **241 connections with zero subscriptions between them**, costing **~1370 rebinds/hour that replayed nothing**. The tell is `path_websocket_rebind_total` high with `path_websocket_subscriptions_replayed_total` at **exactly 0** for the same `service_id` — compare against `eth` (188 rebinds → 182 replays). At the edge these were four WebSocket-only client IPs making no HTTP at all, holding sockets 4-6.5h and receiving ~1.5 KB each.
+
+**The two conditions are ANDed, and each alone is wrong.** Silence alone reaps a subscriber watching a rare event (legitimately quiet for hours). No-subscription alone reaps a WebSocket JSON-RPC client between requests. Neither at once, for half an hour, is neither shape.
+
+Not an endpoint fault, so it **never touches reputation** — the supplier was never asked for anything. Reaps land on `path_websocket_idle_reaped_total{service_id, domain}`, deliberately a separate counter: the shared close path already emits `event="closed"`, and folding reaps in would break established/closed reconciliation, which is the check that separates a gauge leak from real accumulation.
+
+```yaml
+router_config:
+  websocket_idle_timeout: 30m   # negative disables reaping entirely
+```
+```bash
+PATH_WEBSOCKET_IDLE_TIMEOUT=45m   # pod restart instead of a config-map edit
+```
+
 **Circuit Breaker — when to use:**
 - After deploying a fix for a bug that caused false positive circuit breaker lockouts
 - When a domain is stuck in circuit breaker state due to a transient issue that has resolved

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -157,11 +157,21 @@ curl -X POST http://localhost:3069/v1 \
 **Behavior:**
 - When `Target-Suppliers` header is present, PATH will:
   - Filter available endpoints to only those from the specified suppliers
-  - Skip reputation-based filtering (allows targeting suppliers with low reputation)
+  - Skip **all** reputation-derived filtering — both the score-threshold/cooldown filter and
+    tiered (highest-tier-only) selection. A score-0, fully-cooled-down supplier is reachable.
   - Still apply RPC type filtering (only endpoints supporting the requested RPC type)
+  - Still apply the config `blocked_suppliers` list, the endpoint policy (`require_https` /
+    `require_domain`), and the supplier blacklist (signature/validation failures). None of these
+    are reputation, and the header does not override them.
   - Log filtered supplier list and endpoint counts
 - If none of the specified suppliers are available in the current session, the request will fail
 - Header takes precedence over load testing configuration (if any)
+
+Tiered selection used to run *after* the supplier allowlist, so pinning a supplier whose
+endpoints were all below `min_threshold` returned `no valid endpoints available for service` —
+the header failed exactly when it was most needed, on a supplier you were trying to diagnose.
+Health checks were unaffected throughout (they pass `filterByReputation=false`), which is why a
+dark supplier still shows health-check traffic while serving zero user traffic.
 
 **App-Address** (Delegated Mode Only)
 Specifies the target application address when PATH is running in delegated mode.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -296,6 +296,22 @@ PATH_MAX_OPERATOR_SHARE=0.65               # move the cap without a config rollo
 
 **Dry run before changing any of this:** `go test ./qos/selector/ -run Test_ProductionDryRun -v` replays the real pools through the shipped selector and gates on nobody dropped, nobody stranded, nobody allocated past both the cap and their own entitlement.
 
+### Is the cap engaging on WebSocket? Read the `path` label
+
+The cap covers WebSocket selection already — a WS connection reaches it through a QoS type's single-endpoint `Select` (`gateway/websocket_request_context.go` → `qos/*/…Select` → `SelectWithConcentrationCap`), while HTTP reaches it through `SelectMultipleWithArchival` → `SelectEndpointsWithDiversity`. **Do not add a second cap for WebSocket; it is the same cap.**
+
+The two are separable on `path_concentration_cap_reshaped_total{service_id, path}`:
+
+- `path="concentration_cap"` — the **WebSocket** selection path.
+- `path="diversity"` — the HTTP serving pick.
+
+Same `path` vocabulary as `path_selection_pool_size` / `path_selection_selected_total`, so pool composition and reshape counts join on it. Before this label existed the two shared one series, and HTTP — running three to four orders of magnitude more selections per second — completely masked whether the cap ever engaged on a WebSocket selection.
+
+**A near-zero WS series is not proof the cap is broken.** Three things concentrate WebSocket traffic that no cap can touch, and they should be excluded before touching selection:
+1. **A WS connection binds one endpoint for its lifetime.** Selection governs only *new* connections; existing ones move only on rollover / stall / `session_expired` / `POST /admin/websocket/tumble/{svc}`.
+2. **Reputation removes whole operators from the pool before the cap sees it** (`path_reputation_disqualified_total{rpc_type="websocket"}`). The cap water-fills across survivors; it cannot restore what the floor deleted.
+3. **Supply** — some services have only one operator offering WS endpoints at all.
+
 ## Concentration Cap on the Retry / Hedge Paths
 
 The per-operator (eTLD+1) cap governs **primary** selection. Retry, hedge and batch-item picks come from the top-reputation-score band, which was weighted within the band but **not capped by operator** — so an operator holding most of the band took most of the retries and hedges, on the two paths whose entire purpose is to reach different infrastructure than the attempt that just failed.
@@ -316,7 +332,7 @@ PATH_CAP_RETRY_HEDGE_SELECTION=true   # or =false to force off everywhere
 ```
 Unset leaves config in charge. The share value itself is still `max_operator_share`; this key only decides whether the band paths consult it.
 
-**Metric** — a separate counter, not a new label on `path_concentration_cap_reshaped_total`, so the primary path's already-nonzero series stay a valid baseline:
+**Metric** — a separate counter rather than another value in `path_concentration_cap_reshaped_total`'s `path` label, so the primary path's already-nonzero series stay a valid baseline. The two counters keep independent `path` vocabularies: `retry|hedge|batch` here, `diversity|concentration_cap` (HTTP vs WebSocket) there.
 ```
 path_concentration_cap_band_total{service_id, path="retry|hedge|batch", outcome}
 ```

--- a/cmd/healthcheck.go
+++ b/cmd/healthcheck.go
@@ -134,11 +134,13 @@ func runHealthCheckLoop(
 	protocolInstance gateway.Protocol,
 	leaderElector *gateway.LeaderElector,
 ) {
-	// Get check interval from service configs (use minimum if multiple, default to 10s)
-	checkInterval := getMinCheckInterval(executor)
+	// The loop ticks at the SMALLEST configured interval in the fleet; each service is
+	// then gated to its own check_interval inside RunAllChecksViaProtocol. The tick is
+	// therefore a resolution floor, not the rate any single service runs at.
+	checkInterval := executor.MinCheckInterval()
 
 	logger.Info().
-		Dur("check_interval", checkInterval).
+		Dur("tick_interval", checkInterval).
 		Msg("Starting health check loop")
 
 	ticker := time.NewTicker(checkInterval)
@@ -196,33 +198,3 @@ func runHealthChecks(
 	}
 }
 
-// getMinCheckInterval returns the minimum check interval from all configured services.
-// If no services are configured or all have 0 interval, defaults to 10 seconds.
-func getMinCheckInterval(executor *gateway.HealthCheckExecutor) time.Duration {
-	const defaultInterval = 10 * time.Second
-
-	if executor == nil {
-		return defaultInterval
-	}
-
-	configs := executor.GetServiceConfigs()
-	if len(configs) == 0 {
-		return defaultInterval
-	}
-
-	// Find minimum non-zero interval
-	minInterval := time.Duration(0)
-	for _, cfg := range configs {
-		if cfg.CheckInterval > 0 {
-			if minInterval == 0 || cfg.CheckInterval < minInterval {
-				minInterval = cfg.CheckInterval
-			}
-		}
-	}
-
-	if minInterval == 0 {
-		return defaultInterval
-	}
-
-	return minInterval
-}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -24,6 +24,7 @@ import (
 	"github.com/pokt-network/path/reputation"
 	"github.com/pokt-network/path/request"
 	"github.com/pokt-network/path/router"
+	"github.com/pokt-network/path/websockets"
 )
 
 // Version information injected at build time via ldflags
@@ -292,6 +293,11 @@ func main() {
 	// This enables /ready/<service>?detailed=true to include archival status information.
 	protocol.SetQoSServiceRegistry(requestParser)
 
+	// Apply the websocket idle-reaper threshold before any bridge can be created. Bridges
+	// read it on their own goroutines without synchronization, so this must happen before
+	// the server starts accepting connections.
+	configureWebsocketIdleTimeout(logger, config.GetRouterConfig().WebsocketIdleTimeout)
+
 	// NOTE: the gateway uses the requestParser to get the correct QoS instance for any incoming request.
 	gtw := &gateway.Gateway{
 		Logger:                     logger,
@@ -470,6 +476,41 @@ func main() {
 }
 
 /* -------------------- Gateway Init Helpers -------------------- */
+
+// configureWebsocketIdleTimeout applies the websocket idle-reaper threshold, letting
+// PATH_WEBSOCKET_IDLE_TIMEOUT override the config value.
+//
+// The env override exists so the threshold can be moved (or reaping switched off) with a
+// pod restart while watching path_websocket_idle_reaped_total, instead of a config-map edit
+// — the same escape hatch PATH_MAX_OPERATOR_SHARE provides for the concentration cap.
+// Accepts any Go duration ("45m", "2h"); a non-positive value disables reaping.
+func configureWebsocketIdleTimeout(logger polylog.Logger, configured time.Duration) {
+	timeout := configured
+
+	if raw := os.Getenv("PATH_WEBSOCKET_IDLE_TIMEOUT"); raw != "" {
+		parsed, err := time.ParseDuration(raw)
+		if err != nil {
+			logger.Warn().
+				Str("value", raw).
+				Msg("⚠️ ignoring PATH_WEBSOCKET_IDLE_TIMEOUT: not a duration (expected e.g. 30m)")
+		} else {
+			timeout = parsed
+			logger.Warn().
+				Str("value", raw).
+				Msg("⚠️ websocket idle timeout OVERRIDDEN by PATH_WEBSOCKET_IDLE_TIMEOUT")
+		}
+	}
+
+	websockets.SetIdleConnectionThreshold(timeout)
+
+	if timeout <= 0 {
+		logger.Warn().Msg("⚠️ websocket idle reaping DISABLED: connections with no subscription and no traffic are never closed")
+		return
+	}
+	logger.Info().
+		Dur("websocket_idle_timeout", timeout).
+		Msg("🧹 websocket idle reaping enabled")
+}
 
 // getConfigPath returns the full path to the config file relative to the executable.
 //

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -102,6 +102,7 @@ func Test_LoadGatewayConfigFromYAML(t *testing.T) {
 					WebsocketMessageBufferSize:        8192, // Matches example config
 					MaxConcurrentWebsocketConnections: defaultMaxConcurrentWebsocketConnections,
 					MaxRequestBodyBytes:               defaultMaxRequestBodyBytes,
+					WebsocketIdleTimeout:              defaultWebsocketIdleTimeout,
 				},
 				Logger: LoggerConfig{
 					Level: "info", // Matches example config
@@ -202,6 +203,7 @@ logger_config:
 					WebsocketMessageBufferSize:        defaultWebsocketMessageBufferSize,
 					MaxConcurrentWebsocketConnections: defaultMaxConcurrentWebsocketConnections,
 					MaxRequestBodyBytes:               defaultMaxRequestBodyBytes,
+					WebsocketIdleTimeout:              defaultWebsocketIdleTimeout,
 				},
 				Logger: LoggerConfig{
 					Level: "debug",
@@ -417,6 +419,7 @@ logger_config:
 					WebsocketMessageBufferSize:        defaultWebsocketMessageBufferSize,
 					MaxConcurrentWebsocketConnections: defaultMaxConcurrentWebsocketConnections,
 					MaxRequestBodyBytes:               defaultMaxRequestBodyBytes,
+					WebsocketIdleTimeout:              defaultWebsocketIdleTimeout,
 				},
 				Logger: LoggerConfig{
 					Level: "info",

--- a/config/router.go
+++ b/config/router.go
@@ -50,6 +50,20 @@ const (
 	// concurrent websocket load (Polygon is the primary websocket service).
 	// Set to a negative value in config to disable the limit entirely.
 	defaultMaxConcurrentWebsocketConnections = 10000
+
+	// defaultWebsocketIdleTimeout is how long a websocket connection may hold no
+	// established subscription AND send no client frame before PATH closes it.
+	//
+	// Nothing else reaps such a connection: ping/pong keeps it alive as long as the peer
+	// answers, and the endpoint-staleness watchdog arms only on connections that HAVE a
+	// subscription. It is not free — it stays bound to a supplier and is rebound at every
+	// session rollover, replaying nothing.
+	//
+	// 30 minutes is set to be unreachable by a client that is using the connection, not to
+	// be aggressive: a subscriber is exempt on a different condition entirely, so this only
+	// has to clear a websocket JSON-RPC client's gap between requests.
+	// Set to a negative value in config to disable reaping entirely.
+	defaultWebsocketIdleTimeout = 30 * time.Minute
 )
 
 /* --------------------------------- Router Config Struct -------------------------------- */
@@ -74,6 +88,10 @@ type RouterConfig struct {
 	// MaxRequestBodyBytes caps the size (in bytes) of an HTTP request body PATH
 	// will read into memory. Default: 10MB. A negative value disables the limit.
 	MaxRequestBodyBytes int64 `yaml:"max_request_body_bytes"`
+	// WebsocketIdleTimeout is how long a websocket connection may hold no established
+	// subscription and send no client frame before PATH closes it. Default: 30m. A
+	// negative value disables idle reaping.
+	WebsocketIdleTimeout time.Duration `yaml:"websocket_idle_timeout"`
 }
 
 /* --------------------------------- Router Config Private Helpers -------------------------------- */
@@ -109,6 +127,11 @@ func (c *RouterConfig) hydrateRouterDefaults() error {
 	}
 	if c.MaxRequestBodyBytes == 0 {
 		c.MaxRequestBodyBytes = defaultMaxRequestBodyBytes
+	}
+	// Same convention as the limits above: only an unset (zero) value takes the default,
+	// so a negative value survives hydration as an explicit "disable reaping".
+	if c.WebsocketIdleTimeout == 0 {
+		c.WebsocketIdleTimeout = defaultWebsocketIdleTimeout
 	}
 	if c.SystemOverheadAllowanceDuration >= c.ReadTimeout || c.SystemOverheadAllowanceDuration >= c.WriteTimeout {
 		return fmt.Errorf("system overhead allowance duration %v must be less than read timeout %v and write timeout %v", c.SystemOverheadAllowanceDuration, c.ReadTimeout, c.WriteTimeout)

--- a/config/router_test.go
+++ b/config/router_test.go
@@ -70,6 +70,7 @@ func TestRouterConfig_hydrateRouterDefaults(t *testing.T) {
 				WebsocketMessageBufferSize:        defaultWebsocketMessageBufferSize,
 				MaxConcurrentWebsocketConnections: defaultMaxConcurrentWebsocketConnections,
 				MaxRequestBodyBytes:               defaultMaxRequestBodyBytes,
+				WebsocketIdleTimeout:              defaultWebsocketIdleTimeout,
 			},
 			wantErr: false,
 		},
@@ -88,6 +89,7 @@ func TestRouterConfig_hydrateRouterDefaults(t *testing.T) {
 				WebsocketMessageBufferSize:        defaultWebsocketMessageBufferSize,
 				MaxConcurrentWebsocketConnections: defaultMaxConcurrentWebsocketConnections,
 				MaxRequestBodyBytes:               defaultMaxRequestBodyBytes,
+				WebsocketIdleTimeout:              defaultWebsocketIdleTimeout,
 			},
 			wantErr: false,
 		},
@@ -124,6 +126,7 @@ func TestRouterConfig_hydrateRouterDefaults(t *testing.T) {
 				WebsocketMessageBufferSize:        500, // Custom value should be preserved
 				MaxConcurrentWebsocketConnections: defaultMaxConcurrentWebsocketConnections,
 				MaxRequestBodyBytes:               defaultMaxRequestBodyBytes,
+				WebsocketIdleTimeout:              defaultWebsocketIdleTimeout,
 			},
 			wantErr: false,
 		},
@@ -142,6 +145,7 @@ func TestRouterConfig_hydrateRouterDefaults(t *testing.T) {
 				WebsocketMessageBufferSize:        defaultWebsocketMessageBufferSize,
 				MaxConcurrentWebsocketConnections: -1, // Negative preserved: limit disabled
 				MaxRequestBodyBytes:               defaultMaxRequestBodyBytes,
+				WebsocketIdleTimeout:              defaultWebsocketIdleTimeout,
 			},
 			wantErr: false,
 		},
@@ -160,6 +164,7 @@ func TestRouterConfig_hydrateRouterDefaults(t *testing.T) {
 				WebsocketMessageBufferSize:        defaultWebsocketMessageBufferSize,
 				MaxConcurrentWebsocketConnections: defaultMaxConcurrentWebsocketConnections,
 				MaxRequestBodyBytes:               -1, // Negative preserved: limit disabled
+				WebsocketIdleTimeout:              defaultWebsocketIdleTimeout,
 			},
 			wantErr: false,
 		},

--- a/gateway/health_check_executor.go
+++ b/gateway/health_check_executor.go
@@ -25,7 +25,6 @@ import (
 	"strconv"
 	"strings"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	"github.com/alitto/pond/v2"
@@ -111,10 +110,24 @@ type HealthCheckExecutor struct {
 	// Health checks defined here are merged with local/external configs.
 	unifiedServicesConfig *UnifiedServicesConfig
 
-	// cycleCounter increments once per health check cycle. Used to rotate which
-	// supplier represents each backend URL under backend-URL dedup, so every
-	// supplier's own relay path is directly validated every N cycles.
-	cycleCounter uint64
+	// Per-service scheduling state, guarded by scheduleMu.
+	//
+	// The health check loop ticks at ONE global period (the smallest configured
+	// check_interval in the fleet). Without this state every enabled service ran on
+	// every tick, so a service's own check_interval could only ever lower the global
+	// floor - never raise its own rate. Measured 2026-08-03: 33 of 69 services ran
+	// faster than their own config asked for, up to 6x (robinhood: 60s configured,
+	// 10s actual), and services with zero user traffic were the worst offenders
+	// (manta: 14.4 health-check req/s against 0 req/s of real traffic).
+	//
+	// serviceLastRun records when each service last had checks submitted;
+	// serviceCycle is its own rotation counter for backend-URL dedup. The counter is
+	// per-service on purpose: a global one advanced by N per service run, so a
+	// service on a 30s interval whose backend group size divides 3 would re-probe the
+	// same representative forever and never directly validate its siblings.
+	scheduleMu     sync.Mutex
+	serviceLastRun map[protocol.ServiceID]time.Time
+	serviceCycle   map[protocol.ServiceID]uint64
 
 	// endpointLookupBudget caps the endpoint-resolution phase of a cycle.
 	// Zero means defaultEndpointLookupBudget. Only tests set it.
@@ -195,6 +208,8 @@ func NewHealthCheckExecutor(cfg HealthCheckExecutorConfig) *HealthCheckExecutor 
 		qosInstances:              make(map[protocol.ServiceID]QoSService),
 		unifiedServicesConfig:     cfg.UnifiedServicesConfig,
 		perServiceExternalConfigs: make(map[protocol.ServiceID][]HealthCheckConfig),
+		serviceLastRun:            make(map[protocol.ServiceID]time.Time),
+		serviceCycle:              make(map[protocol.ServiceID]uint64),
 	}
 
 	if cfg.Logger != nil {
@@ -2052,6 +2067,115 @@ func representativeIndex(cycle uint64, groupSize int) int {
 	return int(cycle % uint64(groupSize))
 }
 
+// serviceCheckInterval returns the effective check interval for a service config,
+// falling back to the default when unset. External configs reach the executor without
+// passing through hydrateDefaults, so the fallback cannot be assumed applied upstream.
+func serviceCheckInterval(cfg ServiceHealthCheckConfig) time.Duration {
+	if cfg.CheckInterval > 0 {
+		return cfg.CheckInterval
+	}
+	return DefaultHealthCheckInterval
+}
+
+// MinCheckInterval returns the smallest configured check interval across all services,
+// which is the period the health check loop must tick at to be able to honor every
+// service's own interval. Defaults to DefaultHealthCheckInterval when nothing is
+// configured. This is the single source of truth for the loop's tick period.
+func (e *HealthCheckExecutor) MinCheckInterval() time.Duration {
+	if e == nil {
+		return DefaultHealthCheckInterval
+	}
+
+	minInterval := time.Duration(0)
+	for _, cfg := range e.GetServiceConfigs() {
+		if cfg.Enabled != nil && !*cfg.Enabled {
+			continue
+		}
+		if iv := serviceCheckInterval(cfg); minInterval == 0 || iv < minInterval {
+			minInterval = iv
+		}
+	}
+
+	if minInterval <= 0 {
+		return DefaultHealthCheckInterval
+	}
+	return minInterval
+}
+
+// dueServices reports which services are due for checks on this tick and, for each,
+// the rotation counter its backend-URL dedup should use. Services not returned are
+// skipped entirely this cycle - including their endpoint resolution, which is the
+// expensive part (see resolveEndpointInfos).
+//
+// A service is due when the time since its last run has reached its own
+// check_interval, minus half a tick of slack. The slack is load-bearing: the loop
+// ticks on a fixed period, so a 30s service compared against a bare `elapsed >= 30s`
+// would miss the t=30s tick by microseconds of cycle jitter and fire at t=40s
+// instead - silently converting every interval into the next multiple of the tick.
+//
+// Calling this MARKS the returned services as run, so it must be called exactly once
+// per cycle.
+func (e *HealthCheckExecutor) dueServices(
+	serviceConfigs []ServiceHealthCheckConfig,
+	now time.Time,
+	tick time.Duration,
+) map[protocol.ServiceID]uint64 {
+	if tick <= 0 {
+		tick = DefaultHealthCheckInterval
+	}
+	slack := tick / 2
+
+	due := make(map[protocol.ServiceID]uint64, len(serviceConfigs))
+
+	e.scheduleMu.Lock()
+	defer e.scheduleMu.Unlock()
+
+	if e.serviceLastRun == nil {
+		e.serviceLastRun = make(map[protocol.ServiceID]time.Time, len(serviceConfigs))
+	}
+	if e.serviceCycle == nil {
+		e.serviceCycle = make(map[protocol.ServiceID]uint64, len(serviceConfigs))
+	}
+
+	// Track which services the current config knows about, so state for services
+	// dropped by an external config reload does not accumulate.
+	live := make(map[protocol.ServiceID]struct{}, len(serviceConfigs))
+
+	for _, cfg := range serviceConfigs {
+		if cfg.Enabled != nil && !*cfg.Enabled {
+			continue
+		}
+		live[cfg.ServiceID] = struct{}{}
+
+		// GetServiceConfigs can return the same service more than once after a merge;
+		// the first entry decides, and the duplicate must not re-mark it as run.
+		if _, decided := due[cfg.ServiceID]; decided {
+			continue
+		}
+
+		// A service never run before is always due, including on the first cycle
+		// after startup (zero time => elapsed is effectively unbounded).
+		lastRun, seen := e.serviceLastRun[cfg.ServiceID]
+		if seen && now.Sub(lastRun) < serviceCheckInterval(cfg)-slack {
+			continue
+		}
+
+		e.serviceLastRun[cfg.ServiceID] = now
+		cycle := e.serviceCycle[cfg.ServiceID] + 1
+		e.serviceCycle[cfg.ServiceID] = cycle
+		due[cfg.ServiceID] = cycle
+	}
+
+	for serviceID := range e.serviceLastRun {
+		if _, ok := live[serviceID]; !ok {
+			delete(e.serviceLastRun, serviceID)
+			delete(e.serviceCycle, serviceID)
+		}
+	}
+
+	return due
+}
+
 // endpointSessionActive reports whether the endpoint's session is still active, so a
 // stale (rolled-over) endpoint is skipped. Endpoints without a session ID are treated
 // as active (nothing to invalidate against).
@@ -2227,19 +2351,23 @@ func (e *HealthCheckExecutor) RunAllChecksViaProtocol(
 		return nil
 	}
 
-	// Resolve endpoints for every enabled service up front. This MUST stay off the
+	// Decide which services are due on this tick. The loop ticks at the fleet-wide
+	// minimum interval; this is what lets a service's own check_interval raise its
+	// period above that floor instead of being ignored.
+	dueCycles := e.dueServices(serviceConfigs, time.Now(), e.MinCheckInterval())
+	if len(dueCycles) == 0 {
+		e.logger.Debug().Msg("No services due for health checks this cycle")
+		return nil
+	}
+
+	// Resolve endpoints for every DUE service up front. This MUST stay off the
 	// submission loop below: see resolveEndpointInfos for the starvation it fixes.
-	enabledServiceIDs := make([]protocol.ServiceID, 0, len(serviceConfigs))
-	seenServiceIDs := make(map[protocol.ServiceID]struct{}, len(serviceConfigs))
-	for _, svcConfig := range serviceConfigs {
-		if svcConfig.Enabled != nil && !*svcConfig.Enabled {
-			continue
-		}
-		if _, dup := seenServiceIDs[svcConfig.ServiceID]; dup {
-			continue
-		}
-		seenServiceIDs[svcConfig.ServiceID] = struct{}{}
-		enabledServiceIDs = append(enabledServiceIDs, svcConfig.ServiceID)
+	// Skipping not-due services here is the point of the gate - endpoint resolution
+	// is the expensive phase, so scheduling that only skipped the relays would leave
+	// most of the cost in place.
+	enabledServiceIDs := make([]protocol.ServiceID, 0, len(dueCycles))
+	for serviceID := range dueCycles {
+		enabledServiceIDs = append(enabledServiceIDs, serviceID)
 	}
 	resolvedEndpoints := e.resolveEndpointInfos(ctx, enabledServiceIDs, getEndpointInfos)
 
@@ -2248,15 +2376,20 @@ func (e *HealthCheckExecutor) RunAllChecksViaProtocol(
 	totalJobs := 0
 
 	dedup := e.backendDedupEnabled()
-	// One rotation tick per cycle: every backend-URL group advances its representative
-	// by exactly one, giving each supplier on a URL a directly-probed turn every N cycles.
-	cycle := atomic.AddUint64(&e.cycleCounter, 1)
+	seenServiceIDs := make(map[protocol.ServiceID]struct{}, len(dueCycles))
 
 	// Submit health check jobs to the worker pool
 	for _, svcConfig := range serviceConfigs {
-		if svcConfig.Enabled != nil && !*svcConfig.Enabled {
+		// Per-service rotation counter, advanced once per run of THIS service.
+		// Absent means the service is not due this cycle (or is disabled).
+		cycle, isDue := dueCycles[svcConfig.ServiceID]
+		if !isDue {
 			continue
 		}
+		if _, dup := seenServiceIDs[svcConfig.ServiceID]; dup {
+			continue
+		}
+		seenServiceIDs[svcConfig.ServiceID] = struct{}{}
 
 		// Pre-resolved above. Absent means the lookup failed or missed the resolution
 		// budget - both already logged there - so skip the service for this cycle.
@@ -2356,7 +2489,10 @@ func (e *HealthCheckExecutor) RunAllChecksViaProtocol(
 	}
 
 	e.logger.Info().
-		Int("service_count", len(serviceConfigs)).
+		// Services DUE this tick, not services configured: most ticks now check a
+		// subset, so the two differ and only the first explains total_jobs.
+		Int("service_count", len(dueCycles)).
+		Int("configured_service_count", len(serviceConfigs)).
 		Int("total_jobs", totalJobs).
 		Int("max_workers", e.maxWorkers).
 		Int("pool_running_workers", int(e.pool.RunningWorkers())).

--- a/gateway/health_check_schedule_test.go
+++ b/gateway/health_check_schedule_test.go
@@ -1,0 +1,252 @@
+package gateway
+
+import (
+	"context"
+	"net/http"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/pokt-network/poktroll/pkg/polylog/polyzero"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pokt-network/path/protocol"
+)
+
+// The property under test: a service's own check_interval decides how often it is
+// checked. The loop ticks at ONE global period (the fleet minimum), so before this
+// gate existed every enabled service ran on every tick and check_interval could only
+// ever lower the global floor. Measured 2026-08-03 against pnf_path_rules.yaml: 33 of
+// 69 services ran faster than they asked for, up to 6x, and the worst offenders were
+// services with no user traffic at all.
+
+func scheduleConfig(intervals map[protocol.ServiceID]time.Duration) []ServiceHealthCheckConfig {
+	configs := make([]ServiceHealthCheckConfig, 0, len(intervals))
+	for serviceID, interval := range intervals {
+		configs = append(configs, ServiceHealthCheckConfig{
+			ServiceID:     serviceID,
+			CheckInterval: interval,
+			Checks: []HealthCheckConfig{{
+				Name:   "probe",
+				Type:   HealthCheckTypeJSONRPC,
+				Method: http.MethodPost,
+				Path:   "/",
+			}},
+		})
+	}
+	return configs
+}
+
+func newScheduleExecutor(t *testing.T, configs []ServiceHealthCheckConfig) *HealthCheckExecutor {
+	t.Helper()
+
+	executor := NewHealthCheckExecutor(HealthCheckExecutorConfig{
+		Config:     &ActiveHealthChecksConfig{Enabled: true, Local: configs},
+		Logger:     polyzero.NewLogger(),
+		Protocol:   &mockProtocolForRetry{},
+		MaxWorkers: 4,
+	})
+	t.Cleanup(executor.Stop)
+	return executor
+}
+
+// A 30s service must run once per three 10s ticks, not on every one.
+func Test_dueServices_HonorsPerServiceInterval(t *testing.T) {
+	c := require.New(t)
+
+	const (
+		fast protocol.ServiceID = "fast"
+		slow protocol.ServiceID = "slow"
+	)
+	configs := scheduleConfig(map[protocol.ServiceID]time.Duration{
+		fast: 10 * time.Second,
+		slow: 30 * time.Second,
+	})
+	executor := newScheduleExecutor(t, configs)
+
+	const tick = 10 * time.Second
+	base := time.Now()
+
+	runs := map[protocol.ServiceID]int{}
+	// 9 ticks == 90 seconds of wall clock.
+	for i := range 9 {
+		for serviceID := range executor.dueServices(configs, base.Add(time.Duration(i)*tick), tick) {
+			runs[serviceID]++
+		}
+	}
+
+	c.Equal(9, runs[fast], "a service at the tick period must run on every tick")
+	c.Equal(3, runs[slow], "a 30s service must run 3 times in 90s, not 9")
+}
+
+// The regression the half-tick slack exists for. The loop ticks on a fixed period, so
+// a 30s service reaching t=30s microseconds late would miss its tick under a bare
+// `elapsed >= interval` and fire at t=40s instead - silently rounding every interval up
+// to the next multiple of the tick, which is the bug this whole change removes.
+func Test_dueServices_JitterDoesNotPushServiceToNextTick(t *testing.T) {
+	c := require.New(t)
+
+	const slow protocol.ServiceID = "slow"
+	configs := scheduleConfig(map[protocol.ServiceID]time.Duration{slow: 30 * time.Second})
+	executor := newScheduleExecutor(t, configs)
+
+	const tick = 10 * time.Second
+	base := time.Now()
+
+	// Each tick lands slightly LATE, the way a real ticker plus cycle work does. The
+	// t=30s tick is therefore at 30s + jitter relative to the t=0 run, and a naive
+	// comparison against the previous run time would still be under 30s of elapsed
+	// only if jitter were negative - so the failing direction here is the tick landing
+	// EARLY, which a ticker draining a backlog does do.
+	jitter := []time.Duration{0, 0, 0, -2 * time.Millisecond}
+
+	fired := make([]int, 0, 4)
+	for i := range 4 {
+		now := base.Add(time.Duration(i)*tick + jitter[i])
+		if _, due := executor.dueServices(configs, now, tick)[slow]; due {
+			fired = append(fired, i)
+		}
+	}
+
+	c.Equal([]int{0, 3}, fired, "the 30s service must fire on the t=30s tick, not slip to t=40s")
+}
+
+// Nothing has run at startup, so everything is due on the first cycle regardless of
+// interval - a fresh pod must not wait 60s for its slowest service's first signal.
+func Test_dueServices_FirstCycleRunsEverything(t *testing.T) {
+	c := require.New(t)
+
+	configs := scheduleConfig(map[protocol.ServiceID]time.Duration{
+		"a": 10 * time.Second,
+		"b": 60 * time.Second,
+		"c": 30 * time.Second,
+	})
+	executor := newScheduleExecutor(t, configs)
+
+	due := executor.dueServices(configs, time.Now(), 10*time.Second)
+	c.Len(due, 3, "every service must be checked on the first cycle")
+}
+
+// Disabled services are never due, and must not accumulate scheduling state.
+func Test_dueServices_SkipsDisabled(t *testing.T) {
+	c := require.New(t)
+
+	disabled := false
+	configs := scheduleConfig(map[protocol.ServiceID]time.Duration{"on": 10 * time.Second})
+	configs = append(configs, ServiceHealthCheckConfig{
+		ServiceID:     "off",
+		CheckInterval: 10 * time.Second,
+		Enabled:       &disabled,
+	})
+	executor := newScheduleExecutor(t, configs)
+
+	due := executor.dueServices(configs, time.Now(), 10*time.Second)
+	c.Contains(due, protocol.ServiceID("on"))
+	c.NotContains(due, protocol.ServiceID("off"))
+}
+
+// The rotation counter must advance once per run of ITS service. A global counter
+// advanced by 3 per run of a 30s service, so a backend-URL group of size 3 would
+// re-probe the same representative forever and never directly validate its siblings.
+func Test_dueServices_RotationCounterIsPerService(t *testing.T) {
+	c := require.New(t)
+
+	const slow protocol.ServiceID = "slow"
+	configs := scheduleConfig(map[protocol.ServiceID]time.Duration{
+		"fast": 10 * time.Second,
+		slow:   30 * time.Second,
+	})
+	executor := newScheduleExecutor(t, configs)
+
+	const tick = 10 * time.Second
+	base := time.Now()
+
+	cycles := make([]uint64, 0, 3)
+	for i := range 9 {
+		if cycle, due := executor.dueServices(configs, base.Add(time.Duration(i)*tick), tick)[slow]; due {
+			cycles = append(cycles, cycle)
+		}
+	}
+
+	c.Equal([]uint64{1, 2, 3}, cycles, "the slow service's counter must step by 1 per run, not by elapsed ticks")
+
+	// Consecutive counters walk every member of a group; a counter stepping by 3 would
+	// return index 0 forever for a group of 3.
+	seen := map[int]struct{}{}
+	for _, cycle := range cycles {
+		seen[representativeIndex(cycle, 3)] = struct{}{}
+	}
+	c.Len(seen, 3, "three consecutive runs must probe three different representatives")
+}
+
+// The tick period must be the fleet minimum: it is the resolution floor below which no
+// service's interval can be honored.
+func Test_MinCheckInterval(t *testing.T) {
+	c := require.New(t)
+
+	configs := scheduleConfig(map[protocol.ServiceID]time.Duration{
+		"a": 30 * time.Second,
+		"b": 10 * time.Second,
+		"c": 60 * time.Second,
+	})
+	c.Equal(10*time.Second, newScheduleExecutor(t, configs).MinCheckInterval())
+
+	// An unset interval falls back to the default rather than collapsing the tick to 0.
+	unset := []ServiceHealthCheckConfig{{ServiceID: "a"}, {ServiceID: "b", CheckInterval: 30 * time.Second}}
+	c.Equal(DefaultHealthCheckInterval, newScheduleExecutor(t, unset).MinCheckInterval())
+
+	var nilExecutor *HealthCheckExecutor
+	c.Equal(DefaultHealthCheckInterval, nilExecutor.MinCheckInterval())
+}
+
+// A disabled service must not drag the whole fleet's tick period down with it.
+func Test_MinCheckInterval_IgnoresDisabled(t *testing.T) {
+	c := require.New(t)
+
+	disabled := false
+	configs := []ServiceHealthCheckConfig{
+		{ServiceID: "on", CheckInterval: 30 * time.Second},
+		{ServiceID: "off", CheckInterval: time.Second, Enabled: &disabled},
+	}
+	c.Equal(30*time.Second, newScheduleExecutor(t, configs).MinCheckInterval())
+}
+
+// End-to-end on the real cycle entry point: a second cycle immediately after the first
+// must submit nothing AND resolve no endpoints. Endpoint resolution is the expensive
+// phase, so a gate that only skipped the relays would leave most of the cost in place.
+func Test_RunAllChecksViaProtocol_SkipsServicesNotDue(t *testing.T) {
+	c := require.New(t)
+
+	serviceIDs := []protocol.ServiceID{"eth", "poly", "bsc"}
+	executor, proto := newLookupProbeExecutor(t, serviceIDs)
+
+	var mu sync.Mutex
+	lookups := 0
+	getEndpointInfos := func(serviceID protocol.ServiceID) ([]EndpointInfo, error) {
+		mu.Lock()
+		lookups++
+		mu.Unlock()
+		return endpointInfoFor(serviceID), nil
+	}
+
+	c.NoError(executor.RunAllChecksViaProtocol(context.Background(), getEndpointInfos))
+
+	mu.Lock()
+	afterFirst := lookups
+	mu.Unlock()
+	c.Equal(len(serviceIDs), afterFirst, "the first cycle must check every service")
+
+	visitedAfterFirst := proto.visitedServices()
+	for _, serviceID := range serviceIDs {
+		c.Positive(visitedAfterFirst[serviceID])
+	}
+
+	// Immediately again: no service's interval (10s by default) has elapsed.
+	c.NoError(executor.RunAllChecksViaProtocol(context.Background(), getEndpointInfos))
+
+	mu.Lock()
+	afterSecond := lookups
+	mu.Unlock()
+	c.Equal(afterFirst, afterSecond, "a not-due cycle must not resolve endpoints - that is the expensive phase")
+	c.Equal(visitedAfterFirst, proto.visitedServices(), "a not-due cycle must not submit checks")
+}

--- a/gateway/retry_hedge_concentration_cap_test.go
+++ b/gateway/retry_hedge_concentration_cap_test.go
@@ -281,8 +281,13 @@ func TestSelectTopRankedEndpoint_CapReachesRetryAndHedgePaths(t *testing.T) {
 
 	// And the primary path's own counter must be untouched by any of this: its existing
 	// per-service rate has to stay a valid before/after baseline.
-	c.Zero(testutil.ToFloat64(metrics.ConcentrationCapReshapedTotal.WithLabelValues(string(serviceID))),
-		"band-path reshapes must not be charged to the primary path's counter")
+	// Checked on BOTH primary-path series — the counter is labelled by selector path so the
+	// websocket pick and the HTTP serving pick stay separable; a band reshape must land on
+	// neither.
+	for _, path := range []string{metrics.SelectionPathDiversity, metrics.SelectionPathConcentrationCap} {
+		c.Zero(testutil.ToFloat64(metrics.ConcentrationCapReshapedTotal.WithLabelValues(string(serviceID), path)),
+			"band-path reshapes must not be charged to the primary path's counter (path=%s)", path)
+	}
 }
 
 // Two-stage selection must survive the cap on the band paths too: the winner is always a

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -1160,6 +1160,21 @@ var WebsocketConnectionEventsTotal = promauto.NewCounterVec(
 	[]string{LabelDomain, LabelServiceID, "event"},
 )
 
+// WebsocketIdleReapedTotal counts connections closed by the idle reaper — no subscription
+// ever established and no client frame for the idle threshold.
+//
+// A separate counter rather than another `event` value on WebsocketConnectionEventsTotal:
+// every reap also emits event="closed" there (the close path is shared), so folding it in
+// would double-count closures and break established/closed reconciliation, which is the
+// check that tells a real connection leak from real accumulation.
+var WebsocketIdleReapedTotal = promauto.NewCounterVec(
+	prometheus.CounterOpts{
+		Name: MetricPrefix + "websocket_idle_reaped_total",
+		Help: "WebSocket connections closed for idleness (no subscription, no client traffic) by domain and service_id.",
+	},
+	[]string{LabelDomain, LabelServiceID},
+)
+
 var WebsocketConnectionDuration = promauto.NewHistogramVec(
 	prometheus.HistogramOpts{
 		Name: MetricPrefix + "websocket_connection_duration_seconds",
@@ -1602,6 +1617,13 @@ func MoveWebsocketConnection(oldDomain, newDomain, serviceID string) {
 	}
 	WebsocketConnectionsActive.WithLabelValues(oldDomain, serviceID).Dec()
 	WebsocketConnectionsActive.WithLabelValues(newDomain, serviceID).Inc()
+}
+
+// RecordWebsocketIdleReaped records a connection closed by the idle reaper. The paired
+// event="closed" / duration observation still comes from RecordWebsocketConnectionClosed on
+// the shared close path; this only labels WHY.
+func RecordWebsocketIdleReaped(domain, serviceID string) {
+	WebsocketIdleReapedTotal.WithLabelValues(domain, serviceID).Inc()
 }
 
 // RecordWebsocketConnectionFailed records a WebSocket connection failure

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -699,24 +699,43 @@ var HedgeSelfOperatorAvoidedTotal = promauto.NewCounterVec(
 // exceeded the cap and its excess was water-filled to other operators, or the pool was
 // too concentrated to satisfy the cap and selection fell back to uniform-over-operators.
 // Selections where no operator exceeded the cap (the cap is a no-op) are NOT counted, so a
-// nonzero rate on a service_id is the live signal that the cap is bounding a real
-// concentration — the operational proof the shipped-on default is doing something.
+// nonzero rate is the live signal that the cap is bounding a real concentration — the
+// operational proof the shipped-on default is doing something.
+//
+// The `path` label carries the same SelectionPath* value the pool metrics already report, and
+// it is what separates HTTP from WebSocket engagement:
+//
+//   - path="diversity"         — SelectEndpointsWithDiversity, the HTTP serving pick.
+//   - path="concentration_cap" — SelectWithConcentrationCap, reached only from a QoS type's
+//     single-endpoint Select, whose sole production caller is the WebSocket bridge setup
+//     (gateway/websocket_request_context.go). This is the WebSocket series.
+//
+// Without this split the two collapse into one counter and HTTP, running three to four orders
+// of magnitude more selections per second, completely masks whether the cap ever engages on a
+// WebSocket selection at all. That question came up repeatedly and was unanswerable from the
+// unlabeled counter.
 var ConcentrationCapReshapedTotal = promauto.NewCounterVec(
 	prometheus.CounterOpts{
 		Name: MetricPrefix + "concentration_cap_reshaped_total",
-		Help: "Endpoint selections reshaped by the per-operator (eTLD+1) concentration cap, by service_id. Nonzero = the cap is actively bounding a dominant operator's selection share.",
+		Help: "Endpoint selections reshaped by the per-operator (eTLD+1) concentration cap, by service_id and selector path. path=\"concentration_cap\" is the WebSocket selection path; path=\"diversity\" is the HTTP serving pick.",
 	},
-	[]string{LabelServiceID},
+	[]string{LabelServiceID, LabelSelectionPath},
 )
 
 // RecordConcentrationCapReshaped increments the concentration-cap reshape counter for a
 // service. Called once per PRIMARY selection whose distribution the cap actually altered.
 //
-// Deliberately left unlabeled by path: the retry/hedge band paths report through
-// ConcentrationCapBandTotal instead, so this counter's existing per-service series keep their
-// continuity and remain a valid before/after baseline for the primary path.
-func RecordConcentrationCapReshaped(serviceID string) {
-	ConcentrationCapReshapedTotal.WithLabelValues(serviceID).Inc()
+// selectionPath must be one of the SelectionPath* constants, matching the value the same call
+// site passes to RecordSelectionPool — so pool composition and reshape counts can be joined on
+// `path` for the same selection.
+//
+// The retry/hedge band paths do NOT report here; they report through ConcentrationCapBandTotal,
+// which keeps its own separate `path` vocabulary (retry|hedge|batch).
+//
+// NOTE FOR DASHBOARDS: this counter previously had only service_id, so any panel matching its
+// series exactly needs `sum by (service_id)` added. Aggregate queries are unaffected.
+func RecordConcentrationCapReshaped(serviceID, selectionPath string) {
+	ConcentrationCapReshapedTotal.WithLabelValues(serviceID, selectionPath).Inc()
 }
 
 // ConcentrationCapBandTotal counts endpoint picks made from the top-reputation-score band —

--- a/protocol/shannon/context.go
+++ b/protocol/shannon/context.go
@@ -100,12 +100,23 @@ type requestContext struct {
 	// endpointObservations:
 	//   - Captures observations about endpoints used during request handling.
 	//   - Includes enhanced error classification for raw payload analysis.
-	//   - Thread-safe: collected via channel during parallel relay processing.
+	//   - Guarded by endpointObservationsMu: see recordEndpointObservation.
 	endpointObservations []*protocolobservations.ShannonEndpointObservation
 
-	// observationsChan is used to safely collect endpoint observations from concurrent goroutines.
-	// A collector goroutine reads from this channel and appends to endpointObservations.
-	observationsChan chan *protocolobservations.ShannonEndpointObservation
+	// endpointObservationsMu guards endpointObservations.
+	//
+	// A mutex rather than the previous "collector goroutine + channel" scheme, because the
+	// writers are NOT confined to a single HandleServiceRequest call. A hedge race hands the
+	// SAME requestContext (gateway's rc.protocolContexts[0]) to a goroutine that deliberately
+	// outlives the race by defaultLoserGraceWindow, so the losing branch is still recording an
+	// observation while the request path has moved on and is reading the slice via
+	// GetObservations(). That is a concurrent read/append on one slice header, and it crashed a
+	// production pod with a SIGSEGV inside handleEndpointSuccess.
+	//
+	// The channel could not cover that case: it was created per parallel batch and reset to nil
+	// once the batch drained, so a late writer saw nil and fell through to a bare append. The
+	// nil check itself was racing with that reset.
+	endpointObservationsMu sync.Mutex
 
 	// currentRelayMinerError:
 	//   - Tracks RelayMinerError data from the current relay response for reporting.
@@ -283,8 +294,33 @@ func (rc *requestContext) sendSingleRelay(payload protocol.Payload) (protocol.Re
 //   - handleEndpointSuccess
 //   - handleEndpointError
 //
+// recordEndpointObservation appends an endpoint observation under endpointObservationsMu.
+//
+// Every writer goes through here. Callers can be:
+//   - the single-relay path,
+//   - the parallel batch relay goroutines,
+//   - a hedge race branch that LOST and is still finishing on its detached context, after the
+//     request path has already returned and read the slice.
+//
+// The last one is why this is a mutex and not a per-call channel: the losing branch shares the
+// gateway's protocol context with the reader, so the write can land at any time.
+//
+// Bounded by MaxBatchPayloads so a pathological batch cannot grow the slice without limit; the
+// cap previously lived in the collector goroutine and is preserved here.
+func (rc *requestContext) recordEndpointObservation(obs *protocolobservations.ShannonEndpointObservation) {
+	rc.endpointObservationsMu.Lock()
+	defer rc.endpointObservationsMu.Unlock()
+
+	if maxObs := rc.concurrencyConfig.MaxBatchPayloads; maxObs > 0 && len(rc.endpointObservations) >= maxObs {
+		// Silently drop excess observations (shouldn't happen with batch size limit).
+		return
+	}
+	rc.endpointObservations = append(rc.endpointObservations, obs)
+}
+
 // handleParallelRelayRequests orchestrates parallel relay requests to a single endpoint.
-// Uses pond worker pool for bounded concurrency and channels for thread-safe observation collection.
+// Uses pond worker pool for bounded concurrency; observations are collected under
+// endpointObservationsMu via recordEndpointObservation.
 // This prevents DoS attacks via large batch requests that could spawn unbounded goroutines.
 func (rc *requestContext) handleParallelRelayRequests(payloads []protocol.Payload) ([]protocol.Response, error) {
 	maxBatchPayloads := rc.concurrencyConfig.MaxBatchPayloads
@@ -296,21 +332,8 @@ func (rc *requestContext) handleParallelRelayRequests(payloads []protocol.Payloa
 		Int("max_concurrent", maxBatchPayloads).
 		Msg("Starting parallel relay processing with worker pool")
 
-	// Initialize observations channel for thread-safe collection from workers
-	rc.observationsChan = make(chan *protocolobservations.ShannonEndpointObservation, len(payloads))
-
-	// Start collector goroutine to gather observations from workers
-	// Cap at max_batch_payloads since batch size is already limited to that
-	observationsCollected := make(chan struct{})
-	go func() {
-		defer close(observationsCollected)
-		for obs := range rc.observationsChan {
-			if len(rc.endpointObservations) < maxBatchPayloads {
-				rc.endpointObservations = append(rc.endpointObservations, obs)
-			}
-			// Silently drop excess observations (shouldn't happen with batch size limit)
-		}
-	}()
+	// Observations from the relay goroutines are appended under endpointObservationsMu by
+	// recordEndpointObservation, so no collector goroutine is needed here.
 
 	// Create a task group from the shared pool for this batch of requests.
 	// The shared pool bounds global concurrency across all requests.
@@ -348,11 +371,6 @@ func (rc *requestContext) handleParallelRelayRequests(payloads []protocol.Payloa
 	if err != nil {
 		return nil, err
 	}
-
-	// Close observations channel and wait for collector to finish
-	close(rc.observationsChan)
-	<-observationsCollected
-	rc.observationsChan = nil // Reset to nil so single relay mode works normally
 
 	return rc.convertResultsToResponses(results, payloads, rc.findFirstError(results))
 }
@@ -455,6 +473,18 @@ func extractJSONRPCRequestID(payloadData string) string {
 //
 // - Implements gateway.ProtocolRequestContext interface.
 func (rc *requestContext) GetObservations() protocolobservations.Observations {
+	// Snapshot under the mutex rather than handing out the live slice.
+	//
+	// A hedge race's losing branch keeps running for defaultLoserGraceWindow on a detached
+	// context and records its observation through recordEndpointObservation — which can happen
+	// after the request path has returned and called this. Reading the slice header while that
+	// append reallocates is the data race that crashed a pod; passing the live slice to a caller
+	// that outlives the lock would reintroduce it one step later.
+	rc.endpointObservationsMu.Lock()
+	endpointObservations := make([]*protocolobservations.ShannonEndpointObservation, len(rc.endpointObservations))
+	copy(endpointObservations, rc.endpointObservations)
+	rc.endpointObservationsMu.Unlock()
+
 	return protocolobservations.Observations{
 		Shannon: &protocolobservations.ShannonObservationsList{
 			Observations: []*protocolobservations.ShannonRequestObservations{
@@ -463,7 +493,7 @@ func (rc *requestContext) GetObservations() protocolobservations.Observations {
 					RequestError: rc.requestErrorObservation.Load(),
 					ObservationData: &protocolobservations.ShannonRequestObservations_HttpObservations{
 						HttpObservations: &protocolobservations.ShannonHTTPEndpointObservations{
-							EndpointObservations: rc.endpointObservations,
+							EndpointObservations: endpointObservations,
 						},
 					},
 				},
@@ -1236,13 +1266,8 @@ func (rc *requestContext) handleEndpointError(
 		rc.getCurrentRPCType(),           // Use RPC type from request context
 	)
 
-	// Track endpoint error observation for metrics
-	// Use channel if available (parallel processing), otherwise append directly (single relay)
-	if rc.observationsChan != nil {
-		rc.observationsChan <- endpointObs
-	} else {
-		rc.endpointObservations = append(rc.endpointObservations, endpointObs)
-	}
+	// Track endpoint error observation for metrics.
+	rc.recordEndpointObservation(endpointObs)
 
 	// Record reputation signal if reputation service is enabled.
 	// This provides gradual scoring based on error severity.
@@ -1335,13 +1360,8 @@ func (rc *requestContext) handleEndpointSuccess(
 		rc.getCurrentRPCType(),           // Use RPC type from request context
 	)
 
-	// Track endpoint success observation for metrics
-	// Use channel if available (parallel processing), otherwise append directly (single relay)
-	if rc.observationsChan != nil {
-		rc.observationsChan <- endpointObs
-	} else {
-		rc.endpointObservations = append(rc.endpointObservations, endpointObs)
-	}
+	// Track endpoint success observation for metrics.
+	rc.recordEndpointObservation(endpointObs)
 
 	// Record reputation signal if reputation service is enabled.
 	latency := time.Since(endpointQueryTime)

--- a/protocol/shannon/observation_race_test.go
+++ b/protocol/shannon/observation_race_test.go
@@ -1,0 +1,114 @@
+package shannon
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	protocolobservations "github.com/pokt-network/path/observation/protocol"
+)
+
+// Regression tests for the SIGSEGV that killed a production gateway pod inside
+// handleEndpointSuccess (protocol/shannon/context.go, `append` to endpointObservations).
+//
+// The crash was NOT a nil field. It was a data race on the slice header, and the reason the
+// writer and the reader overlap is structural rather than incidental:
+//
+//	gateway: currentProtocolCtx := rc.protocolContexts[0]
+//	  hedge:   go executeRequest(primaryCtx = that same context)
+//	           └─ loses the race, but keeps running for defaultLoserGraceWindow (2s) on a
+//	              detached context, then records its observation
+//	gateway: race() returns the winner, handler returns
+//	           └─ rc.protocolContexts[0].GetObservations() reads endpointObservations
+//
+// So one goroutine appends while another reads the same slice, with no ordering between them.
+// The previous "collector goroutine + channel" scheme could not cover this: the channel existed
+// only for the duration of a parallel batch and was reset to nil when it drained, so a late
+// writer read nil and fell through to a bare append — and that nil check was itself racing with
+// the reset.
+//
+// Both tests below are meaningful only under `-race`.
+
+// Test_RecordEndpointObservation_ConcurrentWithGetObservations reproduces the crash shape
+// directly: writers appending while readers snapshot, on one shared requestContext.
+func Test_RecordEndpointObservation_ConcurrentWithGetObservations(t *testing.T) {
+	c := require.New(t)
+
+	rc := &requestContext{serviceID: "poly"}
+
+	const writers, readers, perWriter = 8, 4, 200
+
+	var wg sync.WaitGroup
+	for w := 0; w < writers; w++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < perWriter; i++ {
+				rc.recordEndpointObservation(&protocolobservations.ShannonEndpointObservation{})
+			}
+		}()
+	}
+	for r := 0; r < readers; r++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < perWriter; i++ {
+				// Walk the returned slice: a torn header or a reallocated backing array
+				// surfaces here rather than being silently tolerated.
+				got := rc.GetObservations()
+				for _, o := range got.GetShannon().GetObservations() {
+					_ = len(o.GetHttpObservations().GetEndpointObservations())
+				}
+			}
+		}()
+	}
+	wg.Wait()
+
+	c.Equal(writers*perWriter, len(rc.endpointObservations), "every observation must be retained")
+}
+
+// Test_GetObservations_ReturnsSnapshotNotLiveSlice guards the subtler half of the fix. Locking
+// the append alone is not enough: handing the caller the live slice moves the same race one step
+// out, where a late hedge loser mutates the backing array the caller is still walking.
+func Test_GetObservations_ReturnsSnapshotNotLiveSlice(t *testing.T) {
+	c := require.New(t)
+
+	rc := &requestContext{serviceID: "poly"}
+	rc.recordEndpointObservation(&protocolobservations.ShannonEndpointObservation{})
+
+	obs := rc.GetObservations()
+	snapshot := obs.GetShannon().GetObservations()[0].
+		GetHttpObservations().GetEndpointObservations()
+	c.Len(snapshot, 1)
+
+	// The losing hedge branch lands after the reader already has its copy.
+	for i := 0; i < 64; i++ {
+		rc.recordEndpointObservation(&protocolobservations.ShannonEndpointObservation{})
+	}
+
+	c.Len(snapshot, 1, "caller's slice must not observe writes made after GetObservations returned")
+	c.Len(rc.endpointObservations, 65, "the context itself must still accumulate them")
+}
+
+// Test_RecordEndpointObservation_BoundedByMaxBatchPayloads verifies the cap that used to live in
+// the collector goroutine survived the move: an unbounded slice is a memory-exhaustion vector on
+// a large batch.
+func Test_RecordEndpointObservation_BoundedByMaxBatchPayloads(t *testing.T) {
+	c := require.New(t)
+
+	rc := &requestContext{serviceID: "poly"}
+	rc.concurrencyConfig.MaxBatchPayloads = 10
+
+	for i := 0; i < 50; i++ {
+		rc.recordEndpointObservation(&protocolobservations.ShannonEndpointObservation{})
+	}
+	c.Len(rc.endpointObservations, 10, "observations must be capped at MaxBatchPayloads")
+
+	// A zero cap means "unset", not "drop everything" — single-relay contexts leave it unset.
+	uncapped := &requestContext{serviceID: "poly"}
+	for i := 0; i < 50; i++ {
+		uncapped.recordEndpointObservation(&protocolobservations.ShannonEndpointObservation{})
+	}
+	c.Len(uncapped.endpointObservations, 50, "an unset cap must not drop observations")
+}

--- a/protocol/shannon/protocol.go
+++ b/protocol/shannon/protocol.go
@@ -1349,13 +1349,8 @@ func (p *Protocol) getSessionsUniqueEndpoints(
 
 	// Return session endpoints if available.
 	if len(endpoints) > 0 {
-		// Apply tiered selection if enabled - only return endpoints from the highest available tier
-		// SKIP tiered filtering when filterByReputation is false (e.g., for leaderboard metrics gathering)
-		// because tiered selection is based on reputation scores.
-		// S1: tiered selection (ranking) stays OFF for WebSocket — there are no active WS
-		// health checks yet, so ranking on WS scores is deferred to S2. WS still gets
-		// blacklist + session-exhaustion + reputation threshold/cooldown disqualification above.
-		if filterByReputation && filterByRPCType != sharedtypes.RPCType_WEBSOCKET && p.tieredSelector != nil && p.tieredSelector.Config().Enabled {
+		// Apply tiered selection if enabled - only return endpoints from the highest available tier.
+		if p.shouldApplyTieredSelection(filterByReputation, effectiveAllowedSuppliers, filterByRPCType) {
 			endpoints = p.filterToHighestTier(ctx, serviceID, endpoints, filterByRPCType, logger, requestedEndpointAddr)
 		}
 
@@ -1367,6 +1362,35 @@ func (p *Protocol) getSessionsUniqueEndpoints(
 	// Don't log here - error will be logged at the top-level caller to avoid duplicate logs
 	err := fmt.Errorf("%w: service %s", errProtocolContextSetupNoEndpoints, serviceID)
 	return nil, filterByRPCType, err
+}
+
+// shouldApplyTieredSelection reports whether tiered (highest-tier-only) selection should run
+// for this endpoint lookup.
+//
+// Tiered selection is derived entirely from reputation scores, so it is skipped wherever the
+// threshold/cooldown reputation filter is skipped:
+//
+//   - filterByReputation is false — health checks and leaderboard metrics gathering, which must
+//     see every endpoint including the ones reputation has already disqualified.
+//   - allowedSuppliers is non-empty — a Target-Suppliers pin. filterToHighestTier returns an
+//     EMPTY map when no endpoint reaches any tier (all below MinThreshold), and its
+//     requestedEndpointAddr escape hatch also requires score >= MinThreshold. Without this skip
+//     the header cannot reach a cooled-down or score-0 supplier, which is precisely the case
+//     operators use it to diagnose.
+//
+// S1: tiered selection (ranking) stays OFF for WebSocket — there are no active WS health checks
+// yet, so ranking on WS scores is deferred to S2. WS still gets blacklist + session-exhaustion +
+// reputation threshold/cooldown disqualification.
+func (p *Protocol) shouldApplyTieredSelection(
+	filterByReputation bool,
+	allowedSuppliers []string,
+	rpcType sharedtypes.RPCType,
+) bool {
+	return filterByReputation &&
+		len(allowedSuppliers) == 0 &&
+		rpcType != sharedtypes.RPCType_WEBSOCKET &&
+		p.tieredSelector != nil &&
+		p.tieredSelector.Config().Enabled
 }
 
 // ** Fallback Endpoint Handling **

--- a/protocol/shannon/target_suppliers_tier_bypass_test.go
+++ b/protocol/shannon/target_suppliers_tier_bypass_test.go
@@ -1,0 +1,163 @@
+package shannon
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/pokt-network/poktroll/pkg/polylog/polyzero"
+	sharedtypes "github.com/pokt-network/poktroll/x/shared/types"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pokt-network/path/protocol"
+	"github.com/pokt-network/path/reputation"
+	reputationstorage "github.com/pokt-network/path/reputation/storage"
+)
+
+// TestFilterToHighestTier_EmptyWhenAllBelowThreshold pins the root cause behind the
+// Target-Suppliers bypass: when no endpoint reaches any tier, filterToHighestTier returns an
+// EMPTY map rather than falling back to the input set.
+//
+// This is correct for normal selection — serving traffic to endpoints reputation has
+// disqualified is worse than failing — but it is why a Target-Suppliers pin could not reach a
+// cooled-down supplier: the pin bypasses the threshold/cooldown filter, then this ran anyway
+// and emptied the pool. Real case (mantle/nodefleet, 2026-07-31): 40 of 50 endpoints at score 0,
+// and `Target-Suppliers: <any of them>` returned "no valid endpoints available for service".
+func TestFilterToHighestTier_EmptyWhenAllBelowThreshold(t *testing.T) {
+	ctx := context.Background()
+	logger := polyzero.NewLogger()
+	serviceID := protocol.ServiceID("mantle")
+	rpcType := sharedtypes.RPCType_JSON_RPC
+
+	repConfig := reputation.Config{
+		Enabled:        true,
+		InitialScore:   80,
+		MinThreshold:   20,
+		KeyGranularity: "per-endpoint",
+	}
+	repSvc := reputation.NewService(repConfig, reputationstorage.NewMemoryStorage(10*time.Minute))
+
+	// Probation disabled so the normal (non-probation) tier path is exercised.
+	tieredConfig := reputation.TieredSelectionConfig{
+		Enabled:        true,
+		Tier1Threshold: 80,
+		Tier2Threshold: 50,
+		Probation:      reputation.ProbationConfig{Enabled: false},
+	}
+	p := &Protocol{
+		reputationService: repSvc,
+		tieredSelector:    reputation.NewTieredSelectorWithLogger(logger, tieredConfig, repConfig.MinThreshold),
+	}
+
+	addrs := []protocol.EndpointAddr{
+		"pokt1a-https://dopokt1.relayminer.example.net",
+		"pokt1b-https://nr.relayminer.example.net",
+	}
+	endpoints := make(map[protocol.EndpointAddr]endpoint, len(addrs))
+	for _, addr := range addrs {
+		endpoints[addr] = &mockEndpoint{addr: addr}
+	}
+
+	// Drive every endpoint below MinThreshold using major errors, which do not trip the
+	// critical-strike cooldown — this isolates the threshold path from the cooldown path.
+	keyBuilder := repSvc.KeyBuilderForService(serviceID)
+	for _, addr := range addrs {
+		key := keyBuilder.BuildKey(serviceID, addr, rpcType)
+		for range 8 {
+			_ = repSvc.RecordSignal(ctx, key, reputation.Signal{
+				Type:   reputation.SignalTypeMajorError,
+				Reason: "health_check_critical_error",
+			})
+		}
+		score, err := repSvc.GetScore(ctx, key)
+		require.NoError(t, err)
+		require.Less(t, score.Value, repConfig.MinThreshold,
+			"endpoint %s must be below MinThreshold for this test to mean anything (got %.1f)", addr, score.Value)
+	}
+
+	result := p.filterToHighestTier(ctx, serviceID, endpoints, rpcType, logger, "")
+	require.Empty(t, result, "filterToHighestTier must return an empty map when no endpoint reaches a tier")
+
+	// The requestedEndpointAddr escape hatch also requires score >= MinThreshold, so it does
+	// NOT rescue a score-0 endpoint either. Skipping the whole stage is the only way through.
+	result = p.filterToHighestTier(ctx, serviceID, endpoints, rpcType, logger, addrs[0])
+	require.Empty(t, result, "requestedEndpointAddr must not rescue an endpoint below MinThreshold")
+}
+
+// TestShouldApplyTieredSelection covers the gate that decides whether the behavior pinned above
+// runs at all. The Target-Suppliers case is the fix: a supplier pin must bypass tiered selection
+// for the same reason it already bypasses the threshold/cooldown filter.
+func TestShouldApplyTieredSelection(t *testing.T) {
+	logger := polyzero.NewLogger()
+	enabledSelector := reputation.NewTieredSelectorWithLogger(
+		logger,
+		reputation.TieredSelectionConfig{Enabled: true, Tier1Threshold: 80, Tier2Threshold: 50},
+		20,
+	)
+	disabledSelector := reputation.NewTieredSelectorWithLogger(
+		logger,
+		reputation.TieredSelectionConfig{Enabled: false},
+		20,
+	)
+
+	tests := []struct {
+		name               string
+		selector           *reputation.TieredSelector
+		filterByReputation bool
+		allowedSuppliers   []string
+		rpcType            sharedtypes.RPCType
+		want               bool
+	}{
+		{
+			name:               "applies for a normal JSON-RPC request",
+			selector:           enabledSelector,
+			filterByReputation: true,
+			rpcType:            sharedtypes.RPCType_JSON_RPC,
+			want:               true,
+		},
+		{
+			name:               "skipped when a Target-Suppliers pin is active",
+			selector:           enabledSelector,
+			filterByReputation: true,
+			allowedSuppliers:   []string{"pokt1abc"},
+			rpcType:            sharedtypes.RPCType_JSON_RPC,
+			want:               false,
+		},
+		{
+			name:               "skipped for health checks / leaderboard gathering",
+			selector:           enabledSelector,
+			filterByReputation: false,
+			rpcType:            sharedtypes.RPCType_JSON_RPC,
+			want:               false,
+		},
+		{
+			name:               "skipped for WebSocket (S1)",
+			selector:           enabledSelector,
+			filterByReputation: true,
+			rpcType:            sharedtypes.RPCType_WEBSOCKET,
+			want:               false,
+		},
+		{
+			name:               "skipped when tiered selection is disabled by config",
+			selector:           disabledSelector,
+			filterByReputation: true,
+			rpcType:            sharedtypes.RPCType_JSON_RPC,
+			want:               false,
+		},
+		{
+			name:               "skipped when no selector is configured",
+			selector:           nil,
+			filterByReputation: true,
+			rpcType:            sharedtypes.RPCType_JSON_RPC,
+			want:               false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := &Protocol{tieredSelector: tt.selector}
+			got := p.shouldApplyTieredSelection(tt.filterByReputation, tt.allowedSuppliers, tt.rpcType)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/protocol/shannon/websocket_context.go
+++ b/protocol/shannon/websocket_context.go
@@ -1612,6 +1612,28 @@ func (wrc *websocketRequestContext) HasActiveSubscriptions() bool {
 	return wrc.registry != nil && wrc.registry.HasActiveSubscriptions()
 }
 
+// OnIdleTimeout records that the bridge is closing a client for holding no subscription and
+// sending nothing past the idle threshold. Implements websockets.IdleReporter.
+//
+// Records the metric ONLY. Unlike a stall, this carries no signal about the bound endpoint:
+// the supplier was never asked for anything, so there is nothing it could have done wrong.
+// Feeding it into reputation would penalize whichever supplier happened to be holding an
+// abandoned socket — and, since the reaper targets exactly the connections that generate no
+// traffic, would concentrate that penalty on the operators serving the quietest services.
+func (wrc *websocketRequestContext) OnIdleTimeout(idleFor time.Duration) {
+	domain, domainErr := shannonmetrics.ExtractDomainOrHost(wrc.signingEndpoint().PublicURL())
+	if domainErr != nil {
+		domain = shannonmetrics.ErrDomain
+	}
+
+	metrics.RecordWebsocketIdleReaped(domain, string(wrc.serviceID))
+
+	wrc.logger.Info().
+		Str("domain", domain).
+		Dur("idle_for", idleFor).
+		Msg("🧹 [WS-IDLE] idle connection reaped")
+}
+
 // OnEndpointStallDetected records that the staleness watchdog fired, for canary
 // observability. gaveUp=false: forcing a rebind onto a different supplier; gaveUp=true:
 // the endpoint stayed silent across repeated rebinds and the bridge is closing the client.

--- a/qos/evm/concentration_cap_e2e_test.go
+++ b/qos/evm/concentration_cap_e2e_test.go
@@ -42,7 +42,7 @@ func TestSelectWithMetadata_ConcentrationCap_EndToEnd(t *testing.T) {
 		}
 	}
 
-	before := testutil.ToFloat64(metrics.ConcentrationCapReshapedTotal.WithLabelValues("eth"))
+	before := testutil.ToFloat64(metrics.ConcentrationCapReshapedTotal.WithLabelValues("eth", metrics.SelectionPathConcentrationCap))
 
 	counts := map[string]int{}
 	const draws = 60_000
@@ -59,7 +59,7 @@ func TestSelectWithMetadata_ConcentrationCap_EndToEnd(t *testing.T) {
 		float64(counts["op0.tech"])/float64(draws))
 
 	// The reshape metric fired for this service (the cap actually bit on every draw here).
-	after := testutil.ToFloat64(metrics.ConcentrationCapReshapedTotal.WithLabelValues("eth"))
+	after := testutil.ToFloat64(metrics.ConcentrationCapReshapedTotal.WithLabelValues("eth", metrics.SelectionPathConcentrationCap))
 	require.Greater(t, after-before, 0.0, "concentration_cap_reshaped_total must increment when the cap reshapes")
 }
 

--- a/qos/selector/concentration_cap.go
+++ b/qos/selector/concentration_cap.go
@@ -297,7 +297,12 @@ func SelectWithConcentrationCap(
 	selected, opKey, reshaped := pickWeightedFromPools(pools, totalUnits, maxUnits, maxOperatorShare)
 	if reshaped {
 		// The distribution is actually being altered here, so record it.
-		metrics.RecordConcentrationCapReshaped(string(serviceID))
+		//
+		// Tagged with the same path the pool metric below reports. This selector is reached
+		// only from a QoS type's single-endpoint Select, whose sole production caller is the
+		// WebSocket bridge setup — so this series is what answers "does the cap ever engage on
+		// a WebSocket selection", a question the previously unlabeled counter could not.
+		metrics.RecordConcentrationCapReshaped(string(serviceID), metrics.SelectionPathConcentrationCap)
 	}
 	// Instrumented on every path, including the no-op one: "the cap was a no-op" is the
 	// majority of selections and the case a reshape-only metric cannot see, so it is exactly

--- a/qos/selector/multiple_selection.go
+++ b/qos/selector/multiple_selection.go
@@ -169,7 +169,7 @@ func SelectEndpointsWithDiversity(
 		// discards this ordering and picks again, so counting a reshape there would inflate
 		// the counter with decisions that never happen.
 		if firstPick.capReshaped && selectionPath == metrics.SelectionPathDiversity {
-			metrics.RecordConcentrationCapReshaped(string(serviceID))
+			metrics.RecordConcentrationCapReshaped(string(serviceID), selectionPath)
 		}
 	}
 

--- a/qos/selector/selection_instrumentation_test.go
+++ b/qos/selector/selection_instrumentation_test.go
@@ -262,3 +262,60 @@ func TestSelectionInstrumentation_NarrowingStaysOnDiversityPath(t *testing.T) {
 		t.Errorf("narrowing leaked into filter path: got %v, want 0", got)
 	}
 }
+
+func reshapedCount(t *testing.T, serviceID, path string) float64 {
+	t.Helper()
+	return testutil.ToFloat64(metrics.ConcentrationCapReshapedTotal.WithLabelValues(serviceID, path))
+}
+
+// The reshape counter carried only service_id, so the WebSocket selector and the HTTP serving
+// pick incremented the SAME series. HTTP runs three to four orders of magnitude more
+// selections per second, so "does the cap ever engage on a WebSocket selection?" was
+// unanswerable from it — the WS contribution was inside the noise of the HTTP rate.
+//
+// SelectWithConcentrationCap is reached only from a QoS type's single-endpoint Select, whose
+// sole production caller is the WebSocket bridge setup; SelectEndpointsWithDiversity is the
+// HTTP path. Tagging each with the SelectionPath it already reports to the pool metrics makes
+// the two separable, and joinable with those pool series on `path`.
+func TestSelectionInstrumentation_ReshapeCounterSeparatesWebsocketFromHTTP(t *testing.T) {
+	const svc = "instr-reshape-path"
+	logger := polyzero.NewLogger()
+	// 4 of 5 endpoints on one operator: 0.8 > 0.65, so the cap reshapes on both paths.
+	eps := protocol.EndpointAddrList{
+		"s1-https://a.big-op.com", "s2-https://b.big-op.com",
+		"s3-https://c.big-op.com", "s4-https://d.big-op.com",
+		"s5-https://e.small-op.com",
+	}
+
+	beforeWS := reshapedCount(t, svc, metrics.SelectionPathConcentrationCap)
+	beforeHTTP := reshapedCount(t, svc, metrics.SelectionPathDiversity)
+
+	const wsRuns = 7
+	for i := 0; i < wsRuns; i++ {
+		SelectWithConcentrationCap(svc, eps, 0.65)
+	}
+
+	// Only the WebSocket-path series moved.
+	if got := reshapedCount(t, svc, metrics.SelectionPathConcentrationCap) - beforeWS; got != wsRuns {
+		t.Errorf("websocket-path reshapes = %v, want %d", got, wsRuns)
+	}
+	if got := reshapedCount(t, svc, metrics.SelectionPathDiversity) - beforeHTTP; got != 0 {
+		t.Errorf("HTTP-path reshapes moved on a websocket selection: %v, want 0", got)
+	}
+
+	const httpRuns = 25
+	for i := 0; i < httpRuns; i++ {
+		if got := SelectEndpointsWithDiversity(logger, svc, eps, 1); len(got) != 1 {
+			t.Fatalf("expected 1 endpoint, got %d", len(got))
+		}
+	}
+
+	// The HTTP series moved by its own count, and the websocket series did not move again —
+	// so a busy HTTP service can no longer drown out or fabricate websocket engagement.
+	if got := reshapedCount(t, svc, metrics.SelectionPathDiversity) - beforeHTTP; got != httpRuns {
+		t.Errorf("HTTP-path reshapes = %v, want %d", got, httpRuns)
+	}
+	if got := reshapedCount(t, svc, metrics.SelectionPathConcentrationCap) - beforeWS; got != wsRuns {
+		t.Errorf("websocket-path reshapes changed during HTTP selections: %v, want %d", got, wsRuns)
+	}
+}

--- a/websockets/bridge.go
+++ b/websockets/bridge.go
@@ -102,6 +102,17 @@ type bridge struct {
 	// swap), so it needs no synchronization.
 	lastEndpointDataAt time.Time
 
+	// lastClientDataAt is the time the client last sent a frame toward the endpoint. The
+	// idle reaper compares it against idleConnectionThreshold to detect a client that
+	// opened a connection and then did nothing with it.
+	//
+	// Client frames only, deliberately. Endpoint→client data is not evidence the client is
+	// using the connection, and pings/pongs are handled below the bridge (connection.go)
+	// and never reach here — which is the point: transport liveness is exactly what an
+	// abandoned socket still has. Mutated only on the start() goroutine (bridge start and
+	// handleClientMessage), so it needs no synchronization.
+	lastClientDataAt time.Time
+
 	// consecutiveStallRebinds counts staleness-triggered rebinds with no intervening
 	// endpoint data. Reset to 0 by any endpoint data frame; when it reaches
 	// maxConsecutiveStallRebinds the bridge stops rebinding and closes the client.
@@ -374,6 +385,20 @@ func (b *bridge) start() {
 
 	// Start the fresh-data clock so the watchdog measures silence from bridge start.
 	b.lastEndpointDataAt = time.Now()
+	// Same for the idle reaper: a client that connects and never speaks is measured from
+	// the moment it connected.
+	b.lastClientDataAt = time.Now()
+
+	// The idle reaper needs the reconnector only to ask whether a subscription exists —
+	// without one, every quiet connection would look reapable, including subscribers.
+	// Nil reconnector (rebind disabled) therefore means no reaping, and idleC stays nil so
+	// its select case blocks forever. Disabled outright by a non-positive threshold.
+	var idleC <-chan time.Time
+	if b.reconnector != nil && idleConnectionThreshold > 0 {
+		ticker := time.NewTicker(idleCheckInterval)
+		defer ticker.Stop()
+		idleC = ticker.C
+	}
 
 	// The staleness watchdog runs only when rebind is enabled (it needs the reconnect
 	// machinery to escape a stalling supplier). When disabled, stalenessC stays nil and
@@ -425,6 +450,12 @@ func (b *bridge) start() {
 		// Runs inline on this goroutine, serialized with everything else.
 		case <-sessionExpiryC:
 			b.checkBoundSessionExpiry()
+
+		// Idle-client check: close a connection that holds no subscription and has sent
+		// nothing for the idle threshold. Runs inline on this goroutine like every other
+		// watchdog, so it cannot race a message or a rebind.
+		case <-idleC:
+			b.checkIdleConnection()
 
 		// Operator-requested rebind onto a different supplier. Only ever selected when
 		// rebind is enabled (tumble is nil otherwise, so this case blocks forever).
@@ -485,6 +516,58 @@ func (b *bridge) checkEndpointStaleness() {
 	// Reuse the standard rebind path; ErrEndpointStalled marks it so the reconnect avoids
 	// the current (stalling) supplier.
 	b.handleEndpointDown(endpointDisconnect{gen: b.endpointGen, err: ErrEndpointStalled})
+}
+
+// checkIdleConnection closes a client that has held the connection open without ever
+// establishing a subscription and without sending a single frame for
+// idleConnectionThreshold.
+//
+// This is the mirror image of checkEndpointStaleness. That one asks "the client wants data
+// — is the supplier delivering?" and rebinds the supplier. This one asks "does the client
+// want anything at all?" and, when the answer is no, closes the client rather than moving
+// it: there is no supplier to blame and nowhere better to put a connection nobody is using.
+//
+// The two conditions are ANDed on purpose, and each alone would be wrong:
+//   - Subscription with no traffic is the normal shape of a subscriber. Closing on silence
+//     alone would reap a client watching a rare event, which is a legitimate and possibly
+//     hours-quiet use of a websocket.
+//   - No subscription is the normal shape of a websocket JSON-RPC client. Closing on that
+//     alone would reap a client between requests.
+//
+// Neither at once, for half an hour, is neither shape.
+//
+// Runs on the start() goroutine, so all state access is unsynchronized.
+func (b *bridge) checkIdleConnection() {
+	// Without a reconnector there is no way to ask whether a subscription exists, and
+	// guessing would reap subscribers. start() already withholds the ticker in that case;
+	// this keeps the method safe if it is ever called directly.
+	if b.reconnector == nil {
+		return
+	}
+
+	// A subscriber is exempt regardless of how quiet it or its endpoint is. If its endpoint
+	// has gone silent that is a stall, and checkEndpointStaleness owns it.
+	if b.reconnector.HasActiveSubscriptions() {
+		return
+	}
+
+	idleFor := time.Since(b.lastClientDataAt)
+	if idleFor < idleConnectionThreshold {
+		return
+	}
+
+	// Report before shutting down: the reporter reads connection state that shutdown tears
+	// down. Optional interface — a reconnector without it just gets no metric.
+	if reporter, ok := b.reconnector.(IdleReporter); ok {
+		reporter.OnIdleTimeout(idleFor)
+	}
+
+	b.logger.Info().
+		Dur("idle_for", idleFor).
+		Dur("idle_threshold", idleConnectionThreshold).
+		Msg("🧹 [WS-IDLE] closing connection: no subscription established and no client frame past the idle threshold")
+
+	b.shutdown(fmt.Errorf("%w: idle for %s with no subscription", ErrBridgeIdleTimeout, idleFor.Round(time.Second)))
 }
 
 // checkBoundSessionExpiry detects a connection still bound to a session that has ended and
@@ -681,6 +764,14 @@ func (b *bridge) determineCloseCodeAndMessage(err error) (int, string) {
 		// Endpoint issues - encourage reconnection (may be temporary)
 		return websocket.CloseServiceRestart, "endpoint temporarily unavailable, please reconnect"
 
+	case errors.Is(err, ErrBridgeIdleTimeout):
+		// Nothing failed. 1000 (Normal Closure) is the honest code: an unused connection
+		// was closed cleanly. Deliberately NOT 1012/1011 — those tell a client to
+		// reconnect, and a client that reconnects into the same idleness just re-creates
+		// the connection this reaped. A client that actually wants the connection will
+		// open a new one when it next has something to say.
+		return websocket.CloseNormalClosure, "idle: no subscription and no activity, closing"
+
 	case errors.Is(err, ErrBridgeMessageProcessingFailed):
 		// Message processing errors - could be transient or client issue
 		return websocket.CloseInternalServerErr, "message processing error occurred"
@@ -708,6 +799,10 @@ func (b *bridge) determineCloseCodeAndMessage(err error) (int, string) {
 // - Message processing errors: shutdown() immediately (application-level failure)
 // - Write errors to endpoint: shutdown() immediately (communication failure)
 func (b *bridge) handleClientMessage(msg message) {
+	// The client spoke, so it is not idle — recorded before processing, since a frame the
+	// processor rejects is still evidence of a client that is using the connection.
+	b.lastClientDataAt = time.Now()
+
 	// Process the message through the client message handler
 	processedData, err := b.websocketMessageProcessor.ProcessClientWebsocketMessage(msg.data)
 	if err != nil {

--- a/websockets/bridge_idle_test.go
+++ b/websockets/bridge_idle_test.go
@@ -1,0 +1,177 @@
+package websockets
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+	"github.com/pokt-network/poktroll/pkg/polylog/polyzero"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pokt-network/path/observation"
+)
+
+// OnIdleTimeout implements IdleReporter on the shared test reconnector.
+func (m *mockReconnector) OnIdleTimeout(time.Duration) {
+	atomic.AddInt32(&m.idleReported, 1)
+}
+
+// shrinkIdleBounds compresses the reaper's bounds so a test observes in milliseconds what
+// production observes in half an hour. Mutates package vars, so callers must not be
+// parallel.
+func shrinkIdleBounds(t *testing.T, threshold, interval time.Duration) {
+	t.Helper()
+	origThreshold, origInterval := idleConnectionThreshold, idleCheckInterval
+	idleConnectionThreshold, idleCheckInterval = threshold, interval
+	t.Cleanup(func() {
+		idleConnectionThreshold, idleCheckInterval = origThreshold, origInterval
+	})
+}
+
+// startIdleTestBridge wires a bridge between a live client and a silent endpoint, and
+// returns the client connection.
+func startIdleTestBridge(t *testing.T, reconnector *mockReconnector) *websocket.Conn {
+	t.Helper()
+	c := require.New(t)
+
+	endpoint := httptest.NewServer(http.HandlerFunc(upgradeAndStaySilent))
+	t.Cleanup(endpoint.Close)
+
+	// The reconnector dials this same silent endpoint if anything ever rebinds; nothing in
+	// these tests should.
+	reconnector.url = wsURL(endpoint)
+
+	processor := &mockWebsocketMessageProcessor{}
+	obsChan := make(chan *observation.RequestResponseObservations, 100)
+
+	clientServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, err := StartBridge(
+			context.Background(), polyzero.NewLogger(), r, w,
+			wsURL(endpoint), http.Header{}, processor, obsChan, reconnector,
+		)
+		c.NoError(err)
+	}))
+	t.Cleanup(clientServer.Close)
+
+	clientConn, _, err := websocket.DefaultDialer.Dial(wsURL(clientServer), nil)
+	c.NoError(err)
+	t.Cleanup(func() { _ = clientConn.Close() })
+
+	return clientConn
+}
+
+// Test_Bridge_IdleReaperClosesSubscriptionlessSilentClient covers the case the reaper
+// exists for: a client that opens a connection, never subscribes, and never sends anything.
+// Ping/pong keeps such a socket alive indefinitely and the staleness watchdog deliberately
+// ignores it (no subscription to arm on), so before the reaper nothing closed it.
+//
+// It must close with 1000 (Normal Closure) — nothing failed, and a reconnect-guidance code
+// would just invite the client to re-create the connection that was reaped.
+func Test_Bridge_IdleReaperClosesSubscriptionlessSilentClient(t *testing.T) {
+	shrinkIdleBounds(t, 40*time.Millisecond, 10*time.Millisecond)
+
+	c := require.New(t)
+	reconnector := &mockReconnector{hasSubs: false}
+	clientConn := startIdleTestBridge(t, reconnector)
+
+	// Read until the close frame arrives; the client sends nothing, so it stays idle.
+	_ = clientConn.SetReadDeadline(time.Now().Add(5 * time.Second))
+	_, _, err := clientConn.ReadMessage()
+	c.Error(err, "idle client must be closed by the reaper")
+	c.True(
+		websocket.IsCloseError(err, websocket.CloseNormalClosure),
+		"idle reap must close with 1000 Normal Closure, got: %v", err,
+	)
+
+	c.Equal(int32(1), atomic.LoadInt32(&reconnector.idleReported), "the reap must be reported once")
+	// A reap is not a rebind: nothing should have been reselected or reported as a stall.
+	c.Equal(int32(0), atomic.LoadInt32(&reconnector.calls))
+	c.Equal(int32(0), atomic.LoadInt32(&reconnector.stallRebindReported))
+}
+
+// Test_Bridge_IdleReaperSparesSubscriber is the guard that matters most. A subscription to a
+// rare event is legitimately silent — potentially for hours — and reaping it would break a
+// correct client. The subscription check must exempt it no matter how long the silence runs,
+// with the endpoint side silent too so only HasActiveSubscriptions can be what saves it.
+func Test_Bridge_IdleReaperSparesSubscriber(t *testing.T) {
+	shrinkIdleBounds(t, 20*time.Millisecond, 5*time.Millisecond)
+	// Keep the staleness watchdog out of it: this test is about the reaper, and a silent
+	// endpoint with a subscription is exactly what that other watchdog acts on.
+	origStaleness := endpointStalenessThreshold
+	endpointStalenessThreshold = time.Hour
+	t.Cleanup(func() { endpointStalenessThreshold = origStaleness })
+
+	c := require.New(t)
+	reconnector := &mockReconnector{hasSubs: true}
+	clientConn := startIdleTestBridge(t, reconnector)
+
+	// Well past several reap intervals: the connection must still be open.
+	_ = clientConn.SetReadDeadline(time.Now().Add(200 * time.Millisecond))
+	_, _, err := clientConn.ReadMessage()
+	c.Error(err, "no message is expected — only a timeout")
+	c.False(
+		websocket.IsCloseError(err, websocket.CloseNormalClosure),
+		"a subscriber must never be reaped for idleness, got close: %v", err,
+	)
+	c.Equal(int32(0), atomic.LoadInt32(&reconnector.idleReported))
+}
+
+// Test_Bridge_IdleReaperSparesActiveJSONRPCClient covers the other exempt shape: a websocket
+// JSON-RPC client holds no subscription at all, so the subscription check alone would reap
+// it. Client traffic is what keeps it alive, and the clock must reset on each frame rather
+// than only at connect.
+func Test_Bridge_IdleReaperSparesActiveJSONRPCClient(t *testing.T) {
+	shrinkIdleBounds(t, 100*time.Millisecond, 10*time.Millisecond)
+
+	c := require.New(t)
+	reconnector := &mockReconnector{hasSubs: false}
+	clientConn := startIdleTestBridge(t, reconnector)
+
+	// Send well inside the threshold, for longer than the threshold in total. If the clock
+	// only started at connect, the reaper would fire partway through this loop.
+	deadline := time.Now().Add(400 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		if err := clientConn.WriteMessage(websocket.TextMessage, []byte(`{"jsonrpc":"2.0","id":1,"method":"eth_blockNumber"}`)); err != nil {
+			c.FailNow("client write failed — connection was closed while active: " + err.Error())
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+
+	c.Equal(int32(0), atomic.LoadInt32(&reconnector.idleReported), "an active client must never be reaped")
+}
+
+// Test_Bridge_IdleReaperDisabled verifies the off-switch: a non-positive threshold means the
+// ticker is never armed, so an idle subscription-less client survives.
+func Test_Bridge_IdleReaperDisabled(t *testing.T) {
+	shrinkIdleBounds(t, 0, 5*time.Millisecond)
+
+	c := require.New(t)
+	reconnector := &mockReconnector{hasSubs: false}
+	clientConn := startIdleTestBridge(t, reconnector)
+
+	_ = clientConn.SetReadDeadline(time.Now().Add(200 * time.Millisecond))
+	_, _, err := clientConn.ReadMessage()
+	c.Error(err, "no message is expected — only a timeout")
+	c.False(
+		websocket.IsCloseError(err, websocket.CloseNormalClosure),
+		"reaping is disabled at threshold <= 0, got close: %v", err,
+	)
+	c.Equal(int32(0), atomic.LoadInt32(&reconnector.idleReported))
+}
+
+// Test_SetIdleConnectionThreshold verifies the startup setter the config/env override uses.
+func Test_SetIdleConnectionThreshold(t *testing.T) {
+	c := require.New(t)
+	orig := idleConnectionThreshold
+	t.Cleanup(func() { idleConnectionThreshold = orig })
+
+	SetIdleConnectionThreshold(45 * time.Minute)
+	c.Equal(45*time.Minute, idleConnectionThreshold)
+
+	SetIdleConnectionThreshold(-1)
+	c.Equal(time.Duration(-1), idleConnectionThreshold, "a negative value must survive as an explicit disable")
+}

--- a/websockets/bridge_reconnect.go
+++ b/websockets/bridge_reconnect.go
@@ -162,6 +162,59 @@ var (
 	maxConsecutiveStallRebinds = 3
 )
 
+// Idle-connection reaper bounds. Package-level vars (not consts) so tests can shrink them;
+// production mutates idleConnectionThreshold only once, at startup, via
+// SetIdleConnectionThreshold.
+//
+// This closes the one gap the other two watchdogs leave open by design. Ping/pong keeps a
+// socket alive for as long as the peer answers, and the staleness watchdog arms only on a
+// connection that HAS a subscription. A connection that never subscribes and never sends a
+// frame therefore lives until the client hangs up — which, measured on production, some
+// never do: five services held 241 connections holding zero subscriptions between them,
+// costing ~1370 rebinds/hour that replayed nothing.
+var (
+	// idleConnectionThreshold is how long a connection may hold NO established subscription
+	// and send NO client frame before the bridge closes it.
+	//
+	// Sized to be unreachable by any client that is actually using the connection rather
+	// than to be aggressive. A websocket JSON-RPC client between requests is the case this
+	// must not break, so the bar is "sent nothing whatsoever for half an hour". A subscriber
+	// is exempt on a separate condition entirely (HasActiveSubscriptions), so a subscription
+	// to a rare event — quiet for hours and legitimately so — is never a candidate no matter
+	// how long it stays quiet.
+	//
+	// Zero or negative disables the reaper.
+	idleConnectionThreshold = 30 * time.Minute
+	// idleCheckInterval is how often the reaper evaluates. Worst-case reap latency is
+	// idleConnectionThreshold + idleCheckInterval. Coarse on purpose: it runs per
+	// connection, and nothing about this condition is urgent.
+	idleCheckInterval = 60 * time.Second
+)
+
+// SetIdleConnectionThreshold overrides how long a connection may stay subscription-less and
+// silent before the bridge reaps it. Zero or negative disables the reaper entirely.
+//
+// Call once during startup, before any bridge is created — bridges read the threshold on
+// their own goroutines and it is not synchronized.
+func SetIdleConnectionThreshold(d time.Duration) {
+	idleConnectionThreshold = d
+}
+
+// IdleReporter is an optional interface an EndpointReconnector may implement to learn that
+// the bridge is closing a client for idleness, so the implementer (which knows service and
+// domain) can emit the metric.
+//
+// Deliberately NOT part of EndpointReconnector: existing reconnectors and test doubles keep
+// compiling, and an implementer that skips it simply gets no metric.
+//
+// Called on the bridge's start() goroutine immediately before shutdown.
+type IdleReporter interface {
+	// OnIdleTimeout reports that a connection is being closed for holding no subscription
+	// and sending nothing for idleFor. This is a client-side condition: implementations
+	// must not attribute it to the bound endpoint's reputation.
+	OnIdleTimeout(idleFor time.Duration)
+}
+
 // Bound-session expiry watchdog bounds. Package-level vars (not consts) so tests can shrink
 // them; production never mutates them.
 var (

--- a/websockets/bridge_reconnect_test.go
+++ b/websockets/bridge_reconnect_test.go
@@ -34,6 +34,7 @@ type mockReconnector struct {
 	avoidCurrentCalls   int32 // ReconnectEndpoint calls that requested a different supplier
 	stallRebindReported int32 // OnEndpointStallDetected(gaveUp=false)
 	stallGiveupReported int32 // OnEndpointStallDetected(gaveUp=true)
+	idleReported        int32 // OnIdleTimeout — see bridge_idle_test.go
 }
 
 func (m *mockReconnector) ReconnectEndpoint(_ context.Context, avoidCurrentSupplier bool) (*websocket.Conn, error) {

--- a/websockets/errors.go
+++ b/websockets/errors.go
@@ -53,4 +53,19 @@ var (
 	// (supplier continuity is fine if the supplier is still in the new session), unlike
 	// ErrEndpointStalled/ErrEndpointTumbled which must land elsewhere.
 	ErrEndpointSessionExpired = errors.New("endpoint session expired: bound session ended without the supplier disconnecting")
+
+	// ErrBridgeIdleTimeout indicates the client has held the connection open without ever
+	// establishing a subscription and without sending a frame for idleConnectionThreshold.
+	//
+	// Every other liveness mechanism deliberately spares this connection. Ping/pong keeps
+	// the socket alive as long as the peer answers, and the staleness watchdog arms only
+	// when HasActiveSubscriptions() is true — a quiet connection with no subscription was
+	// treated as legitimate, on the assumption that it is a websocket JSON-RPC client
+	// between requests. That holds for a client that sends requests; it does not hold for
+	// one that sends nothing at all, which is indistinguishable from an abandoned socket
+	// and is not free: the connection stays bound to a supplier and is rebound at every
+	// session rollover, replaying zero subscriptions each time.
+	//
+	// Reaping it is NOT an endpoint fault and must never reach reputation.
+	ErrBridgeIdleTimeout = errors.New("bridge idle timeout: no subscription and no client activity past the idle threshold")
 )


### PR DESCRIPTION
## Summary

Reap idle WebSocket connections, fix a production SIGSEGV in the hedge path, and three smaller selection/health-check fixes. The reaper is validated in production on both environments; the crash fix is not yet deployed.

### Primary Changes:

- **WebSocket idle-connection reaper** (`695ec607`) — closes a connection that has **never established a subscription** *and* has **sent no client frame** for `websocket_idle_timeout` (default `30m`), with close code **1000 (Normal Closure)**.

  Nothing else reaped these. Ping/pong keeps a socket alive as long as the peer answers, and the endpoint-staleness watchdog arms *only* on connections that have a subscription — a quiet subscription-less connection was assumed to be a WebSocket JSON-RPC client between requests. That holds for a client that sends requests; it does not hold for one that sends nothing at all, which is indistinguishable from an abandoned socket and is not free: it stays bound to a supplier and is rebound at every session rollover, replaying nothing.

  Measured before the fix: **36.5k rebinds / 6h against 3.7k replays fleet-wide — 90% of rebinds replayed nothing.** Several services (`moonbeam`, `eth-sepolia-testnet`, `fuse`) sat at *exactly zero* replays while holding live connections.

  The two conditions are **ANDed**, and each alone is wrong: silence alone reaps a subscriber watching a rare event (legitimately quiet for hours); no-subscription alone reaps a WebSocket JSON-RPC client between requests. Neither at once, for half an hour, is neither shape.

  Not an endpoint fault, so it **never touches reputation** — the supplier was never asked for anything, and since the reaper targets exactly the connections that generate no traffic, attributing it would concentrate the penalty on operators serving the quietest services. Reaps land on their own counter, `path_websocket_idle_reaped_total{service_id, domain}`, rather than another `event` value on the existing connection-events metric: the close path is shared and already emits `event="closed"`, so folding them in would double-count closures and break established/closed reconciliation — the check that separates a gauge leak from real accumulation.

- **Fix data race on `endpointObservations`** (`c66cf142`) — a mainnet pod died with SIGSEGV inside `handleEndpointSuccess`. The faulting line is an `append` to a slice, which cannot fault on its own; the slice header was being torn by a concurrent write, and the overlap is structural:

  ```
  gateway: currentProtocolCtx := rc.protocolContexts[0]
    hedge:   go executeRequest(primaryCtx = that same context)
             loses the race but keeps running for defaultLoserGraceWindow (2s)
             on a detached context, then records its observation
  gateway: race() returns the winner, the handler returns
             rc.protocolContexts[0].GetObservations() reads the slice
  ```

  The previous collector-goroutine-plus-channel scheme could not cover this: the channel was created per parallel batch and reset to `nil` once drained, so a writer arriving afterwards saw `nil` and fell through to a bare `append` — and that nil check was itself racing with the reset. Its only real job was serialising appends, so it is replaced rather than repaired.

  All writers now go through `recordEndpointObservation` under a mutex, and `GetObservations` returns a **snapshot** rather than the live slice. Locking the append alone is insufficient: handing out the live slice relocates the same race one step out, where a late hedge loser mutates the backing array the caller is still walking.

### Secondary Changes:

- **`Target-Suppliers` reaches cooled-down suppliers** (`87a75647`) — tiered selection ran *after* the supplier allowlist, so pinning a supplier whose endpoints were all below `min_threshold` returned `no valid endpoints available for service`. The debug header failed exactly when it was most needed: on a supplier you were trying to diagnose. Reputation-derived filtering (score threshold, cooldown, tier) is now skipped for the header; `blocked_suppliers`, endpoint policy, and the signature/validation blacklist still apply — none of those are reputation.
- **Per-service `check_interval` honored** (`e1628776`) in the health-check scheduler.
- **Split cap reshapes by selector path** (`425eada4`) — `path_concentration_cap_reshaped_total` gains a `path` label (`concentration_cap` = WebSocket selection, `diversity` = HTTP serving pick). HTTP runs three to four orders of magnitude more selections per second and completely masked whether the cap ever engaged on a WebSocket selection.

## Production validation

Deployed to canary `2026-08-04 19:30 UTC`, mainnet `2026-08-05 17:17 UTC`. Both on `sha-695ec60`.

| WebSocket | before | now |
|---|---|---|
| rebinds / 6h | 26,639 | 19,439 |
| replays / 6h | 3,329 | 6,708 |
| replay / rebind | 0.125 | **0.345** |
| idle reaps | 0 | 11,271 |

Twice the useful work from ~a quarter fewer rebinds. Mainnet alone moved `0.037 → 0.433` in its first 6h.

**No over-reaping.** The decisive check is per-service `endpoint_to_client` msg/s across the reap window, using each environment as its own before/after control: every service carrying data still carries it (`eth` went *up*, `bsc` and `base` flat), while `blast`/`moonbeam`/`bera`/`sei`/`op` sat at exactly `0.0 msg/s` both before and after while holding 9-19 connections each.

**Not claimed:** HTTP relay success is unchanged (92.48% → 92.19%, inside noise) and retries are flat at 3.83%. Nothing here was expected to move those; the reaper is WebSocket-only.

**Known behavior:** reaped clients frequently reconnect and re-squat, so this is a ~30-minute cycle rather than a one-time cleanup. Absolute connection churn is unchanged versus the pre-deploy control — the win is in rebinds, not connection count. `PATH_WEBSOCKET_IDLE_TIMEOUT` (or `router_config.websocket_idle_timeout`; non-positive disables) tunes this without a code change.

## Issue

- Issue or PR: N/A

## Type of change

- [x] New feature, functionality or library
- [x] Bug fix
- [ ] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## QoS Checklist

### E2E Validation & Tests

- [ ] `make path_up`
- [ ] `make test_e2e_evm_shannon`

### Observability

- [ ] 1. `make path_up`
- [ ] 2. Run the following E2E test: `make test_request__shannon_relay_util_100`
- [ ] 3. View results in LocalNet's PATH Relay Grafana Dashboard

## Sanity Checklist

- [ ] I have updated the GitHub Issue `assignees`, `reviewers`, `labels`, `project`, `iteration` and `milestone`
- [ ] For docs, I have run `make docusaurus_start`
- [ ] For code, I have run `make test_all`
- [x] For configurations, I have updated the documentation
- [x] I added `TODO`s where applicable

**What was actually run:** `go build ./...`, `go vet`, `golangci-lint run --timeout 5m --build-tags test` (**0 issues**), and `go test ./... -short -count=1` (green except `reputation/storage` Redis testcontainers, which need a local Docker daemon). `protocol/shannon` and `gateway` additionally pass under `-race`.

The race fix has a regression test verified in **both** directions — removing the locks produces 5 `WARNING: DATA RACE` reports and a failure; restoring them is clean. A regression test that passes either way would be worthless here.

E2E boxes are unchecked because E2E was **not** run — this was validated against live production traffic on both environments instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
